### PR TITLE
Add district as a integer for proposals

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -135,7 +135,7 @@ class Proposal < ActiveRecord::Base
     Setting['votes_for_proposal_success'].to_i
   end
 
-  DISTRICTS = YAML::load_file("#{Rails.root}/config/districts.yml").sort
+  DISTRICTS = YAML::load_file("#{Rails.root}/config/districts.yml")["districts"].to_a.map(&:reverse).sort
 
   protected
 

--- a/config/districts.yml
+++ b/config/districts.yml
@@ -1,30 +1,11 @@
-- 
-  - Ciutat Vella
-  - 1
-- 
-  - Eixample
-  - 2
-- 
-  - Sants Montjuïc
-  - 3
-- 
-  - Les Corts
-  - 4
-- 
-  - Sarrià - Sant Gervasi
-  - 5
-- 
-  - Gràcia
-  - 6
-- 
-  - Horta - Guinardó
-  - 7
-- 
-  - Nou Barris
-  - 8
-- 
-  - Sant Andreu
-  - 9
-- 
-  - Sant Martí
-  - 10
+districts:
+  1: "Ciutat Vella"
+  2: "Eixample"
+  3: "Sants Montjuïc"
+  4: "Les Corts"
+  5: "Sarrià - Sant Gervasi"
+  6: "Gràcia"
+  7: "Horta - Guinardó"
+  8: "Nou Barris"
+  9: "Sant Andreu"
+  10: "Sant Martí"

--- a/config/districts.yml
+++ b/config/districts.yml
@@ -1,2 +1,30 @@
-- Eixample
-- Ciutat Vella
+- 
+  - Ciutat Vella
+  - 1
+- 
+  - Eixample
+  - 2
+- 
+  - Sants Montjuïc
+  - 3
+- 
+  - Les Corts
+  - 4
+- 
+  - Sarrià - Sant Gervasi
+  - 5
+- 
+  - Gràcia
+  - 6
+- 
+  - Horta - Guinardó
+  - 7
+- 
+  - Nou Barris
+  - 8
+- 
+  - Sant Andreu
+  - 9
+- 
+  - Sant Martí
+  - 10

--- a/db/migrate/20160111075710_change_proposals_district_to_integer.rb
+++ b/db/migrate/20160111075710_change_proposals_district_to_integer.rb
@@ -1,0 +1,9 @@
+class ChangeProposalsDistrictToInteger < ActiveRecord::Migration
+  def up
+    change_column :proposals, :district, 'integer USING CAST(district AS integer)'
+  end
+
+  def down
+    change_column :proposals, :district, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160105094729) do
+ActiveRecord::Schema.define(version: 20160111075710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -244,7 +244,7 @@ ActiveRecord::Schema.define(version: 20160105094729) do
     t.integer  "category_id"
     t.integer  "subcategory_id"
     t.string   "scope",                        default: "district"
-    t.string   "district"
+    t.integer  "district"
   end
 
   add_index "proposals", ["author_id", "hidden_at"], name: "index_proposals_on_author_id_and_hidden_at", using: :btree

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ app:
     - "3000:3000"
 
 worker:
-  image: barcelonaparticipa_app
+  image: decidimbcn_app
   environment: 
     - DATABASE_HOST=db
     - DATABASE_USERNAME=postgres


### PR DESCRIPTION
Based on Barcelona's district list (http://lameva.barcelona.cat/ca/viure-a-bcn/fem-barri) I changed the `district` field to use an integer.
The district list is still a static file in `config/districts.yml`
