### PR TITLE
Add close meeting form

### DIFF
--- a/app/controllers/moderation/meetings/close_controller.rb
+++ b/app/controllers/moderation/meetings/close_controller.rb
@@ -1,0 +1,29 @@
+class Moderation::Meetings::CloseController <  Moderation::BaseController
+  include ModerateActions
+
+  load_and_authorize_resource :meeting
+
+  def new
+  end
+
+  def create
+    resource.assign_attributes(strong_params)
+    resource.closed_at = Time.now
+    if resource.save
+      redirect_to moderation_meetings_url, notice: t('flash.actions.update.notice', resource_name: "#{resource_name.capitalize}")
+    else
+      set_resource_instance
+      render :edit
+    end
+  end
+
+  private
+
+  def meeting_params
+    params.require(:meeting).permit(:close_report, :meeting_proposals_attributes => [:id, :votes, :groups])
+  end
+
+  def resource_model
+    Meeting
+  end
+end

--- a/app/controllers/moderation/meetings_controller.rb
+++ b/app/controllers/moderation/meetings_controller.rb
@@ -1,11 +1,14 @@
 class Moderation::MeetingsController < Moderation::BaseController
   include ModerateActions
 
+  has_filters %w{pending closed all}, only: :index
+
   before_action :load_resources, only: [:index]
 
   load_and_authorize_resource
 
   def index
+    @resources = @resources.send(@current_filter)
     @resources = @resources.search(params[:search]) if params[:search].present?
     @resources = @resources.page(params[:page]).per(50)
     set_resources_instance

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,7 +1,7 @@
 module AdminHelper
 
   def side_menu
-    render "/#{namespace}/menu"
+    render "/#{top_level_namespace}/menu"
   end
 
   def official_level_options
@@ -13,6 +13,10 @@ module AdminHelper
   end
 
   private
+
+    def top_level_namespace
+      namespace.split(':').first
+    end
 
     def namespace
       controller.class.parent.name.downcase

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -3,8 +3,13 @@ class Meeting < ActiveRecord::Base
   include SearchCache
 
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
-  has_and_belongs_to_many :proposals
 
+  has_many :meeting_proposals
+  accepts_nested_attributes_for :meeting_proposals
+  has_many :proposals, through: :meeting_proposals
+
+  scope :pending, -> { where(closed_at: nil) } 
+  scope :closed, -> { where('closed_at is not ?', nil) } 
   scope :upcoming, -> { where("held_at >= ?", Date.today) }
 
   validates :author, presence: true

--- a/app/models/meeting_proposal.rb
+++ b/app/models/meeting_proposal.rb
@@ -1,0 +1,8 @@
+class MeetingProposal < ActiveRecord::Base
+  self.table_name = 'meetings_proposals'
+
+  belongs_to :meeting
+  belongs_to :proposal
+
+  delegate :title, to: :proposal
+end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -19,7 +19,8 @@ class Proposal < ActiveRecord::Base
 
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
   has_many :comments, as: :commentable
-  has_and_belongs_to_many :meetings
+  has_many :meeting_proposals
+  has_many :meetings, through: :meeting_proposals
 
   validates :title, presence: true
   validates :summary, presence: true, length: { maximum: 350 }

--- a/app/views/moderation/meetings/close/new.html.erb
+++ b/app/views/moderation/meetings/close/new.html.erb
@@ -1,0 +1,39 @@
+<div class="meeting-new row">
+  <div class="small-12 medium-9 column">
+    <%= form_for(@meeting, url: moderation_meeting_close_url(@meeting), method: :post) do |f| %>
+      <%= render 'shared/errors', resource: @meeting %>
+
+      <div class="row">
+        <div class="ckeditor small-12 column">
+          <%= f.label :close_report, t("meetings.close.form.close_report") %>
+          <%= f.cktext_area :close_report, ckeditor: { language: I18n.locale }, label: false %>
+        </div>
+
+        <div class="small-12 column">
+          <table>
+            <thead>
+              <tr>
+                <th><%= t("meetings.close.form.proposals.title") %></th>
+                <th><%= t("meetings.close.form.proposals.votes") %></th>
+                <th><%= t("meetings.close.form.proposals.groups") %></th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= f.fields_for :meeting_proposals do |ff| %>
+                <tr>
+                  <td><%= ff.object.title %></td>
+                  <td><%= ff.number_field :votes, label: false %></td>
+                  <td><%= ff.text_field :groups, label: false %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="actions small-12 column">
+          <%= f.submit(class: "button radius", value: t("meetings.close.#{action_name}.form.submit_button")) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/moderation/meetings/index.html.erb
+++ b/app/views/moderation/meetings/index.html.erb
@@ -1,5 +1,7 @@
 <h2><%= t("moderation.meetings.index.title") %></h2>
 
+<%= render 'shared/filter_subnav', i18n_namespace: "moderation.meetings.index" %>
+
 <div class="row">
   <div class="small-8 column">
     <%= render "shared/search_form",
@@ -29,6 +31,7 @@
         <%= meeting.author.username %>
         <div class="right">
           <%= link_to t("meetings.index.edit"), edit_moderation_meeting_path(meeting), class: 'button radius small' %>
+          <%= link_to t("meetings.index.close"), new_moderation_meeting_close_path(meeting), class: 'button radius small' %>
         </div>
         <br>
         <div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -122,6 +122,7 @@ ignore_unused:
   - 'moderation.proposals.index.order*'
   - 'moderation.debates.index.filter*'
   - 'moderation.debates.index.order*'
+  - 'moderation.meetings.index.filter*'
   - 'users.show.filters.*'
   - 'debates.index.select_order'
   - 'debates.index.orders.*'

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -31,8 +31,8 @@ ca:
     close: Tancar
     menu: Menú
   categories:
+    filter: Veure propostes
     title: Eixos
-    filter: "Veure propostes"
   comments:
     comment:
       admin: Administrador
@@ -204,6 +204,16 @@ ca:
       title: Com puc comentar aquest document?
   locale: Català
   meetings:
+    close:
+      form:
+        close_report: Acta
+        proposals:
+          groups: Col·lectius
+          title: Títol
+          votes: Suports
+      new:
+        form:
+          submit_button: Tancar trobada
     edit:
       form:
         submit_button: Actualitzar trobada
@@ -217,6 +227,7 @@ ca:
       meeting_start_at: A quina hora comença?
       meeting_title: Títol
     index:
+      close: Tancar
       edit: Editar
       new: Crear trobada
       title: Trobades presencials

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,8 +31,8 @@ en:
     close: Close
     menu: Menu
   categories:
+    filter: Show proposals
     title: Axis
-    filter: "Show proposals"
   comments:
     comment:
       admin: Administrator
@@ -204,6 +204,16 @@ en:
       title: How I can comment this document?
   locale: English
   meetings:
+    close:
+      form:
+        close_report: Report
+        proposals:
+          groups: Groups
+          title: Title
+          votes: Votes
+      new:
+        form:
+          submit_button: Close meeting
     edit:
       form:
         submit_button: Update meeting
@@ -217,6 +227,7 @@ en:
       meeting_start_at: What time does it start?
       meeting_title: Title
     index:
+      close: Close
       edit: Edit
       new: Create meeting
       title: Meetings

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -31,8 +31,8 @@ es:
     close: Cerrar
     menu: Menú
   categories:
+    filter: Ver propuestas
     title: Ejes
-    filter: "Ver propuestas"
   comments:
     comment:
       admin: Administrador
@@ -204,6 +204,16 @@ es:
       title: "¿Cómo puedo comentar este documento?"
   locale: Español
   meetings:
+    close:
+      form:
+        close_report: Acta
+        proposals:
+          groups: Colectivos
+          title: Título
+          votes: Apoyos
+      new:
+        form:
+          submit_button: Cerrar encuentro
     edit:
       form:
         submit_button: Actualizar encuentro
@@ -217,6 +227,7 @@ es:
       meeting_start_at: "¿A que hora empieza?"
       meeting_title: Título
     index:
+      close: Cerrar
       edit: Editar
       new: Crear encuentro
       title: Encuentros presenciales

--- a/config/locales/moderation.ca.yml
+++ b/config/locales/moderation.ca.yml
@@ -44,6 +44,10 @@ ca:
         title: Debats
     meetings:
       index:
+        filters:
+          all: Tots
+          closed: Tancats
+          pending: Pendents
         headers:
           meeting: Trobada presencial
         search_form:

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -44,6 +44,10 @@ en:
         title: Debates
     meetings:
       index:
+        filters:
+          all: All
+          closed: Closed
+          pending: Pending
         headers:
           meeting: Meeting
         search_form:

--- a/config/locales/moderation.es.yml
+++ b/config/locales/moderation.es.yml
@@ -44,6 +44,10 @@ es:
         title: Debates
     meetings:
       index:
+        filters:
+          all: Todos
+          closed: Cerrados
+          pending: Pendientes
         headers:
           meeting: Encuentro presencial
         search_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,7 +199,9 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :meetings, except: [:show, :destroy]
+    resources :meetings, except: [:show, :destroy] do
+      resource :close, controller: 'meetings/close', only: [:new, :create]
+    end
   end
 
   namespace :management do

--- a/db/migrate/20160120094613_add_close_fields_to_meetings.rb
+++ b/db/migrate/20160120094613_add_close_fields_to_meetings.rb
@@ -1,0 +1,6 @@
+class AddCloseFieldsToMeetings < ActiveRecord::Migration
+  def change
+    add_column :meetings, :close_report, :text
+    add_column :meetings, :closed_at, :datetime
+  end
+end

--- a/db/migrate/20160120103706_add_votes_and_groups_to_meetings_proposals.rb
+++ b/db/migrate/20160120103706_add_votes_and_groups_to_meetings_proposals.rb
@@ -1,0 +1,6 @@
+class AddVotesAndGroupsToMeetingsProposals < ActiveRecord::Migration
+  def change
+    add_column :meetings_proposals, :votes, :integer
+    add_column :meetings_proposals, :groups, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160119171941) do
+ActiveRecord::Schema.define(version: 20160120103706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -229,6 +229,8 @@ ActiveRecord::Schema.define(version: 20160119171941) do
     t.float    "address_longitude"
     t.string   "address_details"
     t.tsvector "tsv"
+    t.text     "close_report"
+    t.datetime "closed_at"
   end
 
   add_index "meetings", ["tsv"], name: "index_meetings_on_tsv", using: :gin
@@ -236,6 +238,8 @@ ActiveRecord::Schema.define(version: 20160119171941) do
   create_table "meetings_proposals", force: :cascade do |t|
     t.integer "meeting_id"
     t.integer "proposal_id"
+    t.integer "votes"
+    t.string  "groups"
   end
 
   create_table "moderators", force: :cascade do |t|

--- a/spec/features/moderation/meetings_spec.rb
+++ b/spec/features/moderation/meetings_spec.rb
@@ -139,4 +139,28 @@ feature 'Moderate meetings' do
 
     expect(page).to have_content "Meeting updated successfully."
   end
+
+  scenario 'Close a meeting', :js do 
+    moderator = create(:moderator)
+    login_as(moderator.user)
+
+    proposal_1 = create(:proposal, title: "A proposal to discuss #1")
+    proposal_2 = create(:proposal, title: "A proposal to discuss #2")
+    create(:meeting, title: "A finished meeting", proposals: [proposal_1, proposal_2])
+
+    visit moderation_meetings_path
+    click_link 'Close'
+
+    fill_in_ckeditor 'meeting_close_report', with: 'We discussed a few proposals and decided some things'
+
+    fill_in 'meeting_meeting_proposals_attributes_0_votes', with: 100
+    fill_in 'meeting_meeting_proposals_attributes_0_groups', with: 'A,B,C'
+    fill_in 'meeting_meeting_proposals_attributes_1_votes', with: 300
+    fill_in 'meeting_meeting_proposals_attributes_1_groups', with: 'D'
+
+    click_button "Close meeting"
+
+    expect(page).to have_content "Meeting updated successfully."
+    expect(page).to_not have_content "A finished meeting"
+  end
 end


### PR DESCRIPTION
# What and Why

A moderator should be able to close a meeting. I have provided a singleton resource for meetings and a different form. In that form a moderator must provide a `report` and fill some fields for related proposals.
When a meeting is closed it should not appear on the list but still can be filtered.
# QA

Navigate to `moderation/meetings#index` and edit a meeting. Add some proposals and save it. Then press the `Close` button and fill in the form.
The meeting should disappear from the list.
# GIF Tax

![](https://media.giphy.com/media/gVTylcWUpmmyc/giphy.gif)
# TODOs
- [x] Add close form to meetings
- [x] Filter closed meetings on moderation meetings page
- [x] Tests
