### PR TITLE
Manage meetings proposals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem 'redcarpet'
 gem "faker"
 
 gem 'rails-i18n'
+gem 'active_model_serializers'
 
 # React gems
 gem 'react-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    active_model_serializers (0.9.4)
+      activemodel (>= 3.2)
     activejob (4.2.5)
       activesupport (= 4.2.5)
       globalid (>= 0.3.0)
@@ -475,6 +477,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   acts-as-taggable-on
   acts_as_list
   acts_as_votable

--- a/app/assets/javascripts/components/meeting_proposals_autocomplete_input.es6.jsx
+++ b/app/assets/javascripts/components/meeting_proposals_autocomplete_input.es6.jsx
@@ -1,0 +1,85 @@
+class MeetingProposalsAutocompleteInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      proposals: []
+    };
+  }
+
+  componentDidMount() {
+    this.$searchInput = $(this.refs.searchInput);
+    this.$searchInput.on('keyup', (event) => { this.onInputChanged(event.currentTarget.value) });
+    this.$loading = $(this.refs.loading);
+    this.$noResults = $(this.refs.noResults);
+    this.$dropdown = $(this.refs.dropdown);
+
+    this.$loading.hide();
+    this.$noResults.hide();
+    this.$dropdown.hide();
+  }
+
+  componentWillUnmount() {
+    this.$searchInput.off('keyup');
+  }
+
+  render() {
+    return (
+      <div>
+        <input ref="searchInput" placeholder={ I18n.t("components.meeting_proposals_autocomplete_input.search") } />
+        <p ref="loading">{ I18n.t("components.meeting_proposals_autocomplete_input.loading") }</p>
+        <p ref="noResults">{ I18n.t("components.meeting_proposals_autocomplete_input.no_results") }</p>
+        <ul className="dropdown" ref="dropdown">
+          {
+            this.state.proposals.map((proposal) => {
+              return (
+                <li key={proposal.id}><a onClick={(event) => this.onClickProposal(proposal)}>{proposal.title}</a></li>
+              );
+            })
+          }
+        </ul>
+      </div>
+    );
+  }
+
+  onInputChanged (text) {
+    if (this.searchTimeoutId) {
+      clearTimeout(this.searchTimeoutId);
+    }
+
+    this.searchTimeoutId = setTimeout(() => {
+      this.search(text);
+    }, 300);
+  }
+
+  search(text) {
+    this.$noResults.hide();
+    if (text.length > 0) {
+      this.$loading.show();
+      this.$dropdown.hide();
+
+      $.ajax({
+        url: this.props.proposalsApiUrl,
+        method: 'GET',
+        data: {
+          search: text,
+          exclude_ids: this.props.excludeIds
+        }
+      }).then(({ proposals } ) => {
+        this.$loading.hide();
+        if (proposals.length > 0) {
+          this.$dropdown.show();
+          this.setState({ proposals })
+        } else {
+          this.$noResults.show();
+        }
+      });
+    }
+  }
+
+  onClickProposal(proposal) {
+    this.$searchInput.val('');
+    this.$searchInput.focus();
+    this.$dropdown.hide();
+    this.props.onAddProposal(proposal);
+  }
+}

--- a/app/assets/javascripts/components/meeting_proposals_autocomplete_input.es6.jsx
+++ b/app/assets/javascripts/components/meeting_proposals_autocomplete_input.es6.jsx
@@ -25,7 +25,10 @@ class MeetingProposalsAutocompleteInput extends React.Component {
   render() {
     return (
       <div>
-        <input ref="searchInput" placeholder={ I18n.t("components.meeting_proposals_autocomplete_input.search") } />
+        <input 
+          id="proposal_search_input" 
+          ref="searchInput" 
+          placeholder={ I18n.t("components.meeting_proposals_autocomplete_input.search") } />
         <p ref="loading">{ I18n.t("components.meeting_proposals_autocomplete_input.loading") }</p>
         <p ref="noResults">{ I18n.t("components.meeting_proposals_autocomplete_input.no_results") }</p>
         <ul className="dropdown" ref="dropdown">

--- a/app/assets/javascripts/components/meeting_proposals_selector.es6.jsx
+++ b/app/assets/javascripts/components/meeting_proposals_selector.es6.jsx
@@ -1,0 +1,39 @@
+class MeetingProposalsSelector extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      proposals: Immutable.Set(this.props.proposals)
+    };
+  }
+  render() {
+    return (
+      <div className="meeting_proposals_selector">
+        <input type="hidden" name="meeting[proposal_ids][]" value="" />
+        {
+          this.state.proposals.map((proposal) => {
+            return (
+              <input key={proposal.id} type="hidden" name="meeting[proposal_ids][]" value={proposal.id} />
+            )
+          })
+        }
+        <MeetingProposalsAutocompleteInput 
+          proposalsApiUrl={this.props.proposals_api_url}
+          excludeIds={this.state.proposals.map((proposal) => proposal.id).toArray()}
+          onAddProposal={(proposal) => this.addProposal(proposal)} />
+        <MeetingProposalsTable 
+          proposals={this.state.proposals} 
+          onRemoveProposal={(proposal) => this.removeProposal(proposal)} />
+      </div>
+    );
+  }
+
+  addProposal(proposal) {
+    let proposals = this.state.proposals.add(proposal);
+    this.setState({ proposals })
+  }
+
+  removeProposal(proposal) {
+    let proposals = this.state.proposals.delete(proposal);
+    this.setState({ proposals })
+  }
+}

--- a/app/assets/javascripts/components/meeting_proposals_table.es6.jsx
+++ b/app/assets/javascripts/components/meeting_proposals_table.es6.jsx
@@ -1,0 +1,30 @@
+class MeetingProposalsTable extends React.Component {
+  render() {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th>{I18n.t("components.meeting_proposals_table.title")}</th>
+            <th>{I18n.t("components.meeting_proposals_table.actions")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            this.props.proposals.map((proposal) => {
+              return (
+                <tr key={proposal.id}>
+                  <td>{proposal.title}</td>
+                  <td>
+                    <button onClick={(event) => this.props.onRemoveProposal(proposal) }>
+                      {I18n.t("components.meeting_proposals_table.remove")}
+                    </button>
+                  </td>
+                </tr>
+              )
+            })
+          }
+        </tbody>
+      </table>
+    );
+  }
+}

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1,3 +1,4 @@
 @import "components/proposal_category_picker";
 @import "components/google_maps_autocomplete_input";
 @import "components/meetings_directory";
+@import "components/meeting_proposals_selector";

--- a/app/assets/stylesheets/components/_meeting_proposals_selector.scss
+++ b/app/assets/stylesheets/components/_meeting_proposals_selector.scss
@@ -1,0 +1,28 @@
+.meeting_proposals_selector {
+  ul.dropdown {
+    margin: 0;
+    padding: 5px;
+    list-style: none;
+    height: 200px;
+    overflow: hidden;
+    overflow-y: scroll;
+    border: 1px solid $border;
+
+    li {
+      a {
+        color: $text;
+        display: block;
+      }
+
+      &:hover {
+        background: $background;
+
+        a {
+          font-weight: bold;
+          color: $font-bold;
+          text-decoration: none;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -1,0 +1,12 @@
+class Api::ProposalsController < ApplicationController
+  skip_authorization_check
+
+  def index
+    filter = ProposalFilter.new(params)
+    @proposals = filter.collection
+
+    respond_to do |format|
+      format.json { render json: @proposals }
+    end
+  end
+end

--- a/app/controllers/moderation/meetings_controller.rb
+++ b/app/controllers/moderation/meetings_controller.rb
@@ -45,7 +45,7 @@ class Moderation::MeetingsController < Moderation::BaseController
   private
 
   def meeting_params
-    params.require(:meeting).permit(:title, :description, :address, :address_longitude, :address_latitude, :address_details, :held_at, :start_at, :end_at)
+    params.require(:meeting).permit(:title, :description, :address, :address_longitude, :address_latitude, :address_details, :held_at, :start_at, :end_at, :proposal_ids => [])
   end
 
   def resource_model

--- a/app/helpers/meeting_proposals_selector_helper.rb
+++ b/app/helpers/meeting_proposals_selector_helper.rb
@@ -1,0 +1,9 @@
+module MeetingProposalsSelectorHelper
+  def meeting_proposals_selector(options = {})
+    react_component(
+      'MeetingProposalsSelector',
+      proposals_api_url: api_proposals_url(format: :json),
+      proposals: options[:proposals]
+    )
+  end
+end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -3,6 +3,7 @@ class Meeting < ActiveRecord::Base
   include SearchCache
 
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
+  has_and_belongs_to_many :proposals
 
   scope :upcoming, -> { where("held_at >= ?", Date.today) }
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -19,6 +19,7 @@ class Proposal < ActiveRecord::Base
 
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
   has_many :comments, as: :commentable
+  has_and_belongs_to_many :meetings
 
   validates :title, presence: true
   validates :summary, presence: true, length: { maximum: 350 }

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -1,0 +1,3 @@
+class ProposalSerializer < ActiveModel::Serializer
+  attributes :id, :title
+end

--- a/app/services/proposal_filter.rb
+++ b/app/services/proposal_filter.rb
@@ -5,7 +5,9 @@ class ProposalFilter
     @search_filter = params[:search] if params[:search].present?
     @tag_filter = params[:tag]
     @params = params[:filter]
+    @exclude_ids = params[:exclude_ids]
     @collection = Proposal.all
+    exclude
     filter_by_search
     filter_by_tag
     filter
@@ -13,6 +15,12 @@ class ProposalFilter
   end
 
   private
+
+  def exclude
+    if @exclude_ids.present?
+      @collection = @collection.where("id not in (?)", @exclude_ids)
+    end
+  end
 
   def filter_by_search
     if @search_filter.present?

--- a/app/views/moderation/meetings/_form.html.erb
+++ b/app/views/moderation/meetings/_form.html.erb
@@ -45,6 +45,11 @@
       <%= f.time_field :end_at, label: false %>
     </div>
 
+    <div class="small-12 column">
+      <label><%= t("meetings.form.meeting_proposal_ids")%></label>
+      <%= meeting_proposals_selector proposals: @meeting.proposals %>
+    </div>
+
     <div class="actions small-12 column">
       <%= f.submit(class: "button radius", value: t("meetings.#{action_name}.form.submit_button")) %>
     </div>

--- a/app/views/moderation/meetings/index.html.erb
+++ b/app/views/moderation/meetings/index.html.erb
@@ -27,6 +27,9 @@
         <span class="date"><%= meeting.start_at.to_s(:time) %> - <%= meeting.end_at.to_s(:time) %></span>
         <span class="bullet">&nbsp;&bull;&nbsp;</span>
         <%= meeting.author.username %>
+        <div class="right">
+          <%= link_to t("meetings.index.edit"), edit_moderation_meeting_path(meeting), class: 'button radius small' %>
+        </div>
         <br>
         <div>
           <%= meeting.description %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -213,9 +213,11 @@ ca:
       meeting_description: Descripció
       meeting_end_at: A quina hora acaba?
       meeting_held_at: Quan es realitzará?
+      meeting_proposal_ids: Quines propostes es discutiran?
       meeting_start_at: A quina hora comença?
       meeting_title: Títol
     index:
+      edit: Editar
       new: Crear trobada
       title: Trobades presencials
     new:

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -6,6 +6,14 @@ ca:
         label: Eix
       subcategory:
         label: Línia d'acció
+    meeting_proposals_autocomplete_input:
+      loading: Carregant...
+      no_results: No s'han trobat resultats.
+      search: Buscar
+    meeting_proposals_table:
+      actions: Accions
+      remove: Eliminar
+      title: Títol
     proposal_filter_option:
       city: Tota la ciutat
       district: Un districte

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -6,6 +6,14 @@ en:
         label: Axis
       subcategory:
         label: Action Line
+    meeting_proposals_autocomplete_input:
+      loading: Loading...
+      no_results: No results.
+      search: Search
+    meeting_proposals_table:
+      actions: Actions
+      remove: Delete
+      title: Title
     proposal_filter_option:
       city: Whole city
       district: A district

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -6,6 +6,14 @@ es:
         label: Eje
       subcategory:
         label: Línea de actuación
+    meeting_proposals_autocomplete_input:
+      loading: Cargando...
+      no_results: No se han encontrado resultados.
+      search: Buscar
+    meeting_proposals_table:
+      actions: Acciones
+      remove: Delete
+      title: Título
     proposal_filter_option:
       city: Toda la ciudad
       district: Un distrito

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,9 +213,11 @@ en:
       meeting_description: Description
       meeting_end_at: What time does it end?
       meeting_held_at: When it will take place?
+      meeting_proposal_ids: Which proposals are being discussed?
       meeting_start_at: What time does it start?
       meeting_title: Title
     index:
+      edit: Edit
       new: Create meeting
       title: Meetings
     new:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -213,9 +213,11 @@ es:
       meeting_description: Descripción
       meeting_end_at: "¿A que hora acaba?"
       meeting_held_at: "¿Cuándo se va a realizar?"
+      meeting_proposal_ids: "¿Qué propuestas se van a discutir?"
       meeting_start_at: "¿A que hora empieza?"
       meeting_title: Título
     index:
+      edit: Editar
       new: Crear encuentro
       title: Encuentros presenciales
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,10 @@ Rails.application.routes.draw do
   #     resources :products
   #   end
 
+  namespace :api do
+    resources :proposals, only: [:index]
+  end
+
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end

--- a/db/migrate/20160118092256_add_meetings_proposals_table.rb
+++ b/db/migrate/20160118092256_add_meetings_proposals_table.rb
@@ -1,0 +1,8 @@
+class AddMeetingsProposalsTable < ActiveRecord::Migration
+  def change
+    create_table :meetings_proposals do |t|
+      t.integer :meeting_id
+      t.integer :proposal_id
+    end
+  end
+end

--- a/spec/features/moderation/meetings_spec.rb
+++ b/spec/features/moderation/meetings_spec.rb
@@ -120,4 +120,23 @@ feature 'Moderate meetings' do
     expect(page).to have_content "A meeting about dogs"
     expect(page).to_not have_content "A meeting about cats"
   end
+
+  scenario 'Edit meetings proposals', :js do
+    admin = create(:administrator)
+    login_as(admin.user)
+
+    create(:proposal, title: "My proposal")
+    create(:meeting, title: "My meeting", author: create(:moderator).user)
+
+    visit moderation_meetings_path
+
+    click_link 'Edit'
+
+    fill_in 'proposal_search_input', with: "My proposal"
+    page.find('a', text: "My proposal").click
+
+    click_button "Update meeting"
+
+    expect(page).to have_content "Meeting updated successfully."
+  end
 end


### PR DESCRIPTION
# TODO
- [x] Tests
# What and Why

A meeting have many proposals to discuss. I have added a web component to help moderators adding/removing proposals from their meetings.
# QA

Visit de meetings moderation page and click the Edit button from one of them. At the bottom of the form you will see a search input. Enter `voluptas` and select one of the suggestions. Finally press the update button.

If you visit the edit page again you will see the proposals on the table.
# GIF Tax

![](https://media.giphy.com/media/F7enXW5ijlgC4/giphy.gif)
