### PR TITLE
Remove question field from proposals

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -21,7 +21,6 @@ class Proposal < ActiveRecord::Base
   has_many :comments, as: :commentable
 
   validates :title, presence: true
-  validates :question, presence: true
   validates :summary, presence: true, length: { maximum: 350 }
   validates :author, presence: true
   validates :responsible_name, presence: true
@@ -32,7 +31,7 @@ class Proposal < ActiveRecord::Base
   validates :description, length: { maximum: Proposal.description_max_length }
   validates :scope, inclusion: { in: %w(city district) }
   validates :district, inclusion: { in: DISTRICTS.map(&:last).map(&:to_i), allow_nil: true }
-  validates :question, length: { in: 10..Proposal.question_max_length }
+  validates :question, length: { in: 10..Proposal.question_max_length }, allow_blank: true
   validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length }
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create

--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -18,7 +18,6 @@
           <% if proposal.video_url.present? %>
             <p><%= text_with_links proposal.video_url %></p>
           <% end %>
-          <p><%= proposal.question %></p>
         </div>
       </td>
       <td>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -8,14 +8,6 @@
     </div>
 
     <div class="small-12 column">
-      <%= f.label :question, t("proposals.form.proposal_question") %>
-      <span class="note-marked">
-        <%= t("proposals.form.proposal_question_example_html") %>
-      </span>
-      <%= f.text_field :question, maxlength: Proposal.question_max_length, placeholder: t("proposals.form.proposal_question"), label: false %>
-    </div>
-
-    <div class="small-12 column">
       <%= f.label :summary, t("proposals.form.proposal_summary") %>
       <p class="note"><%= t("proposals.form.proposal_summary_note") %></p>
       <%= f.text_area :summary, rows: 4, maxlength: 350, label: false,

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -58,8 +58,6 @@
           </div>
         <% end %>
 
-        <h4><%= @proposal.question %></h4>
-
         <%= render 'shared/tags', taggable: @proposal %>
 
         <div class="js-moderator-proposal-actions margin">

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -129,6 +129,8 @@ ignore_unused:
   - 'proposals.index.select_order'
   - 'proposals.index.orders.*'
   - 'proposals.index.search_form.*'
+  - 'proposals.form.proposal_question'
+  - 'proposals.form.proposal_question_example_html'
   - 'notifications.index.comments_on*'
   - 'notifications.index.replies_to*'
   - 'helpers.page_entries_info.*' # kaminari

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -13,7 +13,6 @@ feature 'Admin proposals' do
 
     expect(page).to have_content(proposal.title)
     expect(page).to have_content(proposal.summary)
-    expect(page).to have_content(proposal.question)
     expect(page).to have_content(proposal.external_url)
     expect(page).to have_content(proposal.video_url)
   end

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -26,7 +26,6 @@ feature 'Proposals' do
       end
 
       fill_in 'proposal_title', with: 'Help refugees'
-      fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
       fill_in 'proposal_summary', with: 'In summary, what we want is...'
       fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_video_url', with: 'http://youtube.com'
@@ -41,7 +40,6 @@ feature 'Proposals' do
       expect(page).to have_content 'Proposal created successfully.'
 
       expect(page).to have_content 'Help refugees'
-      expect(page).to have_content '¿Would you like to give assistance to war refugees?'
       expect(page).to have_content 'In summary, what we want is...'
       expect(page).to have_content 'http://rescue.org/refugees'
       expect(page).to have_content 'http://youtube.com'

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -71,7 +71,6 @@ feature 'Proposals' do
 
     expect(page).to have_content proposal.title
     expect(page).to have_content proposal.code
-    expect(page).to have_content "Proposal question"
     expect(page).to have_content "http://external_documention.es"
     expect(page).to have_content proposal.author.name
     expect(page).to have_content I18n.l(proposal.created_at.to_date)
@@ -98,7 +97,6 @@ feature 'Proposals' do
     visit new_proposal_path
 
     fill_in 'proposal_title', with: 'Help refugees'
-    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     choose 'proposal_scope_district'
     select 'Ciutat Vella', from: 'proposal_district'
@@ -115,7 +113,6 @@ feature 'Proposals' do
 
     expect(page).to have_content 'Proposal created successfully.'
     expect(page).to have_content 'Help refugees'
-    expect(page).to have_content '¿Would you like to give assistance to war refugees?'
     expect(page).to have_content 'In summary, what we want is...'
     expect(page).to have_content 'http://rescue.org/refugees'
     expect(page).to have_content author.name
@@ -129,7 +126,6 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Help refugees'
-    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
@@ -153,7 +149,6 @@ feature 'Proposals' do
     expect(page).to_not have_selector('#proposal_responsible_name')
 
     fill_in 'proposal_title', with: 'Help refugees'
-    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_captcha', with: correct_captcha_text
@@ -171,7 +166,6 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: "Great title"
-    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
@@ -198,7 +192,6 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: ""
-    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'In summary, what we want is...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
@@ -233,7 +226,6 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Testing an attack'
-    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: '<p>This is alert("an attack");</p>'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
@@ -257,7 +249,6 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Testing auto link'
-    fill_in 'proposal_question', with: 'Should I stay or should I go?'
     fill_in 'proposal_summary', with: '<p>This is a link www.example.org</p>'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: correct_captcha_text
@@ -278,7 +269,6 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Testing auto link'
-    fill_in 'proposal_question', with: 'Should I stay or should I go?'
     fill_in 'proposal_summary', with: '<script>alert("hey")</script>http://example.org'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: correct_captcha_text
@@ -316,7 +306,6 @@ feature 'Proposals' do
       visit new_proposal_path
 
       fill_in 'proposal_title', with: 'A test with enough characters'
-      fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
       fill_in 'proposal_summary', with: 'In summary, what we want is...'
       fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
@@ -341,7 +330,6 @@ feature 'Proposals' do
       visit new_proposal_path
 
       fill_in 'proposal_title', with: 'A test of dangerous strings'
-      fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
       fill_in 'proposal_summary', with: 'In summary, what we want is...'
       fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
@@ -396,7 +384,6 @@ feature 'Proposals' do
     expect(current_path).to eq(edit_proposal_path(proposal))
 
     fill_in 'proposal_title', with: "End child poverty"
-    fill_in 'proposal_question', with: '¿Would you like to give assistance to war refugees?'
     fill_in 'proposal_summary', with: 'Basically...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -66,11 +66,6 @@ describe Proposal do
   end
 
   describe "#question" do
-    it "should not be valid without a question" do
-      proposal.question = nil
-      expect(proposal).to_not be_valid
-    end
-
     it "should not be valid when very short" do
       proposal.question = "abc"
       expect(proposal).to_not be_valid


### PR DESCRIPTION
# WHAT AND WHY

I have removed the `question` field from proposals. It was a bit confusing because they already have a `title` field.
# QA

Now it is possible to add a proposal without filling in the `question`.
# GIF TAX

![](https://media.giphy.com/media/cHeR6ROlY9snC/giphy.gif)
