### PR TITLE
Don't use db settings

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,42 +1,4 @@
-class Setting < ActiveRecord::Base
-  validates :key, presence: true, uniqueness: true
-
-  default_scope { order(id: :asc) }
-
-  class << self
-    # Public: Gets a setting given a key. It will query the database to check
-    # if it's overriden, and resort to the YAML setting in `application.yml`
-    # otherwise.
-    #
-    # key - The setting's key.
-    #
-    # Returns a Value with the setting.
-    def [](key)
-      where(key: key).pluck(:value).first || StaticSetting[key]
-    end
-
-    # Sets a setting value given a key.
-    #
-    # key   - The setting's key to override.
-    # value - The setting's value.
-    #
-    # Returns the setting's Value.
-    def []=(key, value)
-      setting = where(key: key).first || new(key: key)
-      setting.value = value
-      setting.save!
-      value
-    end
-  end
-
-  # This class acts as a fallback. By default, we try to find an overriden
-  # setting in the DB. If not found, we fall back to the default settings
-  # put in the static application.yml config file.
-  #
-  # This way, we keep runtime control of the settings without sacrificing
-  # ease of use.
-  class StaticSetting < Settingslogic
-    source "#{Rails.root}/config/application.yml"
-    namespace Rails.env
-  end
+class Setting < Settingslogic
+  source "#{Rails.root}/config/application.yml"
+  namespace Rails.env
 end

--- a/db/migrate/20151211220323_remove_db_settings.rb
+++ b/db/migrate/20151211220323_remove_db_settings.rb
@@ -1,0 +1,5 @@
+class RemoveDbSettings < ActiveRecord::Migration
+  def change
+    drop_table :settings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151111202657) do
+ActiveRecord::Schema.define(version: 20151211220323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -227,13 +227,6 @@ ActiveRecord::Schema.define(version: 20151111202657) do
   add_index "proposals", ["summary"], name: "index_proposals_on_summary", using: :btree
   add_index "proposals", ["title"], name: "index_proposals_on_title", using: :btree
   add_index "proposals", ["tsv"], name: "index_proposals_on_tsv", using: :gin
-
-  create_table "settings", force: :cascade do |t|
-    t.string "key"
-    t.string "value"
-  end
-
-  add_index "settings", ["key"], name: "index_settings_on_key", using: :btree
 
   create_table "simple_captcha_data", force: :cascade do |t|
     t.string   "key",        limit: 40

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 describe Setting do
-  before do
-    Setting["official_level_1_name"] = 'Stormtrooper'
+  context "when it exists" do
+    it "should should return the value" do
+      expect(Setting['brand_name']).not_to be_blank
+    end
   end
 
-  context "when overriden in the database" do
+  context "when overriden" do
     before do
       Setting["official_level_1_name"] = 'Stormtrooper'
     end
@@ -15,14 +17,7 @@ describe Setting do
     end
   end
 
-  context "when there's a fallback" do
-    it "should return the fallback setting" do
-      Setting::StaticSetting["crazy_setting"] = "Crazy setting"
-      expect(Setting["crazy_setting"]).to eq("Crazy setting")
-    end
-  end
-
-  context "when there isn't a fallback" do
+  context "when it doesn't exist" do
     it "should should return nil" do
       expect(Setting['undefined_key']).to eq(nil)
     end


### PR DESCRIPTION
By not using settings from the DB, we're less likely to have errors
caused by environment divergences, and we increase the performance
by avoiding db hits.
