### PR TITLE
Use secret key as devise's key

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` on Rails 4+ applications as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  config.secret_key = '486ed5e25dcabac12a62c72a26e8057cfc2b822dd46c8b593a77aa95479bac481c3d70d5e5ee88a04aac3cf9b40e592575ca7674e248ff747f5afcdf3a320969'
+  # config.secret_key = Rails.application.secrets.secret_key_base
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,


### PR DESCRIPTION
This uses devise's default (which resorts to `secret_key_base`) as encryption key.
