### PR TITLE
Add oficial flag to proposals

### DIFF
--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -12,6 +12,14 @@ class ProposalFilters extends React.Component {
     return (
       <form>
         <ProposalFilterOptionGroup 
+          filterGroupName="source" 
+          filterGroupValue={this.state.filters.get('source')}
+          isExclusive={true}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
+          <ProposalFilterOption filterName="oficial" />
+          <ProposalFilterOption filterName="citizenship" />
+        </ProposalFilterOptionGroup>
+        <ProposalFilterOptionGroup 
           filterGroupName="scope" 
           filterGroupValue={this.state.filters.get('scope')}
           isExclusive={true}

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -793,6 +793,13 @@
       }
     }
   }
+
+  &.oficial {
+    .panel {
+      border: 5px solid;
+      border-color: $brand;
+    }
+  }
 }
 
 // 05. Featured

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -38,7 +38,13 @@ class ProposalsController < ApplicationController
   private
 
     def proposal_params
-      params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url, :responsible_name, :tag_list, :terms_of_service, :captcha, :captcha_key, :category_id, :subcategory_id, :scope, :district)
+      permitted_params = [:title, :question, :summary, :description, :external_url, :video_url, :responsible_name, :tag_list, :terms_of_service, :captcha, :captcha_key, :category_id, :subcategory_id, :scope, :district]
+
+      if current_user.administrator?
+        permitted_params << :oficial
+      end
+
+      params.require(:proposal).permit(permitted_params)
     end
 
     def resource_model

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -28,4 +28,7 @@ module ProposalsHelper
     end
   end
 
+  def proposal_class_names(proposal)
+    proposal.oficial? ? 'oficial' : ''
+  end
 end

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -63,6 +63,17 @@
       </div>
     <% end %>
 
+    <% if current_user.administrator? %>
+      <div class="small-12 column">
+        <%= f.label :oficial do %>
+          <%= f.check_box :oficial, label: false %>
+          <span class="checkbox">
+            <%= t("proposals.form.proposal_oficial") %>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+
     <div class="small-12 column">
       <% if @proposal.new_record? %>
         <%= f.label :terms_of_service do %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id(proposal) %>" class="proposal clear">
+<div id="<%= dom_id(proposal) %>" class="proposal clear <%= proposal_class_names proposal %>">
   <div class="panel">
     <div class="row">
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -136,8 +136,8 @@ ignore_unused:
   - 'notifications.index.replies_to*'
   - 'helpers.page_entries_info.*' # kaminari
   - 'views.pagination.*' # kaminari
-  - 'components.proposal_filter_option.{city,district}'
-  - 'components.proposal_filter_option_group.{category_id,district,scope,subcategory_id}'
+  - 'components.proposal_filter_option.{city,district,oficial,citizenship}'
+  - 'components.proposal_filter_option_group.{category_id,district,scope,subcategory_id, source}'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -271,6 +271,7 @@ ca:
       proposal_title: Títol de la proposta
       proposal_video_url: Enllaç a vídeo extern
       proposal_video_url_note: Pots afegir un enllaç a YouTube o Vimeo
+      proposal_oficial: La proposta és oficial
       tags_instructions: Etiqueta aquesta proposta. Pots triar entre les nostres propostes o introduir les que vulguis.
       tags_label: Temes
       tags_placeholder: Escriu les etiquetes que vulguis separades per una coma (',')

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -17,7 +17,10 @@ ca:
     proposal_filter_option:
       city: Tota la ciutat
       district: Un districte
+      oficial: Programa (Ajuntament)
+      citizenship: Ciutadania
     proposal_filter_option_group:
+      source: Origen
       category_id: Eix
       district: Districte
       scope: "Àmbit"

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -17,7 +17,10 @@ en:
     proposal_filter_option:
       city: Whole city
       district: A district
+      oficial: Program (Town Hall)
+      citizenship: Citizenship
     proposal_filter_option_group:
+      source: Source
       category_id: Axis
       district: District
       scope: Scope

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -17,7 +17,10 @@ es:
     proposal_filter_option:
       city: Toda la ciudad
       district: Un distrito
+      oficial: Programa (Ayuntamiento)
+      citizenship: Ciudadania
     proposal_filter_option_group:
+      source: Orígen
       category_id: Eje
       district: Districto
       scope: "Ámbito"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,6 +271,7 @@ en:
       proposal_title: Proposal title
       proposal_video_url: Link to external video
       proposal_video_url_note: You may add a link to YouTube or Vimeo
+      proposal_oficial: This proposal is oficial
       tags_instructions: Tag this proposal. You can choose from our tags or add your own.
       tags_label: Tags
       tags_placeholder: Enter the tags you would like to use, separated by commas (',')

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -271,6 +271,7 @@ es:
       proposal_title: Título de la propuesta
       proposal_video_url: Enlace a vídeo externo
       proposal_video_url_note: Puedes añadir un enlace a YouTube o Vimeo
+      proposal_oficial: La propuesta es oficial
       tags_instructions: Etiqueta esta propuesta. Puedes elegir entre nuestras sugerencias o introducir las que desees.
       tags_label: Temas
       tags_placeholder: Escribe las etiquetas que desees separadas por una coma (',')

--- a/db/migrate/20160119084845_add_oficial_to_proposals.rb
+++ b/db/migrate/20160119084845_add_oficial_to_proposals.rb
@@ -1,0 +1,5 @@
+class AddOficialToProposals < ActiveRecord::Migration
+  def change
+    add_column :proposals, :oficial, :boolean, default: false
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,6 +88,9 @@ if ENV["SEED"]
       district = nil
     end
 
+    # 25% of the proposals are oficial
+    oficial = [true, false, false, false].sample
+
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.sentence(3).truncate(60),
                                 question: Faker::Lorem.sentence(3),
@@ -101,6 +104,7 @@ if ENV["SEED"]
                                 category: subcategory.category,
                                 scope: scope,
                                 district: district,
+                                oficial: oficial,
                                 terms_of_service: "1")
     puts "    #{proposal.title}"
   end


### PR DESCRIPTION
# TODOs
- [x] Create `oficial` flag
- [x] Update seeds to include random oficial proposals
- [x] Add `.oficial` class to proposals markup for future usage
- [x] Add filters
- [x] Admin should be able to mark proposal as oficial
# What and Why

Some proposals must be marked as `oficial` and they will have a special treatment. In this feature I have included a flag and some proposals are being marked as oficial randomly for seeding purposes.
# QA

If you run `rake db:setup SEED=true` some of the proposals populated will be oficial. I have marked them with a red border for now. I included a new exclusive filter for oficial and not oficial proposals.
An admin should be able to create an oficial proposal direclty. I have provided a checkbox only visible for an admin in the proposals form.
# GIF Tax

![](https://media.giphy.com/media/pSpmpxFxFwDpC/giphy.gif)
