### PR TITLE
Disable sendgrid tracking & unify mailers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,12 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: Rails.application.secrets.email
+  default from: "Decidim Barcelona <#{Rails.application.secrets.email}>"
   layout 'mailer'
+
+  private
+
+  def with_user(user, &block)
+    I18n.with_locale(user.locale) do
+      block.call
+    end
+  end
 end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -6,7 +6,7 @@ class DeviseMailer < Devise::Mailer
   protected
 
   def devise_mail(record, action, opts={})
-    I18n.with_locale record.locale do
+    with_user(record) do
       super(record, action, opts)
     end
   end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -32,12 +32,4 @@ class Mailer < ApplicationMailer
       mail(to: @recipient, subject: t('mailers.email_verification.subject'))
     end
   end
-
-  private
-
-  def with_user(user, &block)
-    I18n.with_locale(user.locale) do
-      block.call
-    end
-  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,16 @@ Rails.application.configure do
     }
   end
 
+  config.action_mailer.default_options = {
+    "X-SMTPAPI" => {
+      filters:  {
+        clicktrack: { settings: { enable: 0 } },
+        opentrack:  { settings: { enable: 0 } }
+      }
+    }.to_json
+  }
+
+
   if ENV["MEMCACHEDCLOUD_SERVERS"]
     credentials = [ENV["MEMCACHEDCLOUD_SERVERS"].split(','), { :username => ENV["MEMCACHEDCLOUD_USERNAME"], :password => ENV["MEMCACHEDCLOUD_PASSWORD"] }]
     config.cache_store = :dalli_store, *credentials

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -17,6 +17,8 @@ Devise.setup do |config|
   # Configure the class responsible to send e-mails.
   config.mailer = 'DeviseMailer'
 
+  config.parent_mailer = "ApplicationMailer"
+
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,7 +22,7 @@ default: &default
 
   rollbar_access_token: "<%= ENV['ROLLBAR_ACCESS_TOKEN'] %>"
   server_name: "<%= ENV['SERVER_NAME'] %>"
-  email: "<%= ENV['EMAIL'] || 'participa@bcn.cat' %>"
+  email: "<%= ENV['EMAIL'] || 'info@decidim.barcelona' %>"
 
   google_maps_api_key: "<%= ENV['GOOGLE_MAPS_API_KEY'] %>"
 


### PR DESCRIPTION
This disables sendgrid tracking and unifies the mailer into a single one.
