### PR TITLE
Comments in favor, against, or neutral

### DIFF
--- a/app/assets/javascripts/comments.js.coffee
+++ b/app/assets/javascripts/comments.js.coffee
@@ -2,16 +2,23 @@ App.Comments =
 
   add_comment: (parent_id, response_html) ->
     $(response_html).insertAfter($("#js-comment-form-#{parent_id}"))
-    this.update_comments_count()
 
   add_reply: (parent_id, response_html) ->
     $("##{parent_id} .comment-children:first").prepend($(response_html))
     this.update_comments_count()
 
-  update_comments_count: (parent_id) ->
-    $(".js-comments-count").each ->
-      new_val = $(this).text().trim().replace /\d+/, (match) -> parseInt(match, 10) + 1
-      $(this).text(new_val)
+  update_comments_count: (alignment) ->
+    comments_count = null;
+
+    if(alignment > 0)
+      comments_count = $(".js-comments-count.positive");
+    else if alignment < 0
+      comments_count = $(".js-comments-count.negative");
+    else
+      comments_count = $(".js-comments-count.neutral");
+
+    new_val = comments_count.text().trim().replace /\d+/, (match) -> parseInt(match, 10) + 1
+    comments_count.text(new_val)
 
   display_error: (field_with_errors, error_html) ->
     $(error_html).insertAfter($("#{field_with_errors}"))

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1677,6 +1677,12 @@ table {
     }
   }
 
+  .new_comment{
+    .alignment-input{
+      margin-right: 1em;
+    }
+  }
+
   .comment {
     margin: $line-height/4 0;
 
@@ -1703,6 +1709,22 @@ table {
       [class^="icon-"] {
         font-size: rem-calc(20);
         vertical-align: middle;
+      }
+    }
+
+    &.positive > .comment-body{
+      & > .comment-user{
+        @include label-style(lighten(#43AC6A, 35%))
+        padding-left: 0.5em;
+        padding-right: 0.5em;
+      }
+    }
+
+    &.negative > .comment-body{
+      & > .comment-user{
+        @include label-style(lighten(#f04124, 35%))
+        padding-left: 0.5em;
+        padding-right: 0.5em;
       }
     }
 
@@ -1759,6 +1781,7 @@ table {
           background: $comment-level-5;
           padding: $line-height/4 $line-height/2;
         }
+
       }
     }
 

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1749,39 +1749,6 @@ table {
         margin-top: $line-height/4;
         padding: $line-height/4 0;
         overflow: hidden;
-
-        @each $n in ("1", "2", "3","4", "5") {
-          &.level-#{$n} {
-            @if $n == "5" {
-              background: $comment-level-5;
-              padding: $line-height/4 $line-height/2;
-            }
-            @elseif $n == "1" {
-              background: none;
-              padding: $line-height/4 $line-height/2;
-            }
-            @else {
-              background: $comment-official;
-              padding: $line-height/4 $line-height/2;
-            }
-          }
-        }
-
-        &.is-author {
-          background: $comment-author;
-          padding: $line-height/4 $line-height/2;
-        }
-
-        &.is-admin, &.is-moderator {
-          background: $comment-admin;
-          padding: $line-height/4 $line-height/2;
-        }
-
-        &.level-5 {
-          background: $comment-level-5;
-          padding: $line-height/4 $line-height/2;
-        }
-
       }
     }
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -40,7 +40,7 @@ class CommentsController < ApplicationController
   private
 
     def comment_params
-      params.require(:comment).permit(:commentable_type, :commentable_id, :parent_id, :body, :as_moderator, :as_administrator)
+      params.require(:comment).permit(:commentable_type, :commentable_id, :parent_id, :body, :as_moderator, :as_administrator, :alignment)
     end
 
     def build_comment

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -44,7 +44,7 @@ class CommentsController < ApplicationController
     end
 
     def build_comment
-      @comment = Comment.build(@commentable, current_user, comment_params[:body], comment_params[:parent_id].presence)
+      @comment = Comment.build(@commentable, current_user, comment_params)
       check_for_special_comments
     end
 

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -39,4 +39,16 @@ module CommentsHelper
       "" # Default not author class
     end
   end
+
+  def comment_class_names(comment)
+    classes = ["comment", comment_alignment_class(comment.alignment)]
+    classes.compact.join(" ")
+  end
+
+  def comment_alignment_class(alignment)
+    return nil unless alignment
+    return "negative" if alignment < 0
+    return "neutral" if alignment == 0
+    return "positive" if alignment > 0
+  end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -26,7 +26,7 @@ module CommentsHelper
     elsif comment.as_moderator?
       "is-moderator"
     elsif comment.user.official?
-      "level-#{comment.user.official_level}"
+      "user-level-#{comment.user.official_level}"
     else
       "" # Default no special user class
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -38,15 +38,28 @@ class Comment < ActiveRecord::Base
 
   after_create :call_after_commented
 
-  def self.build(commentable, user, body, p_id=nil)
-    new commentable: commentable,
-        user_id:     user.id,
-        body:        body,
-        parent_id:   p_id
+  after_initialize do |comment| 
+    comment.alignment ||= 0 unless comment.parent_id
+  end
+
+  def self.build(commentable, user, params = {})
+    new({commentable: commentable, user_id:     user.id}.merge(params))
   end
 
   def self.find_commentable(c_type, c_id)
     c_type.constantize.find(c_id)
+  end
+
+  def self.positive
+    where(arel_table[:alignment].gt 0)
+  end
+
+  def self.negative
+    where(arel_table[:alignment].lt 0)
+  end
+
+  def self.neutral
+    where(arel_table[:alignment].eq 0)
   end
 
   def author_id

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,6 +12,9 @@ class Comment < ActiveRecord::Base
   validates :user, presence: true
   validates_inclusion_of :commentable_type, in: ["Debate", "Proposal"]
 
+  validates :alignment, inclusion: { in: -1..1 }, unless: :parent_id
+  validates :alignment, presence: false, if: :parent_id
+
   validate :validate_body_length
 
   belongs_to :commentable, -> { with_hidden }, polymorphic: true, counter_cache: true

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <% cache [locale_and_user_status(comment), comment, commentable_cache_key(comment.commentable), comment.author, (@comment_flags[comment.id] if @comment_flags)] do %>
   <div class="row">
-  	<div id="<%= dom_id(comment) %>" class="comment small-12 column">
+  	<div id="<%= dom_id(comment) %>" class="comment small-12 column <%= comment_class_names comment %>">
 
       <% if comment.hidden? || comment.user.hidden? %>
         <% if comment.children.size > 0 %>
@@ -43,6 +43,24 @@
                   </span>
                 <% end %>
               <% end %>
+
+              <% if comment.alignment %>
+                &nbsp;&bull;&nbsp;
+                <% if comment.alignment > 0 %>
+                  <span class="success round label">
+                    <%= t('comments.form.alignment.positive') %>
+                  </span>
+                <% elsif comment.alignment < 0 %>
+                  <span class="alert round label">
+                    <%= t('comments.form.alignment.negative') %>
+                  </span>
+                <% else %>
+                  <span class="secondary round label">
+                    <%= t('comments.form.alignment.neutral') %>
+                  </span>
+                <% end %>
+              <% end %>
+
               <% if comment.user.verified_organization? %>
                 &nbsp;&bull;&nbsp;
                 <span class="label round is-association">
@@ -59,15 +77,6 @@
             <% end %>
 
             &nbsp;&bull;&nbsp;<time><%= l comment.created_at.to_datetime, format: :datetime %></time>
-            <% if comment.alignment %>
-              <% if comment.alignment > 0 %>
-                <%= t('comments.form.alignment.positive') %>
-              <% elsif comment.alignment < 0 %>
-                <%= t('comments.form.alignment.negative') %>
-              <% else %>
-                <%= t('comments.form.alignment.neutral') %>
-              <% end %>
-            <% end %>
           </div>
 
           <div class="comment-user

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -59,6 +59,15 @@
             <% end %>
 
             &nbsp;&bull;&nbsp;<time><%= l comment.created_at.to_datetime, format: :datetime %></time>
+            <% if comment.alignment %>
+              <% if comment.alignment > 0 %>
+                <%= t('comments.form.alignment.positive') %>
+              <% elsif comment.alignment < 0 %>
+                <%= t('comments.form.alignment.negative') %>
+              <% else %>
+                <%= t('comments.form.alignment.neutral') %>
+              <% end %>
+            <% end %>
           </div>
 
           <div class="comment-user

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -8,6 +8,12 @@
       <%= f.hidden_field :commentable_id, value: commentable.id %>
       <%= f.hidden_field :parent_id, value: parent_id %>
 
+      <div class="alignment">
+        <%= f.radio_button "alignment", "-1", label: t('comments.form.alignment.negative') %>
+        <%= f.radio_button "alignment", "0", label: t('comments.form.alignment.neutral') %>
+        <%= f.radio_button "alignment", "1", label: t('comments.form.alignment.positive') %>
+      </div>
+
       <%= f.submit comment_button_text(parent_id), class: "button radius small inline-block" %>
 
       <% if can? :comment_as_moderator, commentable %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -8,11 +8,19 @@
       <%= f.hidden_field :commentable_id, value: commentable.id %>
       <%= f.hidden_field :parent_id, value: parent_id %>
 
-      <div class="alignment">
-        <%= f.radio_button "alignment", "-1", label: t('comments.form.alignment.negative') %>
-        <%= f.radio_button "alignment", "0", label: t('comments.form.alignment.neutral') %>
-        <%= f.radio_button "alignment", "1", label: t('comments.form.alignment.positive') %>
-      </div>
+      <% unless parent_id %>
+        <div class="alignment">
+          <span class="alignment-input">
+            <%= f.radio_button "alignment", "1", label: t('comments.form.alignment.positive') %>
+          </span>
+          <span class="alignment-input">
+            <%= f.radio_button "alignment", "0", label: t('comments.form.alignment.neutral') %>
+          </span>
+          <span class="alignment-input">
+            <%= f.radio_button "alignment", "-1", label: t('comments.form.alignment.negative') %>
+          </span>
+        </div>
+      <% end %>
 
       <%= f.submit comment_button_text(parent_id), class: "button radius small inline-block" %>
 

--- a/app/views/comments/_summary.html.erb
+++ b/app/views/comments/_summary.html.erb
@@ -1,0 +1,5 @@
+<span>
+  (<%= t('comments.form.alignment.positive') %>: <span class="js-comments-count positive"><%= commentable.comments.positive.count %></span>,
+  <%= t('comments.form.alignment.negative') %>: <span class="js-comments-count negative"><%= commentable.comments.negative.count %></span>,
+  <%= t('comments.form.alignment.neutral') %>: <span class="js-comments-count neutral"><%= commentable.comments.neutral.count %></span>)
+</span>

--- a/app/views/comments/create.js.erb
+++ b/app/views/comments/create.js.erb
@@ -4,6 +4,7 @@ var comment_html = "<%= j(render @comment) %>"
   var commentable_id = '<%= dom_id(@commentable) %>';
   App.Comments.reset_form(commentable_id);
   App.Comments.add_comment(commentable_id, comment_html);
+  App.Comments.update_comments_count(<%= @comment.alignment %>);
 <% else -%>
   var parent_id = '<%= "comment_#{@comment.parent_id}" %>';
   App.Comments.reset_and_hide_form(parent_id);

--- a/app/views/debates/_comments.html.erb
+++ b/app/views/debates/_comments.html.erb
@@ -4,7 +4,7 @@
       <div id="comments" class="small-12 column">
         <h2>
           <%= t("debates.show.comments_title") %>
-          <span class="js-comments-count">(<%= @debate.comments_count %>)</span>
+          <%= render partial: 'comments/summary', locals: { commentable: @debate } %>
         </h2>
 
         <%= render 'shared/wide_order_selector', i18n_namespace: "comments" %>

--- a/app/views/proposals/_comments.html.erb
+++ b/app/views/proposals/_comments.html.erb
@@ -5,11 +5,7 @@
 
         <h2>
           <%= t("proposals.show.comments_title") %>
-          <span>
-          (<%= t('comments.form.alignment.positive') %>: <span class="js-comments-count positive"><%= @proposal.comments.positive.count %></span>,
-          <%= t('comments.form.alignment.negative') %>: <span class="js-comments-count negative"><%= @proposal.comments.negative.count %></span>,
-          <%= t('comments.form.alignment.neutral') %>: <span class="js-comments-count neutral"><%= @proposal.comments.neutral.count %></span>)
-          </span>
+          <%= render partial: 'comments/summary', locals: { commentable: @proposal } %>
         </h2>
 
         <%= render 'shared/wide_order_selector', i18n_namespace: "comments" %>

--- a/app/views/proposals/_comments.html.erb
+++ b/app/views/proposals/_comments.html.erb
@@ -5,7 +5,11 @@
 
         <h2>
           <%= t("proposals.show.comments_title") %>
-          <span class="js-comments-count">(<%= @proposal.comments_count %>)</span>
+          <span>
+          (<%= t('comments.form.alignment.positive') %>: <span class="js-comments-count positive"><%= @proposal.comments.positive.count %></span>,
+          <%= t('comments.form.alignment.negative') %>: <span class="js-comments-count negative"><%= @proposal.comments.negative.count %></span>,
+          <%= t('comments.form.alignment.neutral') %>: <span class="js-comments-count neutral"><%= @proposal.comments.neutral.count %></span>)
+          </span>
         </h2>
 
         <%= render 'shared/wide_order_selector', i18n_namespace: "comments" %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -49,6 +49,10 @@ ca:
       comment_as_admin: Comentar com a administrador
       comment_as_moderator: Comentar com a moderador
       leave_comment: Deixa el teu comentari
+      alignment:
+        positive: "A favor"
+        negative: "En contra"
+        neutral: "Neutral"
     orders:
       most_voted: Més votats
       newest: Més nous primer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,6 +233,10 @@ en:
       leave_comment: "Leave your comment"
       comment_as_moderator: "Comment as moderator"
       comment_as_admin: "Comment as admin"
+      alignment:
+        positive: "In favor"
+        negative: "Against"
+        neutral: "Neutral"
     comment:
       author: "Author"
       moderator: "Moderator"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -232,6 +232,10 @@ es:
       leave_comment: "Deja tu comentario"
       comment_as_moderator: "Comentar como moderador"
       comment_as_admin: "Comentar como administrador"
+      alignment:
+        positive: "A favor"
+        negative: "En contra"
+        neutral: "Neutral"
     comment:
       author: "Autor"
       moderator: "Moderador"

--- a/db/migrate/20160113111235_add_alignment_to_comments.rb
+++ b/db/migrate/20160113111235_add_alignment_to_comments.rb
@@ -1,0 +1,7 @@
+class AddAlignmentToComments < ActiveRecord::Migration
+  def change
+    change_table :comments do |t|
+      t.integer :alignment, limit: 1
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111075710) do
+ActiveRecord::Schema.define(version: 20160113111235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,20 +81,21 @@ ActiveRecord::Schema.define(version: 20160111075710) do
     t.string   "commentable_type"
     t.text     "body"
     t.string   "subject"
-    t.integer  "user_id",                        null: false
+    t.integer  "user_id",                                  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "hidden_at"
-    t.integer  "flags_count",        default: 0
+    t.integer  "flags_count",                  default: 0
     t.datetime "ignored_flag_at"
     t.integer  "moderator_id"
     t.integer  "administrator_id"
-    t.integer  "cached_votes_total", default: 0
-    t.integer  "cached_votes_up",    default: 0
-    t.integer  "cached_votes_down",  default: 0
+    t.integer  "cached_votes_total",           default: 0
+    t.integer  "cached_votes_up",              default: 0
+    t.integer  "cached_votes_down",            default: 0
     t.datetime "confirmed_hide_at"
     t.string   "ancestry"
-    t.integer  "confidence_score",   default: 0, null: false
+    t.integer  "confidence_score",             default: 0, null: false
+    t.integer  "alignment",          limit: 2
   end
 
   add_index "comments", ["ancestry"], name: "index_comments_on_ancestry", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -112,6 +112,7 @@ if ENV["SEED"]
     Comment.create!(user: author,
                     created_at: rand(debate.created_at .. Time.now),
                     commentable: debate,
+                    alignment: [-1, 0, 1].sample,
                     body: Faker::Lorem.sentence)
   end
 
@@ -124,6 +125,7 @@ if ENV["SEED"]
     Comment.create!(user: author,
                     created_at: rand(proposal.created_at .. Time.now),
                     commentable: proposal,
+                    alignment: [-1, 0, 1].sample,
                     body: Faker::Lorem.sentence)
   end
 

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -133,7 +133,7 @@ feature 'Commenting debates' do
     end
   end
 
-  scenario 'Create', :js do
+  scenario 'Create a neutral comment', :js do
     login_as(user)
     visit debate_path(debate)
 
@@ -142,7 +142,35 @@ feature 'Commenting debates' do
 
     within "#comments" do
       expect(page).to have_content 'Have you thought about...?'
-      expect(page).to have_content '(1)'
+      expect(page).to have_content 'Neutral: 1'
+    end
+  end
+
+  scenario 'Create a comment in favor', :js do
+    login_as(user)
+    visit debate_path(debate)
+
+    fill_in "comment-body-debate_#{debate.id}", with: 'Have you thought about...?'
+    choose "In favor"
+    click_button 'Publish comment'
+
+    within "#comments" do
+      expect(page).to have_content 'Have you thought about...?'
+      expect(page).to have_content 'In favor: 1'
+    end
+  end
+
+  scenario 'Create a comment against', :js do
+    login_as(user)
+    visit debate_path(debate)
+
+    fill_in "comment-body-debate_#{debate.id}", with: 'Have you thought about...?'
+    choose "Against"
+    click_button 'Publish comment'
+
+    within "#comments" do
+      expect(page).to have_content 'Have you thought about...?'
+      expect(page).to have_content 'Against: 1'
     end
   end
 

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -133,7 +133,7 @@ feature 'Commenting proposals' do
     end
   end
 
-  scenario 'Create', :js do
+  scenario 'Create a neutral comment', :js do
     login_as(user)
     visit proposal_path(proposal)
 
@@ -142,7 +142,35 @@ feature 'Commenting proposals' do
 
     within "#comments" do
       expect(page).to have_content 'Have you thought about...?'
-      expect(page).to have_content '(1)'
+      expect(page).to have_content 'Neutral: 1'
+    end
+  end
+
+  scenario 'Create a comment in favor', :js do
+    login_as(user)
+    visit proposal_path(proposal)
+
+    fill_in "comment-body-proposal_#{proposal.id}", with: 'Have you thought about...?'
+    choose "In favor"
+    click_button 'Publish comment'
+
+    within "#comments" do
+      expect(page).to have_content 'Have you thought about...?'
+      expect(page).to have_content 'In favor: 1'
+    end
+  end
+
+  scenario 'Create a comment against', :js do
+    login_as(user)
+    visit proposal_path(proposal)
+
+    fill_in "comment-body-proposal_#{proposal.id}", with: 'Have you thought about...?'
+    choose "Against"
+    click_button 'Publish comment'
+
+    within "#comments" do
+      expect(page).to have_content 'Have you thought about...?'
+      expect(page).to have_content 'Against: 1'
     end
   end
 

--- a/spec/helpers/comments_helper_spec.rb
+++ b/spec/helpers/comments_helper_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CommentsHelper, type: :helper do
     it 'returns level followed by official level if user is official' do
       comment = comment_double(official: true)
 
-      expect(helper.user_level_class(comment)).to eq('level-Y')
+      expect(helper.user_level_class(comment)).to eq('user-level-Y')
     end
 
     it 'returns an empty class otherwise' do


### PR DESCRIPTION
## What and why?

In order to allow users to show their support to an iniciative through a comment (without actually supporting it) as well as starting a discussion over it, comments can be in favor, against or neutral.
## GIF TAX

![](https://media.giphy.com/media/rV3vKOSyjZSaQ/giphy.gif)
## TODO
- [ ] Tests
