### PR TITLE
Use `en` as default locale

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
   config.include(CommonActions)
   config.before(:suite) do
     DatabaseCleaner.clean_with :truncation
+    I18n.locale = :en
   end
 
   config.before(:each) do |example|


### PR DESCRIPTION
Acceptance tests shouldn't be coupled with the language. Let's try to find out which of those are, and fix that.
