### PR TITLE
Send email via sendgrid

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,8 @@
   "addons": [
     "heroku-postgresql",
     "heroku-redis",
-    "rollbar:free"
+    "rollbar:free",
+    "sendgrid:starter"
   ],
   "formation": [
     { "process": "web",    "quantity": 1},

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,6 +66,18 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Rails.application.secrets.server_name }
   config.action_mailer.asset_host = "https://#{Rails.application.secrets.server_name}"
 
+  if ENV["SENDGRID_USERNAME"]
+    config.action_mailer.smtp_settings = {
+      :address        => 'smtp.sendgrid.net',
+      :port           => '587',
+      :authentication => :plain,
+      :user_name      => ENV['SENDGRID_USERNAME'],
+      :password       => ENV['SENDGRID_PASSWORD'],
+      :domain         => 'heroku.com',
+      :enable_starttls_auto => true
+    }
+  end
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
This adds support for sending email via sendgrid. It also adds the specification in `app.json`.
