### PR TITLE
Moderators should be able to create/update meetings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 # Mac finder artifacts
 .DS_Store
 .ruby-gemset
+
+# Ignore custom environment variables file
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ gem "faker"
 
 gem 'rails-i18n'
 
+# React gems
 gem 'react-rails'
 gem 'immutablejs-rails', '>= 2.0.17'
 gem 'i18n-js', github: 'fnando/i18n-js'
@@ -78,6 +79,7 @@ group :development, :test do
   gem 'spring-commands-rspec'
   gem 'rspec-rails', '~> 3.3'
   gem 'capybara'
+  gem 'capybara-screenshot'
   gem 'factory_girl_rails'
   gem 'fuubar'
   gem 'launchy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-screenshot (1.0.11)
+      capybara (>= 1.0, < 3)
+      launchy
     chronic (0.10.2)
     ckeditor (4.1.6)
       cocaine
@@ -459,6 +462,7 @@ DEPENDENCIES
   byebug
   cancancan
   capybara
+  capybara-screenshot
   ckeditor (~> 4.1.5)
   coffee-rails (~> 4.1.0)
   coveralls

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -67,3 +67,7 @@ $(function(){
   $(document).on('page:load', initialize_modules);
   $(document).on('ajax:complete', initialize_modules);
 });
+
+function gmapsLoaded () {
+  $(document).trigger('gmaps:loaded');
+}

--- a/app/assets/javascripts/components/google_maps_autocomplete_input.es6.jsx
+++ b/app/assets/javascripts/components/google_maps_autocomplete_input.es6.jsx
@@ -1,0 +1,123 @@
+class GoogleMapsAutocompleteInput extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.$addressInput = $($(`#${this.props.addressInputId}`));
+    this.$latitudeInput = $($(`#${this.props.latitudeInputId}`));
+    this.$longitudeInput = $($(`#${this.props.longitudeInputId}`));
+
+    if (this.props.defaultLocation && this.props.defaultLocation.lat) {
+      this.defaultZoom = 15;
+      this.defaultLocation = this.props.defaultLocation;
+    } else {
+      this.defaultZoom = 12;
+      this.defaultLocation = { lat: 41.3833, lng: 2.1833 };
+    }
+  }
+
+  componentDidMount() {
+    $(document).on('gmaps:loaded', (event) => this.forceUpdate());
+    this.createGmapsIntegration();
+  }
+
+  componentWillUnmount() {
+    $(document).off('gmaps:loaded');
+  }
+
+  componentDidUpdate() {
+    this.createGmapsIntegration();
+  }
+
+  createGmapsIntegration () {
+    if (window.google) {
+      this.createMap();
+      this.createAutocomplete();
+    }
+  }
+  
+  createMap() {
+    this.map = new google.maps.Map(
+      $('.gmaps_autocomplete_input .map')[0], 
+      {
+        zoom: this.defaultZoom,
+        center: this.defaultLocation,
+        draggable: false,
+        scrollwheel: false,
+        mapTypeControl: false,
+        panControl: false,
+        zoomControl: false,
+        streetViewControl: false
+      }
+    );
+
+    this.service = new google.maps.places.PlacesService(this.map);
+
+    this.marker = new google.maps.Marker({
+      position: this.defaultLocation,
+      animation: google.maps.Animation.DROP,
+      map: this.map
+    });
+  }
+
+  createAutocomplete() {
+    this.$addressInput.on('keydown', (event) => {
+      let key = event.keyCode;
+
+      if (key === 13) { // Prevent form submission
+        event.preventDefault();
+      }
+    });
+
+    this.$addressInput.on('change', (event) => { this.onInputChanged(event.currentTarget.value) });
+
+    this.autocomplete = new google.maps.places.Autocomplete(
+      this.$addressInput[0],
+      { 
+        componentRestrictions: { 
+          country: 'es' 
+        }
+      }
+    );
+
+    this.autocomplete.addListener('place_changed', () => { this.onPlaceChanged() });
+  }
+
+  onInputChanged(value) {
+    this.searchTimeoutId = setTimeout(() => {
+    this.service.textSearch({ 
+      query: value,
+      componentRestrictions: { 
+        country: 'es' 
+      }
+    }, (results, status) => {
+        if (status == google.maps.places.PlacesServiceStatus.OK && results.length > 0) {
+          this.$addressInput.val(results[0].formatted_address);
+          this.setPlace(results[0]);
+        }
+      });
+    }, 200);
+  }
+
+  onPlaceChanged() {
+    clearTimeout(this.searchTimeoutId);
+    this.setPlace(this.autocomplete.getPlace());
+  }
+
+  setPlace(place) {
+    if (place.geometry) {
+      this.map.panTo(place.geometry.location);
+      this.map.setZoom(15);
+      this.marker.setPosition(place.geometry.location);
+      this.$latitudeInput.val(place.geometry.location.lat());
+      this.$longitudeInput.val(place.geometry.location.lng());
+    }
+  }
+
+  render() {
+    return (
+      <div className="gmaps_autocomplete_input">
+        <div className="map"></div>
+      </div>
+    )
+  }
+}

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1,1 +1,2 @@
 @import "components/proposal_category_picker";
+@import "components/google_maps_autocomplete_input";

--- a/app/assets/stylesheets/components/google_maps_autocomplete_input.scss
+++ b/app/assets/stylesheets/components/google_maps_autocomplete_input.scss
@@ -1,0 +1,5 @@
+.gmaps_autocomplete_input {
+  .map {
+    height: 250px;
+  }
+}

--- a/app/controllers/moderation/meetings_controller.rb
+++ b/app/controllers/moderation/meetings_controller.rb
@@ -1,0 +1,57 @@
+class Moderation::MeetingsController < Moderation::BaseController
+  include ModerateActions
+
+  before_action :load_resources, only: [:index]
+
+  load_and_authorize_resource
+
+  def index
+    @resources = @resources.page(params[:page]).per(50)
+    set_resources_instance
+  end
+
+
+  def new
+    @resource = resource_model.new
+    set_resource_instance
+  end
+
+  def create
+    @resource = resource_model.new(strong_params)
+    @resource.author = current_user
+
+    if @resource.save
+      redirect_to moderation_meetings_url, notice: t('flash.actions.create.notice', resource_name: "#{resource_name.capitalize}")
+    else
+      set_resource_instance
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    resource.assign_attributes(strong_params)
+    if resource.save
+      redirect_to moderation_meetings_url, notice: t('flash.actions.update.notice', resource_name: "#{resource_name.capitalize}")
+    else
+      set_resource_instance
+      render :edit
+    end
+  end
+
+  private
+
+  def meeting_params
+    params.require(:meeting).permit(:title, :description, :address, :address_longitude, :address_latitude, :address_details, :held_at, :start_at, :end_at)
+  end
+
+  def resource_model
+    Meeting
+  end
+
+  def load_resources
+    @resources = resource_model.accessible_by(current_ability, :read)
+  end
+end

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -22,4 +22,14 @@ module ComponentsHelper
   def localize_attribute(attribute)
     attribute[I18n.locale.to_s] if attribute
   end
+
+  def google_maps_autocomplete_input(options = {})
+    react_component(
+      'GoogleMapsAutocompleteInput',
+      defaultLocation: options[:default_location],
+      addressInputId: options[:address_input_id],
+      latitudeInputId: options[:latitude_input_id],
+      longitudeInputId: options[:longitude_input_id]
+    ) 
+  end
 end

--- a/app/models/abilities/administrator.rb
+++ b/app/models/abilities/administrator.rb
@@ -34,6 +34,8 @@ module Abilities
       can [:search, :create, :index, :destroy], ::Moderator
 
       can :manage, Annotation
+
+      can :manage, Meeting
     end
   end
 end

--- a/app/models/abilities/moderation.rb
+++ b/app/models/abilities/moderation.rb
@@ -43,6 +43,9 @@ module Abilities
 
       can :block, User
       cannot :block, User, id: user.id
+
+      can :manage, Meeting, author_id: user.id
+      can :create, Meeting
     end
   end
 end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,0 +1,11 @@
+class Meeting < ActiveRecord::Base
+  belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
+
+  validates :author, presence: true
+  validates :title, presence: true
+  validates :description, presence: true
+  validates :address, presence: true
+  validates :held_at, presence: true
+  validates :start_at, presence: true
+  validates :end_at, presence: true
+end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -13,6 +13,7 @@
     <%= content_for :head %>
     <%= csrf_meta_tags %>
     <%= favicon_link_tag "favicon.ico" %>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.secrets.google_maps_api_key%>&signed_in=true&libraries=places&callback=gmapsLoaded" async defer></script>
   </head>
 
   <body class="admin">

--- a/app/views/moderation/_menu.html.erb
+++ b/app/views/moderation/_menu.html.erb
@@ -31,5 +31,12 @@
         <%= t("moderation.menu.users") %>
       <% end %>
     </li>
+
+    <li <%= "class=active" if controller_name == "meetings" %>>
+      <%= link_to moderation_meetings_path do %>
+        <i class="icon-calendar"></i>
+        <%= t("moderation.menu.meetings") %>
+      <% end %>
+    </li>
   </ul>
 </nav>

--- a/app/views/moderation/meetings/_form.html.erb
+++ b/app/views/moderation/meetings/_form.html.erb
@@ -1,0 +1,52 @@
+<%= form_for(@meeting, url: form_url) do |f| %>
+  <%= render 'shared/errors', resource: @meeting %>
+
+  <div class="row">
+    <div class="small-12 column">
+      <%= f.label :title, t("meetings.form.meeting_title") %>
+      <%= f.text_field :title, placeholder: t("meetings.form.meeting_title"), label: false %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.label :description, t("meetings.form.meeting_description") %>
+      <p class="note"><%= t("meetings.form.meeting_description") %></p>
+      <%= f.text_area :description, rows: 4, maxlength: 350, label: false,
+                      placeholder: t('meetings.form.meeting_description') %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.label :address, t("meetings.form.meeting_address") %>
+      <%= f.text_field :address, placeholder: t("meetings.form.meeting_address"), label: false %>
+      <%= f.hidden_field :address_latitude %>
+      <%= f.hidden_field :address_longitude %>
+    </div>
+
+    <div class="small-12 column">
+      <%= google_maps_autocomplete_input address_input_id: "meeting_address", latitude_input_id: "meeting_address_latitude", longitude_input_id: "meeting_address_longitude", default_location: { lat: @meeting.address_latitude, lng: @meeting.address_longitude } %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.label :address_details, t("meetings.form.meeting_address_details") %>
+      <%= f.text_field :address_details, placeholder: t("meetings.form.meeting_address_details"), label: false %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.label :held_at, t("meetings.form.meeting_held_at") %>
+      <%= f.date_field :held_at, label: false %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.label :start_at, t("meetings.form.meeting_start_at") %>
+      <%= f.time_field :start_at, label: false %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.label :end_at, t("meetings.form.meeting_end_at") %>
+      <%= f.time_field :end_at, label: false %>
+    </div>
+
+    <div class="actions small-12 column">
+      <%= f.submit(class: "button radius", value: t("meetings.#{action_name}.form.submit_button")) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/moderation/meetings/edit.html.erb
+++ b/app/views/moderation/meetings/edit.html.erb
@@ -1,0 +1,5 @@
+<div class="meeting-edit row">
+  <div class="small-12 medium-9 column">
+    <%= render "form", form_url: moderation_meeting_url(@meeting) %>
+  </div>
+</div>

--- a/app/views/moderation/meetings/index.html.erb
+++ b/app/views/moderation/meetings/index.html.erb
@@ -1,0 +1,36 @@
+<h2><%= t("moderation.meetings.index.title") %></h2>
+
+<div class="right">
+  <%= link_to t("meetings.index.new"), new_moderation_meeting_path, class: 'button radius expand' %>
+</div>
+
+<table class="clear">
+  <tr>
+    <th>
+      <%= t("moderation.meetings.index.headers.meeting") %>
+    </th>
+  </tr>
+  <% @meetings.each do |meeting| %>
+    <tr id="meeting<%= meeting.id %>">
+      <td>
+        <%= link_to meeting.title, edit_moderation_meeting_path(meeting) %>
+        <br>
+        <span class="date"><%= l meeting.held_at %></span>
+        <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <span class="date"><%= meeting.start_at.to_s(:time) %> - <%= meeting.end_at.to_s(:time) %></span>
+        <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <%= meeting.author.username %>
+        <br>
+        <div>
+          <%= meeting.description %>
+        </div>
+      </td>
+    </tr>
+  <% end %>
+</table>
+
+<div class="right">
+  <%= link_to t("meetings.index.new"), new_moderation_meeting_path, class: 'button radius expand' %>
+</div>
+
+<%= paginate @meetings %>

--- a/app/views/moderation/meetings/new.html.erb
+++ b/app/views/moderation/meetings/new.html.erb
@@ -1,0 +1,5 @@
+<div class="meeting-new row">
+  <div class="small-12 medium-9 column">
+    <%= render "form", form_url: moderation_meetings_url %>
+  </div>
+</div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -155,6 +155,7 @@ ca:
     user: el compte
     verification::letter: la verificació
     verification::sms: el telèfon
+    meeting: la trobada presencial
   layouts:
     application:
       chrome: Google Chrome
@@ -305,6 +306,23 @@ ca:
     update:
       form:
         submit_button: Desa els canvis
+  meetings:
+    index:
+      new: "Crear trobada"
+    new:
+      form:
+        submit_button: "Crear trobada"
+    edit:
+      form:
+        submit_button: "Actualitzar trobada"
+    form:
+      meeting_title: "Títol"
+      meeting_description: "Descripció"
+      meeting_address: "On es realitzará?"
+      meeting_address_details: "Detalls adicionals del lloc"
+      meeting_held_at: "Quan es realitzará?"
+      meeting_start_at: "A quina hora comença?"
+      meeting_end_at: "A quina hora acaba?"
   shared:
     author_info:
       author_deleted: Usuari eliminat

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
     proposal: "Proposal"
     verification::sms: "Telephone"
     verification::letter: "the verification"
+    meeting: "the meeting"
   application:
     close: "Close"
     menu: "Menu"
@@ -221,6 +222,23 @@ en:
     update:
       form:
         submit_button: "Save changes"
+  meetings:
+    index:
+      new: "Create meeting"
+    new:
+      form:
+        submit_button: "Create meeting"
+    edit:
+      form:
+        submit_button: "Update meeting"
+    form:
+      meeting_title: "Title"
+      meeting_description: "Description"
+      meeting_address: "Where is going to take place?"
+      meeting_address_details: "Additional address details"
+      meeting_held_at: "When it will take place?"
+      meeting_start_at: "What time does it start?"
+      meeting_end_at: "What time does it end?"
   comments:
     show:
       return_to_commentable: "Go back to "

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -53,6 +53,7 @@ es:
     proposal: "la propuesta"
     verification::sms: "el teléfono"
     verification::letter: "la verificación"
+    meeting: "el encuentro presencial"
   application:
     close: "Cerrar"
     menu: "Menú"
@@ -220,6 +221,23 @@ es:
     update:
       form:
         submit_button: "Guardar cambios"
+  meetings:
+    index:
+      new: "Crear encuentro"
+    new:
+      form:
+        submit_button: "Crear encuentro"
+    edit:
+      form:
+        submit_button: "Actualizar encuentro"
+    form:
+      meeting_title: "Título"
+      meeting_description: "Descripción"
+      meeting_address: "¿Dónde se va a realizar?"
+      meeting_address_details: "Detalles adicionales del lugar"
+      meeting_held_at: "¿Cuándo se va a realizar?"
+      meeting_start_at: "¿A que hora empieza?"
+      meeting_end_at: "¿A que hora acaba?"
   comments:
     show:
       return_to_commentable: "Volver a "

--- a/config/locales/moderation.ca.yml
+++ b/config/locales/moderation.ca.yml
@@ -47,6 +47,7 @@ ca:
       flagged_debates: Debats
       proposals: Propostes
       users: Bloquejar usuaris
+      meetings: Trobades presencials
     proposals:
       index:
         block_authors: Bloquejar autors
@@ -74,3 +75,8 @@ ca:
         search_placeholder: email o nom d'usuari
         title: Bloquejar usuaris
       notice_hide: Usuari bloquejat. S'han ocultat tots els seus debats i comentaris.
+    meetings:
+      index:
+        title: Trobades presencials
+        headers:
+          meeting: Trobada presencial 

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -5,6 +5,7 @@ en:
       flagged_debates: "Debates"
       flagged_comments: "Comments"
       users: "Block users"
+      meetings: "Meetings"
     dashboard:
       index:
         title: "Moderation"
@@ -73,3 +74,8 @@ en:
         search: "Search"
         hide: "Block"
         hidden: "Blocked"
+    meetings:
+      index:
+        title: Meetings
+        headers:
+          meeting: Meeting 

--- a/config/locales/moderation.es.yml
+++ b/config/locales/moderation.es.yml
@@ -5,6 +5,7 @@ es:
       flagged_debates: "Debates"
       flagged_comments: "Comentarios"
       users: "Bloquear usuarios"
+      meetings: "Encuentros presenciales"
     dashboard:
       index:
         title: "Moderación"
@@ -73,3 +74,8 @@ es:
         search: "Buscar"
         hide: "Bloquear"
         hidden: "Bloqueado"
+    meetings:
+      index:
+        title: Encuentros presenciales
+        headers:
+          meeting: Encuentro presencial

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,8 @@ Rails.application.routes.draw do
         put :moderate
       end
     end
+
+    resources :meetings, except: [:show, :destroy]
   end
 
   namespace :management do

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -24,6 +24,7 @@ default: &default
   server_name: "<%= ENV['SERVER_NAME'] %>"
   email: "<%= ENV['EMAIL'] || 'participa@bcn.cat' %>"
 
+  google_maps_api_key: "<%= ENV['GOOGLE_MAPS_API_KEY'] %>"
 
 development:
   <<: *default

--- a/db/migrate/20160112092315_create_meetings.rb
+++ b/db/migrate/20160112092315_create_meetings.rb
@@ -1,0 +1,15 @@
+class CreateMeetings < ActiveRecord::Migration
+  def change
+    create_table :meetings do |t|
+      t.string :title
+      t.text :description
+      t.string :address
+      t.date :held_at
+      t.time :start_at
+      t.time :end_at
+      t.integer :author_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160113114210_add_lat_lng_and_address_details_to_meetings.rb
+++ b/db/migrate/20160113114210_add_lat_lng_and_address_details_to_meetings.rb
@@ -1,0 +1,7 @@
+class AddLatLngAndAddressDetailsToMeetings < ActiveRecord::Migration
+  def change
+    add_column :meetings, :address_latitude, :float
+    add_column :meetings, :address_longitude, :float
+    add_column :meetings, :address_details, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160113111235) do
+ActiveRecord::Schema.define(version: 20160113114210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -204,6 +204,21 @@ ActiveRecord::Schema.define(version: 20160113111235) do
   end
 
   add_index "locks", ["user_id"], name: "index_locks_on_user_id", using: :btree
+
+  create_table "meetings", force: :cascade do |t|
+    t.string   "title"
+    t.text     "description"
+    t.string   "address"
+    t.date     "held_at"
+    t.time     "start_at"
+    t.time     "end_at"
+    t.integer  "author_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.float    "address_latitude"
+    t.float    "address_longitude"
+    t.string   "address_details"
+  end
 
   create_table "moderators", force: :cascade do |t|
     t.integer "user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,7 +49,6 @@ if ENV["SEED"]
   org_user_ids = User.organizations.pluck(:id)
   not_org_users = User.where(['users.id NOT IN(?)', org_user_ids])
 
-
   puts "Creating Debates"
 
   tags = Faker::Lorem.words(25)
@@ -103,7 +102,27 @@ if ENV["SEED"]
     puts "    #{proposal.title}"
   end
 
+  puts "Creating Meetings"
 
+  places = YAML.load_file("#{Rails.root}/db/seeds/places.yml")[:places]
+
+  (1..50).each do |i|
+    place = places.sample
+    start_at = Faker::Time.forward(23, :morning)
+    meeting = Meeting.create!(
+      author: moderator,
+      title: Faker::Lorem.sentence(3).truncate(60),
+      description: Faker::Lorem.sentence(3),
+      address: place[:address],
+      address_latitude: place[:lat],
+      address_longitude: place[:lng],
+      held_at: Faker::Date.between(30.days.ago, 30.days.from_now),
+      start_at: start_at, 
+      end_at: start_at + ((1..5).to_a.sample).hours
+    )
+    puts "    #{meeting.title}"
+  end
+  
   puts "Commenting Debates"
 
   (1..100).each do |i|

--- a/db/seeds/places.yml
+++ b/db/seeds/places.yml
@@ -1,0 +1,302 @@
+---
+:places:
+- :lat: 41.40312589757035
+  :lng: 2.152813504477835
+  :address: Carrer de Santa Rosa, 4, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.4022043013453
+  :lng: 2.1655750839990557
+  :address: Passeig de Sant Joan, 157, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.403744937790606
+  :lng: 2.1453103929711026
+  :address: Carrer de la Gleva, 29, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.39819900541797
+  :lng: 2.148964687464565
+  :address: Carrer de Dénia, 13, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.397662089420535
+  :lng: 2.1395998689546145
+  :address: Via Augusta, 197, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.399916070688114
+  :lng: 2.1830884899094087
+  :address: Carrer de Lepant, 186, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.403996513941806
+  :lng: 2.169065511237875
+  :address: Carrer de Còrsega, 495, 08025 Barcelona, Barcelona, Spain
+- :lat: 41.39572365063892
+  :lng: 2.148248361240677
+  :address: Passatge de Josep Llovera, 3, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.39870688321808
+  :lng: 2.1638670841865735
+  :address: Carrer del Bruc, 164, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.404487502876734
+  :lng: 2.1429483289247084
+  :address: Carrer de Puig-reig, 14, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.404620905726595
+  :lng: 2.1694856016960387
+  :address: Carrer de Sicília, 360-362, 08025 Barcelona, Barcelona, Spain
+- :lat: 41.40176425834281
+  :lng: 2.150487126961694
+  :address: Carrer dels Madrazo, 6, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.395828709471175
+  :lng: 2.174142333706701
+  :address: Passeig de Sant Joan, 41, 08009 Barcelona, Barcelona, Spain
+- :lat: 41.390351420546565
+  :lng: 2.174298250730759
+  :address: Carrer d'Ausiàs Marc, 12, 08010 Barcelona, Barcelona, Spain
+- :lat: 41.39294505012854
+  :lng: 2.1746775640033533
+  :address: Carrer de Casp, 51, 08010 Barcelona, Barcelona, Spain
+- :lat: 41.40432230776262
+  :lng: 2.1656563987499777
+  :address: Carrer de Roger de Flor, 314, 08025 Barcelona, Barcelona, Spain
+- :lat: 41.38918865780014
+  :lng: 2.155999153032235
+  :address: Carrer de Muntaner, 105, 08036 Barcelona, Barcelona, Spain
+- :lat: 41.394174952233826
+  :lng: 2.1530011444067365
+  :address: Av. Diagonal, 427B, 08036 Barcelona, Barcelona, Spain
+- :lat: 41.3978370456396
+  :lng: 2.1504127494682646
+  :address: Carrer d'Alfons XII, 14, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.404960184841265
+  :lng: 2.160341258766858
+  :address: Carrer de Joan Blanques, 25, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.39303657488262
+  :lng: 2.1615576839931707
+  :address: Carrer de Mallorca, 242, 08008 Barcelona, Barcelona, Spain
+- :lat: 41.40027271061497
+  :lng: 2.1653465943449692
+  :address: Passatge dels Caputxins, 5, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.40060507694501
+  :lng: 2.1601218663563673
+  :address: Carrer de Tordera, 11, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.40064329062428
+  :lng: 2.173168912918912
+  :address: Passatge de Gaiolà, 6, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.40036438879445
+  :lng: 2.1775968839663453
+  :address: Carrer de Sardenya, 262, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.39967731853996
+  :lng: 2.1608975288055974
+  :address: Carrer del Progrés, 2, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.40421080550632
+  :lng: 2.1695594492618095
+  :address: Carrer de Còrsega, 490-492, 08025 Barcelona, Barcelona, Spain
+- :lat: 41.404318206079026
+  :lng: 2.1806763828875395
+  :address: Carrer d'Aragó, 491, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.4004250831753
+  :lng: 2.163296094096414
+  :address: Carrer de Milà i Fontanals, 7, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.39827468436221
+  :lng: 2.18431438486537
+  :address: Carrer de Lepant, 143, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.39229566496641
+  :lng: 2.174555322470262
+  :address: Carrer de Casp, 49-51, 08010 Barcelona, Barcelona, Spain
+- :lat: 41.390132375381924
+  :lng: 2.139928066560543
+  :address: Carrer del Taquígraf Garriga, 166, 08029 Barcelona, Barcelona, Spain
+- :lat: 41.390045189922276
+  :lng: 2.145949481477509
+  :address: Av. de Sarrià, 8-10, 08029 Barcelona, Barcelona, Spain
+- :lat: 41.389883316403576
+  :lng: 2.164591906695809
+  :address: Rambla de Catalunya, 41, 08007 Barcelona, Barcelona, Spain
+- :lat: 41.39334189795519
+  :lng: 2.1724241661017505
+  :address: Gran Via de Les Corts Catalanes, 655, 08009 Barcelona, Barcelona, Spain
+- :lat: 41.39882017261221
+  :lng: 2.1479658042420517
+  :address: Carrer d'Oliana, 21, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.394618816020916
+  :lng: 2.1453122909175386
+  :address: Carrer d'Amigó, 21, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.390068325788434
+  :lng: 2.149597812213534
+  :address: Carrer de Villarroel, 217, 08036 Barcelona, Barcelona, Spain
+- :lat: 41.39980612264589
+  :lng: 2.1507424822101093
+  :address: Carrer de Laforja, 9, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.4016784869228
+  :lng: 2.1828188086892544
+  :address: Carrer de Padilla, 168, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.404008288018545
+  :lng: 2.1647530739777876
+  :address: Carrer de Sant Antoni Maria Claret, 23, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.394531842872176
+  :lng: 2.1450743767640095
+  :address: Carrer d'Amigó, 21, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.40427029739937
+  :lng: 2.1663910196519045
+  :address: Carrer d'En Grassot, 63, 08025 Barcelona, Barcelona, Spain
+- :lat: 41.39266338524034
+  :lng: 2.152197795330124
+  :address: Carrer de París, 170, 08036 Barcelona, Barcelona, Spain
+- :lat: 41.403785997373525
+  :lng: 2.14972021450059
+  :address: Carrer de Camps i Fabrés, 6, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.39062541042347
+  :lng: 2.166848484051047
+  :address: Passeig de Gràcia, 21-23, 08007 Barcelona, Barcelona, Spain
+- :lat: 41.40086639453954
+  :lng: 2.1736163539170033
+  :address: Carrer de València, 385, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.39688666339739
+  :lng: 2.163318520004896
+  :address: Carrer de Roger de Llúria, 129, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.39067826883268
+  :lng: 2.1652830079378567
+  :address: Carrer del Consell de Cent, 306, 08007 Barcelona, Barcelona, Spain
+- :lat: 41.39519407228949
+  :lng: 2.1652395800347164
+  :address: Carrer de Mallorca, 274, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.39988117192058
+  :lng: 2.1463228874189513
+  :address: Carrer de Sant Eusebi, 56, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.39718482550643
+  :lng: 2.169410284724354
+  :address: Carrer de València, 348, 08009 Barcelona, Barcelona, Spain
+- :lat: 41.397615082240186
+  :lng: 2.138234651982459
+  :address: Carrer Via Augusta, 209, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.3916153328218
+  :lng: 2.1759095134083073
+  :address: Carrer d'Ausiàs Marc, 33-35, 08010 Barcelona, Barcelona, Spain
+- :lat: 41.397676797213514
+  :lng: 2.162894116517713
+  :address: Carrer de Roger de Llúria, 126, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.399713371010556
+  :lng: 2.1810780376604773
+  :address: Gran Via de Les Corts Catalanes, 11, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.3920883860295
+  :lng: 2.165217978462524
+  :address: Passeig de Gràcia, 1504, 08007 Barcelona, Barcelona, Spain
+- :lat: 41.39943974940909
+  :lng: 2.182760279695259
+  :address: Carrer de Lepant, 171, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.40231775968371
+  :lng: 2.1543300703368535
+  :address: Travessia de Sant Antoni, 11, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.399816144249925
+  :lng: 2.140330130672122
+  :address: Carrer de Santaló, 137, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.3996848600007
+  :lng: 2.142862434904606
+  :address: Carrer De Descartes, 9, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.40360288163012
+  :lng: 2.143256303309785
+  :address: Carrer de Pàdua, 117, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.404060284616875
+  :lng: 2.147449763834981
+  :address: Carrer de Vallirana, 41, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.39286222471476
+  :lng: 2.1446270908198493
+  :address: Plaça de Francesc Macià, 9999, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.40242144230698
+  :lng: 2.1753380310979984
+  :address: Passatge de Font, 9, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.39264903122974
+  :lng: 2.146243784488352
+  :address: Av. Diagonal, 473, 08036 Barcelona, Barcelona, Spain
+- :lat: 41.40418603358354
+  :lng: 2.1726814493480506
+  :address: Passatge de Simó, 1, 08025 Barcelona, Barcelona, Spain
+- :lat: 41.40509979360269
+  :lng: 2.184807281866276
+  :address: Carrer del Dos de Maig, 190, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.40230059480719
+  :lng: 2.1470437575642927
+  :address: Carrer de Lincoln, 55, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.40001643852961
+  :lng: 2.170290784324542
+  :address: Carrer de Mallorca, 341, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.390419059653205
+  :lng: 2.141333519039436
+  :address: Plaça Dr. Ignasi Barraquer, 67-225, 08029 Barcelona, Barcelona, Spain
+- :lat: 41.40368144508554
+  :lng: 2.1471384503139586
+  :address: Carrer de Saragossa, 64-66, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.39627638972644
+  :lng: 2.1619969773642587
+  :address: Carrer de Pau Claris, 181, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.39676300352916
+  :lng: 2.14848523810205
+  :address: Carrer de l'Avenir, 21, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.39483653338702
+  :lng: 2.1485273566869654
+  :address: Carrer de Muntaner, 237, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.39852022308938
+  :lng: 2.1581834431962355
+  :address: Carrer de Sant Pere Màrtir, 1, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.39223449763937
+  :lng: 2.174631459064355
+  :address: Carrer de Girona, 30, 08010 Barcelona, Barcelona, Spain
+- :lat: 41.402161789185925
+  :lng: 2.1511050214417673
+  :address: Carrer de Bretón de los Herreros, 28, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.3918819642818
+  :lng: 2.1420628762264147
+  :address: Av. Diagonal, 501, 08029 Barcelona, Barcelona, Spain
+- :lat: 41.39643423370693
+  :lng: 2.13893986859221
+  :address: Carrer de Vallmajor, 4, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.39991943172638
+  :lng: 2.1566519719127517
+  :address: Carrer de Sant Domènec, 18, 08012 Barcelona, Barcelona, Spain
+- :lat: 41.40271272536886
+  :lng: 2.1797780961331155
+  :address: Carrer dels Enamorats, 21, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.39848947782679
+  :lng: 2.1826437615946404
+  :address: Carrer de Casp, 131, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.397438401808834
+  :lng: 2.161176152709764
+  :address: Carrer de Pau Claris, 194, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.3893586557745
+  :lng: 2.1765305013430125
+  :address: Passatge Sert, 48, 08003 Barcelona, Barcelona, Spain
+- :lat: 41.39128716684102
+  :lng: 2.153022638232709
+  :address: Carrer de Muntaner, 159, 08036 Barcelona, Barcelona, Spain
+- :lat: 41.39880305367675
+  :lng: 2.1535793030936192
+  :address: Plaça de Gal·la Placídia, 2, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.40326921477715
+  :lng: 2.146447897460235
+  :address: Carrer de la Gleva, 12, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.40068269214059
+  :lng: 2.180241530434883
+  :address: Carrer de la Diputació, 457, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.39740661517566
+  :lng: 2.166560350341424
+  :address: Carrer de Mallorca, 309, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.39633030463659
+  :lng: 2.177057595086391
+  :address: Gran Via de Les Corts Catalanes, 677, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.396170497137184
+  :lng: 2.1581909576561302
+  :address: Av. Diagonal, 389, 08006 Barcelona, Barcelona, Spain
+- :lat: 41.40130635961317
+  :lng: 2.1836469458299637
+  :address: Gran Via de Les Corts Catalanes, 755, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.39107655266329
+  :lng: 2.1828523068599317
+  :address: Carrer de Roger de Flor, 23, 08018 Barcelona, Barcelona, Spain
+- :lat: 41.39051352363043
+  :lng: 2.1729241323409436
+  :address: Carrer de Roger de Llúria, 14, 08010 Barcelona, Barcelona, Spain
+- :lat: 41.40006009074188
+  :lng: 2.1738133584479886
+  :address: Av. Diagonal, 299B, 08013 Barcelona, Barcelona, Spain
+- :lat: 41.396457300130876
+  :lng: 2.1436674821155988
+  :address: Carrer Galvany, 108, 08021 Barcelona, Barcelona, Spain
+- :lat: 41.4029056955968
+  :lng: 2.162268806253353
+  :address: Carrer de Bailèn, 229, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.403233596981885
+  :lng: 2.161729056295353
+  :address: Carrer de Bailèn, 235I, 08037 Barcelona, Barcelona, Spain
+- :lat: 41.3948863396649
+  :lng: 2.158669894880429
+  :address: Rambla de Catalunya, 114, 08008 Barcelona, Barcelona, Spain

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ app:
     - DATABASE_PASSWORD=
     - DATABASE_NAME=postgres
     - GEM_HOME=/bundle
+    - GOOGLE_MAPS_API_KEY=${GOOGLE_MAPS_API_KEY}
   volumes:
     - .:/decidimbcn
   volumes_from:

--- a/lib/tasks/places.rake
+++ b/lib/tasks/places.rake
@@ -1,0 +1,28 @@
+namespace :places do
+  desc "Generate a yml file with random Barcelona places for seeds"
+  task :generate_seeds do
+    filename = "#{Rails.root}/db/seeds/places.yml"
+    boundings = [
+      [41.405199, 2.136749],
+      [41.389167, 2.184815]
+    ]
+
+    random = Random.new 
+    places = []
+
+    100.times do
+      lat = random.rand(boundings[1][0]..boundings[0][0])
+      lng = random.rand(boundings[0][1]..boundings[1][1])
+      address = Geocoder.search("#{lat},#{lng}").first.formatted_address
+      places.push({
+        lat: lat,
+        lng: lng,
+        address: address
+      })
+    end
+
+    File.open(filename, 'w') do |f| 
+      f.write({places: places}.to_yaml)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryGirl.define do  
   sequence(:document_number) { |n| "#{n.to_s.rjust(8, '0')}X" }
 
   factory :user do
@@ -314,5 +314,15 @@ FactoryGirl.define do
   factory :notification do
     user
     association :notifiable, factory: :proposal
+  end
+
+  factory :meeting do
+    sequence(:title)       { |n| "Meeting #{n} title" }
+    sequence(:description) { |n| "Meeting #{n} description" }
+    sequence(:address)     { |n| "Fake address #{n}" }
+    held_at Date.today
+    start_at Time.now
+    end_at Time.now + 1.hour
+    association :author, factory: :user
   end
 end

--- a/spec/features/moderation/meetings_spec.rb
+++ b/spec/features/moderation/meetings_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+feature 'Moderate meetings' do
+  context 'As a moderator' do
+    before :each do 
+      @moderator = create(:moderator)
+      login_as(@moderator.user)
+
+      @meeting_data = {
+        title: 'First meeting',
+        description: 'We are going to discuss a few things',
+        address: 'Passeig de Sant Joan, 11',
+        held_at: '2016-01-12',
+        start_at: '10:00',
+        end_at: '10:00'
+      }
+    end
+
+    def fill_in_meeting_form
+      fill_in 'meeting_title', with: @meeting_data[:title]
+      fill_in 'meeting_description', with: @meeting_data[:description]
+      fill_in 'meeting_address', with: @meeting_data[:address] 
+      fill_in 'meeting_held_at', with: @meeting_data[:held_at]
+      fill_in 'meeting_start_at', with: @meeting_data[:start_at]
+      fill_in 'meeting_end_at', with: @meeting_data[:end_at]
+    end
+
+    scenario 'Create a meeting with valid values', :js do
+      visit new_moderation_meeting_path
+
+      fill_in_meeting_form
+
+      click_button 'Create meeting'
+
+      expect(page).to have_content @meeting_data[:title]
+      expect(page).to have_content @meeting_data[:description]
+      expect(page).to have_content @meeting_data[:held_at]
+      expect(page).to have_content @meeting_data[:start_at]
+      expect(page).to have_content @meeting_data[:end_at]
+    end
+
+    scenario 'Create a meeting with some invalid values', :js do
+      visit new_moderation_meeting_path
+
+      fill_in_meeting_form
+
+      fill_in 'meeting_title', with: ''
+
+      click_button 'Create meeting'
+
+      expect(page).to_not have_content "Meeting created successfully."
+      expect(page).to have_content "1 error"
+    end
+
+    scenario 'List meetings which I have created' do
+      other_moderator = create(:moderator)
+      create(:meeting, title: "My meeting", author: @moderator.user)
+      create(:meeting, title: "Other meeting", author: other_moderator.user)
+
+      visit moderation_meetings_path
+
+      expect(page).to have_content "My meeting"
+      expect(page).to have_no_content "Other meeting"
+    end
+
+    scenario 'Update a meeting', :js do
+      meeting = create(:meeting, title: "My meeting", author: @moderator.user)
+      visit edit_moderation_meeting_path(meeting)
+
+      fill_in 'meeting_title', with: "My updated meeting"
+
+      click_button 'Update meeting'
+
+      expect(page).to have_content "My updated meeting"
+    end
+
+    scenario 'Update a meeting with some invalid values', :js do
+      meeting = create(:meeting, title: "My meeting", author: @moderator.user)
+      visit edit_moderation_meeting_path(meeting)
+
+      fill_in 'meeting_title', with: ''
+
+      click_button 'Update meeting'
+
+      expect(page).to_not have_content "Meeting updated successfully."
+      expect(page).to have_content "1 error"
+    end
+
+  end
+
+  context 'As an administrator' do
+    before :each do 
+      @admin = create(:administrator)
+      login_as(@admin.user)
+    end
+
+    scenario 'List all meetings' do 
+      create(:meeting, title: "My meeting", author: create(:moderator).user)
+      create(:meeting, title: "Other meeting", author: create(:moderator).user)
+
+      visit moderation_meetings_path
+
+      expect(page).to have_content "My meeting"
+      expect(page).to have_content "Other meeting"
+    end
+  end
+
+end

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe Meeting do
+  let(:meeting) { build(:meeting) }
+
+  it "should be valid" do
+    expect(meeting).to be_valid
+  end
+
+  it "should not be valid without an author" do
+    meeting.author = nil
+    expect(meeting).to_not be_valid
+  end
+
+  it "should not be valid without a title" do
+    meeting.title = nil
+    expect(meeting).to_not be_valid
+  end
+
+  it "should not be valid without a summary" do
+    meeting.description = nil
+    expect(meeting).to_not be_valid
+  end
+
+  it "should not be valid without an address" do
+    meeting.address = nil
+    expect(meeting).to_not be_valid
+  end
+
+  it "should not be valid without an address" do
+    meeting.address = nil
+    expect(meeting).to_not be_valid
+  end
+
+  it "should not be valid without a held_at date" do
+    meeting.held_at = nil
+    expect(meeting).to_not be_valid
+  end
+
+  it "should not be valid without a start_at time" do
+    meeting.start_at = nil
+    expect(meeting).to_not be_valid
+  end
+
+  it "should not be valid without a end_at time" do
+    meeting.end_at = nil
+    expect(meeting).to_not be_valid
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'spec_helper'
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'capybara/poltergeist'
+require 'capybara-screenshot/rspec'
 
 I18n.default_locale = :en
 
@@ -23,5 +24,9 @@ end
 
 Capybara.javascript_driver = :poltergeist
 Capybara.exact = true
+
+Capybara::Screenshot::RSpec.add_link_to_screenshot_for_failed_examples = false
+Capybara::Screenshot.webkit_options = { width: 1024, height: 768 }
+Capybara::Screenshot.prune_strategy = :keep_last_run
 
 OmniAuth.config.test_mode = true


### PR DESCRIPTION
# What and Why

A moderator should be able to create a `meeting` to discuss different `proposals`. A meeting should be held at a specific address and time.
I used standard HTML5 inputs for date and time. For the `address` field I created a simple component called `GoogleMapsAutocompleteInput`. This component uses the `autocomplete` feature from Google Maps Places API and listen change events in a specific input field. Then it displays different suggestions and the user can choose one of them.

As a bonus feature I included a rake task called `places:seeds` to create a yml file with random Barcelona places. I use those places to generate a collection of meetings with random data.
Also I included some basic code to edit/update a meeting but this part is not finished.
# QA

Since we are using Google Maps Javascript API an environment variable called `GOOGLE_MAPS_API_KEY` is needed in order to work. The `meetings` administration is currently under the `moderation` namespace.
# Gif

![](https://media.giphy.com/media/caeFs9k2rswyQ/giphy.gif)
