### PR TITLE
Fixing travis-ci ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 addons:
   postgresql: "9.4"
 rvm:
- - "2.2.3"
+ - "2.2.4"
 cache: bundler
 before_script:
   - "for i in config/*.example; do cp \"$i\" \"${i/.example}\"; done"


### PR DESCRIPTION
Fix for travis-ci.org failing tests with: "Your Ruby version is 2.2.3, but your Gemfile specified 2.2.4".
