### PR TITLE
Fix filter behavior

### DIFF
--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -8,34 +8,33 @@ class ProposalFilters extends React.Component {
     };
   }
 
-  renderChildren() {
-    return React.Children.map(this.props.children, (child) => {
-      return React.cloneElement(child, {
-        onChangeFilter: (filterName, filterValue) => this.changeFilter(filterName, filterValue)
-      })
-    });
-  }
-
   render() {
     return (
       <form>
         <ProposalFilterOptionGroup 
           filterGroupName="scope" 
           filterGroupValue={this.state.filters.get('scope')}
+          isExclusive={true}
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
-          <ProposalFilterOption filterName="district" />
           <ProposalFilterOption filterName="city" />
+          <ProposalFilterOption filterName="district" />
         </ProposalFilterOptionGroup>
-        <ProposalFilterOptionGroup 
-          filterGroupName="district" 
-          filterGroupValue={this.state.filters.get('district')}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
-          {
-            this.props.districts.map(function (district) {
-              return <ProposalFilterOption key={district[1]} filterName={district[1]} filterLabel={district[0]} />
-            })
+        {(() => {
+          if(this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1) {
+            return (
+              <ProposalFilterOptionGroup 
+                filterGroupName="district" 
+                filterGroupValue={this.state.filters.get('district')}
+                onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
+                {
+                  this.props.districts.map(function (district) {
+                    return <ProposalFilterOption key={district[1]} filterName={district[1]} filterLabel={district[0]} />
+                  })
+                }
+              </ProposalFilterOptionGroup>
+            )
           }
-        </ProposalFilterOptionGroup>
+        })()}
         <ProposalFilterOptionGroup 
           filterGroupName="category_id" 
           filterGroupValue={this.state.filters.get('category_id')}
@@ -83,6 +82,9 @@ class ProposalFilters extends React.Component {
     let filters = this.state.filters.set(filterGroupName, filterGroupValue);
     if (filterGroupName === 'category_id') {
       filters = this.checkFilterSubcategoryIds(filters);
+    }
+    if (filterGroupName === 'scope' && filterGroupValue !== 'district') {
+      filters = filters.delete('district');
     }
     this.applyFilters(filters.toObject(), this.state.tags.toArray());
     this.setState({ filters });

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -135,7 +135,7 @@ class Proposal < ActiveRecord::Base
     Setting['votes_for_proposal_success'].to_i
   end
 
-  DISTRICTS = YAML::load_file("#{Rails.root}/config/districts.yml")["districts"].to_a.map(&:reverse).sort
+  DISTRICTS = YAML::load_file("#{Rails.root}/config/districts.yml")["districts"].to_a.map(&:reverse).map {|a,b| [a.to_s, b.to_s]}.sort
 
   protected
 

--- a/app/views/debates/_debate.html.erb
+++ b/app/views/debates/_debate.html.erb
@@ -14,7 +14,7 @@
               <span class="bullet">&nbsp;&bull;&nbsp;</span>
               <%= l debate.created_at.to_date %>
 
-              <% if debate.author.hidden? || debate.author.erased? %>
+              <% if !debate.author || debate.author.hidden? || debate.author.erased? %>
                 <span class="bullet">&nbsp;&bull;&nbsp;</span>
                 <span class="author">
                   <%= t("debates.show.author_deleted") %>


### PR DESCRIPTION
This fixes the filter's behavior on `scope` and `district`. It:
- [x] Makes scope exclusive
- [x] Resets districts on scope change
- [x] Only shows districts when `district` is selected, duh.
