### PR TITLE
Add search form to moderation meetings

### DIFF
--- a/app/controllers/moderation/meetings_controller.rb
+++ b/app/controllers/moderation/meetings_controller.rb
@@ -6,7 +6,8 @@ class Moderation::MeetingsController < Moderation::BaseController
   load_and_authorize_resource
 
   def index
-    @resources = @resources.page(params[:page]).per(5)
+    @resources = @resources.search(params[:search]) if params[:search].present?
+    @resources = @resources.page(params[:page]).per(50)
     set_resources_instance
   end
 

--- a/app/models/concerns/search_cache.rb
+++ b/app/models/concerns/search_cache.rb
@@ -7,7 +7,7 @@ module SearchCache
 
   def calculate_tsvector
     ActiveRecord::Base.connection.execute("
-      UPDATE proposals SET tsv = (#{searchable_values_sql}) WHERE id = #{self.id}")
+      UPDATE #{self.class.table_name} SET tsv = (#{searchable_values_sql}) WHERE id = #{self.id}")
   end
 
   private

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,4 +1,7 @@
 class Meeting < ActiveRecord::Base
+  include PgSearch
+  include SearchCache
+
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
 
   scope :upcoming, -> { where("held_at >= ?", Date.today) }
@@ -10,4 +13,29 @@ class Meeting < ActiveRecord::Base
   validates :held_at, presence: true
   validates :start_at, presence: true
   validates :end_at, presence: true
+
+  pg_search_scope :pg_search, {
+    against: {
+      title:       'A',
+      description: 'B'
+    },
+    using: {
+      tsearch: { dictionary: "spanish", tsvector_column: 'tsv' }
+    },
+    ignoring: :accents,
+    ranked_by: '(:tsearch)'
+  }
+
+  def searchable_values
+    values = {
+      title       => 'A',
+      description => 'B'
+    }
+    values[author.username] = 'C'
+    values
+  end
+
+  def self.search(terms)
+    self.pg_search(terms)
+  end
 end

--- a/app/views/moderation/meetings/index.html.erb
+++ b/app/views/moderation/meetings/index.html.erb
@@ -1,7 +1,14 @@
 <h2><%= t("moderation.meetings.index.title") %></h2>
 
-<div class="right">
-  <%= link_to t("meetings.index.new"), new_moderation_meeting_path, class: 'button radius expand' %>
+<div class="row">
+  <div class="small-8 column">
+    <%= render "shared/search_form",
+               search_path: moderation_meetings_path(page: 1),
+               i18n_namespace: "moderation.meetings.index.search_form" %>
+  </div>
+  <div class="small-4 column">
+    <%= link_to t("meetings.index.new"), new_moderation_meeting_path, class: 'button radius expand' %>
+  </div>
 </div>
 
 <table class="clear">

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -131,6 +131,7 @@ ignore_unused:
   - 'proposals.index.search_form.*'
   - 'proposals.form.proposal_question'
   - 'proposals.form.proposal_question_example_html'
+  - 'moderation.meetings.index.search_form.*'
   - 'notifications.index.comments_on*'
   - 'notifications.index.replies_to*'
   - 'helpers.page_entries_info.*' # kaminari

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,26 +335,26 @@ en:
         submit_button: Save changes
   shared:
     advanced_search:
-      author_type: 'By author category'
-      author_type_blank: 'Select a category'
-      author_type_1: 'Public employee'
-      author_type_2: 'Municipal Organization'
-      author_type_3: 'General director'
-      author_type_4: 'City councillor'
-      author_type_5: 'Mayoress'
-      date: 'By date'
-      date_range_blank: 'Choose a date'
-      date_1: 'Last 24 hours'
-      date_2: 'Last week'
-      date_3: 'Last month'
-      date_4: 'Last year'
-      date_5: 'Customized'
-      from: 'From'
-      general: 'With the text'
-      general_placeholder: 'Write the text'
-      search: 'Filter'
-      title: 'Advanced search'
-      to: 'To'
+      author_type: By author category
+      author_type_1: Public employee
+      author_type_2: Municipal Organization
+      author_type_3: General director
+      author_type_4: City councillor
+      author_type_5: Mayoress
+      author_type_blank: Select a category
+      date: By date
+      date_1: Last 24 hours
+      date_2: Last week
+      date_3: Last month
+      date_4: Last year
+      date_5: Customized
+      date_range_blank: Choose a date
+      from: From
+      general: With the text
+      general_placeholder: Write the text
+      search: Filter
+      title: Advanced search
+      to: To
     author_info:
       author_deleted: User deleted
     check: Select

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -335,26 +335,26 @@ es:
         submit_button: Guardar cambios
   shared:
     advanced_search:
-      author_type: 'Por categoría de autor'
-      author_type_blank: 'Elige una categoría'
-      author_type_1: 'Empleado público'
-      author_type_2: 'Organización Municipal'
-      author_type_3: 'Director general'
-      author_type_4: 'Concejal'
-      author_type_5: 'Alcaldesa'
-      date: 'Por fecha'
-      date_range_blank: 'Elige una fecha'
-      date_1: 'Últimas 24 horas'
-      date_2: 'Última semana'
-      date_3: 'Último mes'
-      date_4: 'Último año'
-      date_5: 'Personalizada'
-      from: 'Desde'
-      general: 'Con el texto'
-      general_placeholder: 'Escribe el texto'
-      search: 'Filtrar'
-      title: 'Búsqueda avanzada'
-      to: 'Hasta'
+      author_type: Por categoría de autor
+      author_type_1: Empleado público
+      author_type_2: Organización Municipal
+      author_type_3: Director general
+      author_type_4: Concejal
+      author_type_5: Alcaldesa
+      author_type_blank: Elige una categoría
+      date: Por fecha
+      date_1: "Últimas 24 horas"
+      date_2: "Última semana"
+      date_3: "Último mes"
+      date_4: "Último año"
+      date_5: Personalizada
+      date_range_blank: Elige una fecha
+      from: Desde
+      general: Con el texto
+      general_placeholder: Escribe el texto
+      search: Filtrar
+      title: Búsqueda avanzada
+      to: Hasta
     author_info:
       author_deleted: Usuario eliminado
     check: Seleccionar

--- a/config/locales/moderation.ca.yml
+++ b/config/locales/moderation.ca.yml
@@ -46,6 +46,9 @@ ca:
       index:
         headers:
           meeting: Trobada presencial
+        search_form:
+          button: Cercar
+          placeholder: Cercar
         title: Trobades presencials
     menu:
       flagged_comments: Comentaris

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -46,6 +46,9 @@ en:
       index:
         headers:
           meeting: Meeting
+        search_form:
+          button: Search
+          placeholder: Search
         title: Meetings
     menu:
       flagged_comments: Comments

--- a/config/locales/moderation.es.yml
+++ b/config/locales/moderation.es.yml
@@ -46,6 +46,9 @@ es:
       index:
         headers:
           meeting: Encuentro presencial
+        search_form:
+          button: Buscar
+          placeholder: Buscar
         title: Encuentros presenciales
     menu:
       flagged_comments: Comentarios

--- a/db/migrate/20160119143154_add_tsvector_update_trigger_to_meetings.rb
+++ b/db/migrate/20160119143154_add_tsvector_update_trigger_to_meetings.rb
@@ -1,0 +1,13 @@
+class AddTsvectorUpdateTriggerToMeetings < ActiveRecord::Migration
+
+  def up
+    add_column :meetings, :tsv, :tsvector
+    add_index :meetings, :tsv, using: "gin"
+  end
+
+  def down
+    remove_index :meetings, :tsv
+    remove_column :meetings, :tsv
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -228,6 +228,14 @@ ActiveRecord::Schema.define(version: 20160119171941) do
     t.float    "address_latitude"
     t.float    "address_longitude"
     t.string   "address_details"
+    t.tsvector "tsv"
+  end
+
+  add_index "meetings", ["tsv"], name: "index_meetings_on_tsv", using: :gin
+
+  create_table "meetings_proposals", force: :cascade do |t|
+    t.integer "meeting_id"
+    t.integer "proposal_id"
   end
 
   create_table "moderators", force: :cascade do |t|
@@ -280,6 +288,7 @@ ActiveRecord::Schema.define(version: 20160119171941) do
     t.integer  "subcategory_id"
     t.string   "scope",                        default: "district"
     t.integer  "district"
+    t.boolean  "oficial",                      default: false
   end
 
   add_index "proposals", ["author_id", "hidden_at"], name: "index_proposals_on_author_id_and_hidden_at", using: :btree

--- a/spec/features/moderation/meetings_spec.rb
+++ b/spec/features/moderation/meetings_spec.rb
@@ -105,4 +105,19 @@ feature 'Moderate meetings' do
     end
   end
 
+  scenario 'Using the search filter' do 
+    moderator = create(:moderator)
+    login_as(moderator.user)
+
+    create(:meeting, title: "A meeting about dogs")
+    create(:meeting, title: "A meeting about cats")
+
+    visit moderation_meetings_path
+
+    fill_in 'search', with: "dogs"
+    click_button 'Search'
+
+    expect(page).to have_content "A meeting about dogs"
+    expect(page).to_not have_content "A meeting about cats"
+  end
 end


### PR DESCRIPTION
# TODOs
- [x] Add search form template to moderation meetings page
- [x] Create service to filter meetings using pg_search
- [x] Tests
# What and Why

I have included a search form in the moderation meetings page. I think it may be useful for filtering meetings by title or description.
# QA

Visit the meetings moderation page and enter a search. Click the search button and check the results.
# GIF Tax

![](https://media.giphy.com/media/NJbeypFZCHj2g/giphy.gif)
