### PR TITLE
Add filters to meetings public page

### DIFF
--- a/app/assets/javascripts/components/category_filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/category_filter_option_group.es6.jsx
@@ -1,0 +1,19 @@
+class CategoryFilterOptionGroup extends React.Component {
+  render() {
+    return (
+      <FilterOptionGroup 
+        filterGroupName="category_id" 
+        filterGroupValue={this.props.filterGroupValue}
+        isExclusive={true}
+        onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.props.onChangeFilterGroup(filterGroupName, filterGroupValue) }>
+        {
+          this.props.categories.map(function (category) {
+            return <FilterOption key={category.id} filterName={category.id} filterLabel={category.name}>
+              <a href={`/categories#category_${category.id}`} target="_blank"><i className="fa fa-info-circle"></i></a>
+            </FilterOption>
+          })
+        }
+      </FilterOptionGroup>
+    )
+  }
+}

--- a/app/assets/javascripts/components/district_filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/district_filter_option_group.es6.jsx
@@ -2,6 +2,7 @@ class DistrictFilterOptionGroup extends React.Component {
   render() {
     return (
       <ProposalFilterOptionGroup 
+        condition={this.props.condition}
         filterGroupName="district" 
         filterGroupValue={this.props.filterGroupValue}
         onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.props.onChangeFilterGroup(filterGroupName, filterGroupValue) }>

--- a/app/assets/javascripts/components/district_filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/district_filter_option_group.es6.jsx
@@ -1,17 +1,20 @@
 class DistrictFilterOptionGroup extends React.Component {
   render() {
-    return (
-      <ProposalFilterOptionGroup 
-        condition={this.props.condition}
-        filterGroupName="district" 
-        filterGroupValue={this.props.filterGroupValue}
-        onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.props.onChangeFilterGroup(filterGroupName, filterGroupValue) }>
-        {
-          this.props.districts.map(function (district) {
-            return <ProposalFilterOption key={district[1]} filterName={district[1]} filterLabel={district[0]} />
-          })
-        }
-      </ProposalFilterOptionGroup>
-    )
+    if (this.props.scopeSelected && this.props.scopeSelected.indexOf("district") !== -1) {
+      return (
+        <FilterOptionGroup 
+          condition={this.props.condition}
+          filterGroupName="district" 
+          filterGroupValue={this.props.filterGroupValue}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.props.onChangeFilterGroup(filterGroupName, filterGroupValue) }>
+          {
+            this.props.districts.map(function (district) {
+              return <FilterOption key={district[1]} filterName={district[1]} filterLabel={district[0]} />
+            })
+          }
+        </FilterOptionGroup>
+      )
+    }
+    return null;
   }
 }

--- a/app/assets/javascripts/components/district_filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/district_filter_option_group.es6.jsx
@@ -1,0 +1,16 @@
+class DistrictFilterOptionGroup extends React.Component {
+  render() {
+    return (
+      <ProposalFilterOptionGroup 
+        filterGroupName="district" 
+        filterGroupValue={this.props.filterGroupValue}
+        onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.props.onChangeFilterGroup(filterGroupName, filterGroupValue) }>
+        {
+          this.props.districts.map(function (district) {
+            return <ProposalFilterOption key={district[1]} filterName={district[1]} filterLabel={district[0]} />
+          })
+        }
+      </ProposalFilterOptionGroup>
+    )
+  }
+}

--- a/app/assets/javascripts/components/filter_option.es6.jsx
+++ b/app/assets/javascripts/components/filter_option.es6.jsx
@@ -1,6 +1,6 @@
-class ProposalFilterOption extends React.Component {
+class FilterOption extends React.Component {
   render() {
-    let elemId = `proposal_filter_${this.props.filterGroupName}_${this.props.filterName}`;
+    let elemId = `filter_${this.props.filterGroupName}_${this.props.filterName}`;
 
     return (
       <div className="field">
@@ -11,7 +11,7 @@ class ProposalFilterOption extends React.Component {
           checked={this.props.checked}
           onChange={(event) => this.props.onChangeFilter(this.props.filterName, event.target.checked)}
         />
-        <label htmlFor={elemId}>{this.props.filterLabel || I18n.t(`components.proposal_filter_option.${this.props.filterName}`)}</label> {this.props.children}
+        <label htmlFor={elemId}>{this.props.filterLabel || I18n.t(`components.filter_option.${this.props.filterName}`)}</label> {this.props.children}
       </div>
     );
   }

--- a/app/assets/javascripts/components/filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/filter_option_group.es6.jsx
@@ -1,4 +1,4 @@
-class ProposalFilterOptionGroup extends React.Component {
+class FilterOptionGroup extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -17,17 +17,12 @@ class ProposalFilterOptionGroup extends React.Component {
   }
 
   render() {
-    let condition = !this.props.hasOwnProperty('condition') || this.props.condition;
-
-    if (condition) {
-      return (
-        <div>
-          <h3>{I18n.t(`components.proposal_filter_option_group.${this.props.filterGroupName}`)}</h3>
-          {this.renderChildren()}
-        </div>
-      );
-    }
-    return null;
+    return (
+      <div>
+        <h3>{I18n.t(`components.filter_option_group.${this.props.filterGroupName}`)}</h3>
+        {this.renderChildren()}
+      </div>
+    )
   }
 
   changeFilter(filterName, isChecked) {

--- a/app/assets/javascripts/components/meetings_directory.es6.jsx
+++ b/app/assets/javascripts/components/meetings_directory.es6.jsx
@@ -1,13 +1,17 @@
 class MeetingsDirectory extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   render () {
     return (
       <div className="meetings-directory">
-        <MeetingsMap meetings={this.props.meetings} />
-        <MeetingsFilter meetings={this.props.meetings} />
+        <div className="small-12 medium-3 column">
+          <aside className="sidebar" role="complementary">
+            <MeetingsFilter districts={this.props.districts} meetings={this.props.meetings} />
+          </aside>
+        </div>
+
+        <div id="proposals" className="small-12 medium-9 column">
+          <MeetingsMap meetings={this.props.meetings} />
+        </div>
+
         <MeetingsList />
       </div>
     );

--- a/app/assets/javascripts/components/meetings_directory.es6.jsx
+++ b/app/assets/javascripts/components/meetings_directory.es6.jsx
@@ -2,7 +2,8 @@ class MeetingsDirectory extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      meetings: this.props.meetings
+      meetings: this.props.meetings,
+      filter: this.props.filter
     };
   }
 
@@ -12,12 +13,13 @@ class MeetingsDirectory extends React.Component {
         <div className="small-12 medium-3 column">
           <aside className="sidebar" role="complementary">
             <MeetingsFilter 
-              filter={this.props.filter}
+              filterUrl={this.props.filterUrl}
+              filter={this.state.filter}
               districts={this.props.districts} 
               meetings={this.state.meetings} 
               categories={this.props.categories}
               subcategories={this.props.subcategories} 
-              onFilterResult={(meetings) => this.setState({ meetings })} />
+              onFilterResult={({ meetings, filter }) => this.setState({ meetings, filter })} />
           </aside>
         </div>
 

--- a/app/assets/javascripts/components/meetings_directory.es6.jsx
+++ b/app/assets/javascripts/components/meetings_directory.es6.jsx
@@ -4,7 +4,11 @@ class MeetingsDirectory extends React.Component {
       <div className="meetings-directory">
         <div className="small-12 medium-3 column">
           <aside className="sidebar" role="complementary">
-            <MeetingsFilter districts={this.props.districts} meetings={this.props.meetings} />
+            <MeetingsFilter 
+              districts={this.props.districts} 
+              meetings={this.props.meetings} 
+              categories={this.props.categories}
+              subcategories={this.props.subcategories} />
           </aside>
         </div>
 

--- a/app/assets/javascripts/components/meetings_directory.es6.jsx
+++ b/app/assets/javascripts/components/meetings_directory.es6.jsx
@@ -1,22 +1,35 @@
 class MeetingsDirectory extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      meetings: this.props.meetings
+    };
+  }
+
   render () {
     return (
       <div className="meetings-directory">
         <div className="small-12 medium-3 column">
           <aside className="sidebar" role="complementary">
             <MeetingsFilter 
+              filter={this.props.filter}
               districts={this.props.districts} 
-              meetings={this.props.meetings} 
+              meetings={this.state.meetings} 
               categories={this.props.categories}
-              subcategories={this.props.subcategories} />
+              subcategories={this.props.subcategories} 
+              onFilterResult={(meetings) => this.setState({ meetings })} />
           </aside>
         </div>
 
         <div id="proposals" className="small-12 medium-9 column">
-          <MeetingsMap meetings={this.props.meetings} />
+          <div className="row">
+            <MeetingsMap meetings={this.state.meetings} />
+          </div>
+          <div className="row">
+            <MeetingsList meetings={this.state.meetings} />
+          </div>
         </div>
 
-        <MeetingsList />
       </div>
     );
   }

--- a/app/assets/javascripts/components/meetings_filter.es6.jsx
+++ b/app/assets/javascripts/components/meetings_filter.es6.jsx
@@ -29,9 +29,18 @@ class MeetingsFilter extends React.Component {
           filterGroupValue={this.state.filters.get('scope')} 
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <DistrictFilterOptionGroup 
-          condition={this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1}
+          scopeSelected={this.state.filters.get('scope')}
           districts={this.props.districts} 
           filterGroupValue={this.state.filters.get('district')}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+        <CategoryFilterOptionGroup
+          categories={this.props.categories}
+          filterGroupValue={this.state.filters.get('category_id')} 
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+        <SubcategoryFilterOptionGroup
+          selectedCategory={this.state.filters.get('category_id')}
+          subcategories={this.props.subcategories}
+          filterGroupValue={this.state.filters.get('subcategory_id')}
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
       </form>
     )

--- a/app/assets/javascripts/components/meetings_filter.es6.jsx
+++ b/app/assets/javascripts/components/meetings_filter.es6.jsx
@@ -1,4 +1,16 @@
 class MeetingsFilter extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      /*search: this.props.filter.search_filter,*/
+      //tags: Immutable.Set(this.props.filter.tag_filter || []),
+      /*filters : Immutable.Map(this.props.filter.params || {})*/
+      search: '',
+      tags: Immutable.Set([]),
+      filters : Immutable.Map({})
+    };
+  }
+
   render() {
     return (
       <form>
@@ -13,9 +25,24 @@ class MeetingsFilter extends React.Component {
               onKeyDown={(event) => this.onKeyDown(event)} />
           </div>
         </div>
+        <ScopeFilterOptionGroup 
+          filterGroupValue={this.state.filters.get('scope')} 
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+        {(() => {
+          if(this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1) {
+            return (
+              <DistrictFilterOptionGroup 
+                districts={this.props.districts} 
+                filterGroupValue={this.state.filters.get('district')}
+                onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+            )
+          }
+        })()}
       </form>
     )
   }
+
+  //if(this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1) {
 
   filterByText(text) {
      let rex = new RegExp(text, "igm");
@@ -33,4 +60,17 @@ class MeetingsFilter extends React.Component {
       event.preventDefault();
     }
   }
+
+  changeFilterGroup(filterGroupName, filterGroupValue) {
+    let filters = this.state.filters.set(filterGroupName, filterGroupValue);
+    /*if (filterGroupName === 'category_id') {*/
+      //filters = this.checkFilterSubcategoryIds(filters);
+    /*}*/
+    if (filterGroupName === 'scope' && filterGroupValue !== 'district') {
+      filters = filters.delete('district');
+    }
+    //this.applyFilters(filters.toObject(), this.state.tags.toArray());
+    this.setState({ filters });
+  }
+
 }

--- a/app/assets/javascripts/components/meetings_filter.es6.jsx
+++ b/app/assets/javascripts/components/meetings_filter.es6.jsx
@@ -2,7 +2,7 @@ class MeetingsFilter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      search: this.props.filter.search_filter,
+      searchText: this.props.filter.search_filter,
       tags: Immutable.Set(this.props.filter.tag_filter || []),
       filters : Immutable.Map(this.props.filter.params || {})
     };
@@ -55,13 +55,19 @@ class MeetingsFilter extends React.Component {
     }
   }
 
-  filterByText(text) {
-    /* let rex = new RegExp(text, "igm");*/
-         //filteredMeetings = this.props.meetings.filter((meeting) => {
-           //return meeting.title.match(rex) || meeting.description.match(rex);
-         //});
+  filterByText(searchText) {
+    if (this.searchTimeoutId) {
+      clearTimeout(this.searchTimeoutId);
+    }
 
-    /*$(document).trigger('meetings:filtered', { meetings: filteredMeetings });*/
+    this.searchTimeoutId = setTimeout(() => {
+      this.applyFilters(
+        this.state.filters.toObject(), 
+        this.state.tags.toArray(),
+        searchText
+      );
+      this.setState({ searchText });
+    }, 300);
   }
 
   changeFilterGroup(filterGroupName, filterGroupValue) {
@@ -72,16 +78,24 @@ class MeetingsFilter extends React.Component {
     if (filterGroupName === 'scope' && filterGroupValue !== 'district') {
       filters = filters.delete('district');
     }
-    this.applyFilters(filters.toObject(), this.state.tags.toArray());
+    this.applyFilters(
+      filters.toObject(), 
+      this.state.tags.toArray(),
+      this.state.searchText
+    );
     this.setState({ filters });
   }
 
   setFilterTags(tags) {
-    this.applyFilters(this.state.filters.toObject(), tags.toArray());
+    this.applyFilters(
+      this.state.filters.toObject(), 
+      tags.toArray(), 
+      this.state.searchText
+    );
     this.setState({ tags });
   }
 
-  applyFilters(filters, tags) {
+  applyFilters(filters, tags, searchText) {
     let filterString = [], 
         data;
 
@@ -94,12 +108,13 @@ class MeetingsFilter extends React.Component {
     filterString = filterString.join(':');
 
     data = {
-      search: this.state.search,
+      search: searchText,
       tag: tags,
       filter: filterString 
     }
 
     this.replaceUrl(data);
+
     $.ajax(this.props.filterUrl, { data, dataType: "json" }).then((result) => {
       this.props.onFilterResult(result);
     });
@@ -110,8 +125,8 @@ class MeetingsFilter extends React.Component {
       let queryParams = [],
           url;
 
-      if (this.state.search) {
-        queryParams.push(`search=${this.state.search}`);
+      if (data.searchText) {
+        queryParams.push(`search=${data.searchText}`);
       }
 
       if (data.tag) {

--- a/app/assets/javascripts/components/meetings_filter.es6.jsx
+++ b/app/assets/javascripts/components/meetings_filter.es6.jsx
@@ -39,6 +39,10 @@ class MeetingsFilter extends React.Component {
           subcategories={this.props.subcategories}
           filterGroupValue={this.state.filters.get('subcategory_id')}
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+        <TagCloudFilter 
+          currentTags={this.state.tags} 
+          tagCloud={this.props.filter.tag_cloud} 
+          onSetFilterTags={(tags) => this.setFilterTags(tags)} />
       </form>
     )
   }
@@ -72,6 +76,11 @@ class MeetingsFilter extends React.Component {
     this.setState({ filters });
   }
 
+  setFilterTags(tags) {
+    this.applyFilters(this.state.filters.toObject(), tags.toArray());
+    this.setState({ tags });
+  }
+
   applyFilters(filters, tags) {
     let filterString = [], 
         data;
@@ -91,8 +100,8 @@ class MeetingsFilter extends React.Component {
     }
 
     this.replaceUrl(data);
-    $.ajax(this.props.filterUrl, { data, dataType: "script" }).then((result) => {
-      this.props.onFilterResult(JSON.parse(result));
+    $.ajax(this.props.filterUrl, { data, dataType: "json" }).then((result) => {
+      this.props.onFilterResult(result);
     });
   }
 

--- a/app/assets/javascripts/components/meetings_filter.es6.jsx
+++ b/app/assets/javascripts/components/meetings_filter.es6.jsx
@@ -28,21 +28,14 @@ class MeetingsFilter extends React.Component {
         <ScopeFilterOptionGroup 
           filterGroupValue={this.state.filters.get('scope')} 
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
-        {(() => {
-          if(this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1) {
-            return (
-              <DistrictFilterOptionGroup 
-                districts={this.props.districts} 
-                filterGroupValue={this.state.filters.get('district')}
-                onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
-            )
-          }
-        })()}
+        <DistrictFilterOptionGroup 
+          condition={this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1}
+          districts={this.props.districts} 
+          filterGroupValue={this.state.filters.get('district')}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
       </form>
     )
   }
-
-  //if(this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1) {
 
   filterByText(text) {
      let rex = new RegExp(text, "igm");

--- a/app/assets/javascripts/components/meetings_list.es6.jsx
+++ b/app/assets/javascripts/components/meetings_list.es6.jsx
@@ -2,43 +2,21 @@ class MeetingsList extends React.Component {
   constructor(props) {
     super(props);
 
-    this.meetings = [];
-
     this.state = {
-      meetings: [],
-      currentPage: 1,
-      totalPages: 1,
-      perPage: this.props.page,
+      currentPage: 1
     };
   }
 
-  componentDidMount() {
-    $(document).on('meetings:visible', (event, { visibleMeetings }) => {
-      this.setState({ 
-        meetings: visibleMeetings,
-        currentPage: 1,
-        totalPages: Math.ceil(visibleMeetings.length / this.props.perPage)
-      });
-    });
-  }
-
-  componentWillUnmount() {
-    $(document).off('meetings:visible');
-  }
-
-  componentWillUpdate(nextProps, nextState) {
-    let begin = (nextState.currentPage - 1) * this.props.perPage,
-        end = begin + this.props.perPage;
-    
-    this.meetings = nextState.meetings.slice(begin, end);
-  }
-
   render () {
+    let begin = (this.state.currentPage - 1) * this.props.perPage,
+        end = begin + this.props.perPage,
+        meetings = this.props.meetings.slice(begin, end);
+
     return (
       <div>
         <ul className="small-block-grid-2 medium-block-grid-3 large-block-grid-4">
           {
-            this.meetings.map((meeting) => {
+            meetings.map((meeting) => {
               return (
                 <li className="meeting" key={ `meeting_${meeting.id}` } >
                   <a href={meeting.url} className="meeting-title" >
@@ -57,7 +35,7 @@ class MeetingsList extends React.Component {
         <div className="row">
           <Pagination 
             currentPage={this.state.currentPage}
-            totalPages={this.state.totalPages}
+            totalPages={Math.ceil(this.props.meetings.length / this.props.perPage)}
             onSetCurrentPage={(page) => this.setCurrentPage(page)} />
         </div>
       </div>

--- a/app/assets/javascripts/components/meetings_list.es6.jsx
+++ b/app/assets/javascripts/components/meetings_list.es6.jsx
@@ -19,7 +19,7 @@ class MeetingsList extends React.Component {
             meetings.map((meeting) => {
               return (
                 <li className="meeting" key={ `meeting_${meeting.id}` } >
-                  <a href={meeting.url} className="meeting-title" >
+                  <a href={`/meetings/${meeting.id}`} className="meeting-title" >
                     { meeting.title }
                   </a>
                   <div className="tags">

--- a/app/assets/javascripts/components/meetings_map.es6.jsx
+++ b/app/assets/javascripts/components/meetings_map.es6.jsx
@@ -8,13 +8,11 @@ class MeetingsMap extends React.Component {
 
   componentDidMount() {
     $(document).on('gmaps:loaded', (event) => this.forceUpdate());
-    $(document).on('meetings:filtered', (event, { meetings } ) => this.filterMeetings(meetings));
     this.createGmapsIntegration();
   }
 
   componentWillUnmount() {
     $(document).off('gmaps:loaded');
-    $(document).on('meetings:filtered');
   }
 
   componentDidUpdate() {
@@ -23,7 +21,9 @@ class MeetingsMap extends React.Component {
 
   createGmapsIntegration () {
     if (window.google) {
-      this.createMap();
+      if (!this.map) {
+        this.createMap();
+      }
       this.createMarkers();
     }
   }
@@ -40,13 +40,21 @@ class MeetingsMap extends React.Component {
         streetViewControl: true
       }
     );
-
-    google.maps.event.addListener(this.map, 'bounds_changed', () => {
-      this.checkMarkersVisibility();
-    });
   }
 
   createMarkers() {
+    if (this.markerClusterer) {
+      this.markerClusterer.clearMarkers();
+    } else {
+      this.markerClusterer = new MarkerClusterer(this.map, [], {
+        gridSize: 30,
+        ignoreHidden: true,
+        enableRetinaIcons: true,
+        maxZoom: 13,
+        minimumClusterSize: 1
+      });
+    }
+
     let markers = this.props.meetings.map((meeting) => {
       let map = this.map,
           marker = new google.maps.Marker({
@@ -84,74 +92,7 @@ class MeetingsMap extends React.Component {
       return marker;
     });
 
-    this.markers = markers;
-    this.markerClusterer = new MarkerClusterer(this.map, this.markers, {
-      gridSize: 30,
-      ignoreHidden: true,
-      enableRetinaIcons: true,
-      maxZoom: 13,
-      minimumClusterSize: 1
-    });
-  }
-
-  checkMarkersVisibility () {
-    let bounds = this.map.getBounds(),
-        visibleMeetings = [];
-
-    this.markers.forEach((marker) => {
-      if (marker.visible && bounds.contains(marker.getPosition())) {
-        visibleMeetings.push(marker._meeting);
-      }
-    });
-
-    $(document).trigger('meetings:visible', { visibleMeetings });
-  }
-
-  centerMapOnMeeting (meeting, marker) {
-    this.map.setCenter({
-      lat: meeting.address_latitude,
-      lng: meeting.address_longitude
-    });
-    this.map.setZoom(16);
-    if (!marker) {
-      marker = this.findMarkerByMeeting(meeting);
-    }
-  }
-
-  openMarkerWindow (marker) {
-    if (marker) {
-      this.closeCurrentWindow();
-      marker._infoWindow.open(this.map, marker);
-      this.currentInfoWindow = marker._infoWindow;
-    }
-  }
-
-  closeCurrentWindow () {
-    if (this.currentInfoWindow) {
-      this.currentInfoWindow.close();
-    }
-  }
-
-  findMarkerByMeeting (meeting) {
-    let markers = this.markers.filter((marker) => {
-      return marker._meeting.id === meeting.id;
-    });
-
-    if (markers.length > 0) {
-      return markers[0];
-    }
-  }
-
-  filterMeetings(meetings) {
-    meetingIds = meetings.map((meeting) => meeting.id);
-
-    this.markers.forEach((marker) => {
-      marker.setVisible(meetingIds.indexOf(marker._meeting.id) !== -1);
-    });
-
-    this.markerClusterer.repaint();
-
-    $(document).trigger('meetings:visible', { visibleMeetings: meetings });
+    this.markerClusterer.addMarkers(markers);
   }
 
   render () {

--- a/app/assets/javascripts/components/proposal_filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filter_option_group.es6.jsx
@@ -17,12 +17,17 @@ class ProposalFilterOptionGroup extends React.Component {
   }
 
   render() {
-    return (
-      <div>
-        <h3>{I18n.t(`components.proposal_filter_option_group.${this.props.filterGroupName}`)}</h3>
-        {this.renderChildren()}
-      </div>
-    );
+    let condition = !this.props.hasOwnProperty('condition') || this.props.condition;
+
+    if (condition) {
+      return (
+        <div>
+          <h3>{I18n.t(`components.proposal_filter_option_group.${this.props.filterGroupName}`)}</h3>
+          {this.renderChildren()}
+        </div>
+      );
+    }
+    return null;
   }
 
   changeFilter(filterName, isChecked) {

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -19,27 +19,16 @@ class ProposalFilters extends React.Component {
           <ProposalFilterOption filterName="official" />
           <ProposalFilterOption filterName="citizenship" />
         </ProposalFilterOptionGroup>
-        <ProposalFilterOptionGroup 
-          filterGroupName="scope" 
-          filterGroupValue={this.state.filters.get('scope')}
-          isExclusive={true}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
-          <ProposalFilterOption filterName="city" />
-          <ProposalFilterOption filterName="district" />
-        </ProposalFilterOptionGroup>
+        <ScopeFilterOptionGroup 
+          filterGroupValue={this.state.filters.get('scope')} 
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
         {(() => {
           if(this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1) {
             return (
-              <ProposalFilterOptionGroup 
-                filterGroupName="district" 
+              <DistrictFilterOptionGroup 
+                districts={this.props.districts} 
                 filterGroupValue={this.state.filters.get('district')}
-                onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
-                {
-                  this.props.districts.map(function (district) {
-                    return <ProposalFilterOption key={district[1]} filterName={district[1]} filterLabel={district[0]} />
-                  })
-                }
-              </ProposalFilterOptionGroup>
+                onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
             )
           }
         })()}

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -11,48 +11,31 @@ class ProposalFilters extends React.Component {
   render() {
     return (
       <form>
-        <ProposalFilterOptionGroup 
+        <FilterOptionGroup 
           filterGroupName="source" 
           filterGroupValue={this.state.filters.get('source')}
           isExclusive={true}
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
-          <ProposalFilterOption filterName="official" />
-          <ProposalFilterOption filterName="citizenship" />
-        </ProposalFilterOptionGroup>
+          <FilterOption filterName="official" />
+          <FilterOption filterName="citizenship" />
+        </FilterOptionGroup>
         <ScopeFilterOptionGroup 
           filterGroupValue={this.state.filters.get('scope')} 
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <DistrictFilterOptionGroup 
-          condition={this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1}
+          scopeSelected={this.state.filters.get('scope')}
           districts={this.props.districts} 
           filterGroupValue={this.state.filters.get('district')}
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
-        <ProposalFilterOptionGroup 
-          filterGroupName="category_id" 
-          filterGroupValue={this.state.filters.get('category_id')}
-          isExclusive={true}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
-          {
-            this.props.categories.map(function (category) {
-              return <ProposalFilterOption key={category.id} filterName={category.id} filterLabel={category.name}>
-                <a href={`/categories#category_${category.id}`} target="_blank"><i className="fa fa-info-circle"></i></a>
-              </ProposalFilterOption>
-            })
-          }
-        </ProposalFilterOptionGroup>
-        <ProposalFilterOptionGroup 
-          condition={this.state.filters.get('category_id') && this.state.filters.get('category_id').length > 0}
-          filterGroupName="subcategory_id" 
+        <CategoryFilterOptionGroup
+          categories={this.props.categories}
+          filterGroupValue={this.state.filters.get('category_id')} 
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+        <SubcategoryFilterOptionGroup
+          selectedCategory={this.state.filters.get('category_id')}
+          subcategories={this.props.subcategories}
           filterGroupValue={this.state.filters.get('subcategory_id')}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
-          {
-            this.filteredSubCategories(this.state.filters).map(function (subcategory) {
-              return <ProposalFilterOption key={subcategory.id} filterName={subcategory.id} filterLabel={subcategory.name}>
-                <a href={`/categories#subcategory_${subcategory.id}`} target="_blank"><i className="fa fa-info-circle"></i></a>
-              </ProposalFilterOption>
-            })
-          }
-        </ProposalFilterOptionGroup>
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <ProposalFilterTagCloud 
           currentTags={this.state.tags} 
           tagCloud={this.props.filter.tag_cloud} 
@@ -61,37 +44,16 @@ class ProposalFilters extends React.Component {
     );
   }
 
-  filteredSubCategories(filters) {
-    return this.props.subcategories.filter((subcategory) => this.checkCategoryFiltered(filters, subcategory));
-  }
-
-  checkCategoryFiltered(filters, subcategory) {
-    return filters.get('category_id') && filters.get('category_id').indexOf(subcategory.categoryId) !== -1;
-  }
-
   changeFilterGroup(filterGroupName, filterGroupValue) {
     let filters = this.state.filters.set(filterGroupName, filterGroupValue);
     if (filterGroupName === 'category_id') {
-      filters = this.checkFilterSubcategoryIds(filters);
+      filters = filters.delete('subcategory_id')
     }
     if (filterGroupName === 'scope' && filterGroupValue !== 'district') {
       filters = filters.delete('district');
     }
     this.applyFilters(filters.toObject(), this.state.tags.toArray());
     this.setState({ filters });
-  }
-
-  checkFilterSubcategoryIds(filters) {
-    let filterCategoryIds = filters.get('category_id'),
-        filterSubCategoryIds = filters.get('subcategory_id'),
-        allowedSubcategories = this.filteredSubCategories(filters).map((subcategory) => subcategory.id);
-
-    if (filterSubCategoryIds) {
-      filterSubCategoryIds = filterSubCategoryIds.filter((subcategory_id) => allowedSubcategories.indexOf(subcategory_id) !== -1);
-      return filters.set('subcategory_id', filterSubCategoryIds);
-    }
-
-    return filters;
   }
 
   setFilterTags(tags) {

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -22,16 +22,11 @@ class ProposalFilters extends React.Component {
         <ScopeFilterOptionGroup 
           filterGroupValue={this.state.filters.get('scope')} 
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
-        {(() => {
-          if(this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1) {
-            return (
-              <DistrictFilterOptionGroup 
-                districts={this.props.districts} 
-                filterGroupValue={this.state.filters.get('district')}
-                onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
-            )
-          }
-        })()}
+        <DistrictFilterOptionGroup 
+          condition={this.state.filters.get('scope') && this.state.filters.get('scope').indexOf("district") !== -1}
+          districts={this.props.districts} 
+          filterGroupValue={this.state.filters.get('district')}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <ProposalFilterOptionGroup 
           filterGroupName="category_id" 
           filterGroupValue={this.state.filters.get('category_id')}
@@ -45,24 +40,19 @@ class ProposalFilters extends React.Component {
             })
           }
         </ProposalFilterOptionGroup>
-        {(() => {
-          if(this.state.filters.get('category_id') && this.state.filters.get('category_id').length > 0) {
-            return (
-              <ProposalFilterOptionGroup 
-                filterGroupName="subcategory_id" 
-                filterGroupValue={this.state.filters.get('subcategory_id')}
-                onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
-                {
-                  this.filteredSubCategories(this.state.filters).map(function (subcategory) {
-                    return <ProposalFilterOption key={subcategory.id} filterName={subcategory.id} filterLabel={subcategory.name}>
-                      <a href={`/categories#subcategory_${subcategory.id}`} target="_blank"><i className="fa fa-info-circle"></i></a>
-                    </ProposalFilterOption>
-                  })
-                }
-              </ProposalFilterOptionGroup>
-            )
+        <ProposalFilterOptionGroup 
+          condition={this.state.filters.get('category_id') && this.state.filters.get('category_id').length > 0}
+          filterGroupName="subcategory_id" 
+          filterGroupValue={this.state.filters.get('subcategory_id')}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
+          {
+            this.filteredSubCategories(this.state.filters).map(function (subcategory) {
+              return <ProposalFilterOption key={subcategory.id} filterName={subcategory.id} filterLabel={subcategory.name}>
+                <a href={`/categories#subcategory_${subcategory.id}`} target="_blank"><i className="fa fa-info-circle"></i></a>
+              </ProposalFilterOption>
+            })
           }
-        }())}
+        </ProposalFilterOptionGroup>
         <ProposalFilterTagCloud 
           currentTags={this.state.tags} 
           tagCloud={this.props.filter.tag_cloud} 

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -36,7 +36,7 @@ class ProposalFilters extends React.Component {
           subcategories={this.props.subcategories}
           filterGroupValue={this.state.filters.get('subcategory_id')}
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
-        <ProposalFilterTagCloud 
+        <TagCloudFilter 
           currentTags={this.state.tags} 
           tagCloud={this.props.filter.tag_cloud} 
           onSetFilterTags={(tags) => this.setFilterTags(tags)} />

--- a/app/assets/javascripts/components/scope_filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/scope_filter_option_group.es6.jsx
@@ -1,14 +1,14 @@
 class ScopeFilterOptionGroup extends React.Component {
   render() {
     return (
-        <ProposalFilterOptionGroup 
+        <FilterOptionGroup 
           filterGroupName="scope" 
           filterGroupValue={this.props.filterGroupValue}
           isExclusive={true}
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.props.onChangeFilterGroup(filterGroupName, filterGroupValue) }>
-          <ProposalFilterOption filterName="city" />
-          <ProposalFilterOption filterName="district" />
-        </ProposalFilterOptionGroup>
+          <FilterOption filterName="city" />
+          <FilterOption filterName="district" />
+        </FilterOptionGroup>
     )
   }
 }

--- a/app/assets/javascripts/components/scope_filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/scope_filter_option_group.es6.jsx
@@ -1,0 +1,14 @@
+class ScopeFilterOptionGroup extends React.Component {
+  render() {
+    return (
+        <ProposalFilterOptionGroup 
+          filterGroupName="scope" 
+          filterGroupValue={this.props.filterGroupValue}
+          isExclusive={true}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.props.onChangeFilterGroup(filterGroupName, filterGroupValue) }>
+          <ProposalFilterOption filterName="city" />
+          <ProposalFilterOption filterName="district" />
+        </ProposalFilterOptionGroup>
+    )
+  }
+}

--- a/app/assets/javascripts/components/subcategory_filter_option_group.es6.jsx
+++ b/app/assets/javascripts/components/subcategory_filter_option_group.es6.jsx
@@ -1,0 +1,24 @@
+class SubcategoryFilterOptionGroup extends React.Component {
+  render() {
+    if (this.props.selectedCategory && this.props.selectedCategory.length > 0) {
+      let subcategories = this.props.subcategories.filter((subcategory) => this.props.selectedCategory.indexOf(subcategory.categoryId) !== -1);
+
+      return (
+        <FilterOptionGroup 
+          filterGroupName="subcategory_id" 
+          filterGroupValue={this.props.filterGroupValue}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.props.onChangeFilterGroup(filterGroupName, filterGroupValue) }>
+          {
+            subcategories.map(function (subcategory) {
+              return <FilterOption key={subcategory.id} filterName={subcategory.id} filterLabel={subcategory.name}>
+                <a href={`/categories#subcategory_${subcategory.id}`} target="_blank"><i className="fa fa-info-circle"></i></a>
+              </FilterOption>
+            })
+          }
+        </FilterOptionGroup>
+      )
+    }
+    return null;
+  }
+}
+//subcategories={this.filteredSubCategories(this.state.filters)}

--- a/app/assets/javascripts/components/tag_cloud_filter.es6.jsx
+++ b/app/assets/javascripts/components/tag_cloud_filter.es6.jsx
@@ -1,4 +1,4 @@
-class ProposalFilterTagCloud extends React.Component {
+class TagCloudFilter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -13,6 +13,10 @@ class ProposalFilterTagCloud extends React.Component {
 
   componentWillUnmount() {
     $(document).off('tags:reload');
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ tagCloud: nextProps.tagCloud });
   }
 
   reloadTagCloud(event, tagCloud) {

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -2,7 +2,7 @@ class Api::ProposalsController < ApplicationController
   skip_authorization_check
 
   def index
-    filter = ResourceFilter.new(Proposal, params)
+    filter = ResourceFilter.new(Proposal.all, params)
     @proposals = filter.collection
 
     respond_to do |format|

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -2,7 +2,7 @@ class Api::ProposalsController < ApplicationController
   skip_authorization_check
 
   def index
-    filter = ProposalFilter.new(params)
+    filter = ResourceFilter.new(Proposal, params)
     @proposals = filter.collection
 
     respond_to do |format|

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -1,14 +1,19 @@
 class MeetingsController < ApplicationController
   load_and_authorize_resource
-  respond_to :html, :js
+  respond_to :html, :json
 
   def index
-    @filter = ResourceFilter.new(Meeting, params)
-    @meetings = @filter.collection.upcoming
+    @filter = ResourceFilter.new(Meeting.upcoming, params)
+    @meetings = @filter.collection
 
     respond_to do |format|
       format.html
-      format.js { render json: @meetings.to_json }
+      format.json do 
+        render json: {
+          meetings: @meetings,
+          filter: @filter
+        }
+      end
     end
   end
 

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -1,9 +1,15 @@
 class MeetingsController < ApplicationController
   load_and_authorize_resource
-  respond_to :html
+  respond_to :html, :js
 
   def index
-    @meetings = Meeting.upcoming
+    @filter = ResourceFilter.new(Meeting, params)
+    @meetings = @filter.collection.upcoming
+
+    respond_to do |format|
+      format.html
+      format.js { render json: @meetings.to_json }
+    end
   end
 
   def show

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -12,7 +12,7 @@ class ProposalsController < ApplicationController
   respond_to :html, :js
 
   def index
-    @filter = ProposalFilter.new(params)
+    @filter = ResourceFilter.new(Proposal, params)
     @proposals = @filter.collection
 
     @featured_proposals = @proposals.sort_by_confidence_score.limit(3) if (@filter.search_filter.blank? && @filter.tag_filter.blank?)

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -12,7 +12,7 @@ class ProposalsController < ApplicationController
   respond_to :html, :js
 
   def index
-    @filter = ResourceFilter.new(Proposal, params)
+    @filter = ResourceFilter.new(Proposal.all, params)
     @proposals = @filter.collection
 
     @featured_proposals = @proposals.sort_by_confidence_score.limit(3) if (@filter.search_filter.blank? && @filter.tag_filter.blank?)

--- a/app/helpers/meetings_directory_helper.rb
+++ b/app/helpers/meetings_directory_helper.rb
@@ -1,6 +1,14 @@
 module MeetingsDirectoryHelper
   def meetings_directory(options = {})
-    meetings = options[:meetings].map do |meeting|
+    react_component(
+      'MeetingsDirectory', 
+      meetings: serialized_meetings(options[:meetings]),
+      districts: Proposal::DISTRICTS
+    )
+  end
+
+  def serialized_meetings(meetings)
+    meetings.map do |meeting|
       {
         id: meeting.id,
         title: meeting.title,
@@ -14,6 +22,5 @@ module MeetingsDirectoryHelper
         url: meeting_url(meeting)
       }
     end
-    react_component 'MeetingsDirectory', meetings: meetings
   end
 end

--- a/app/helpers/meetings_directory_helper.rb
+++ b/app/helpers/meetings_directory_helper.rb
@@ -22,8 +22,7 @@ module MeetingsDirectoryHelper
         address_longitude: meeting.address_longitude,
         held_at: l(meeting.held_at),
         start_at: l(meeting.start_at),
-        end_at: l(meeting.end_at),
-        url: meeting_url(meeting)
+        end_at: l(meeting.end_at)
       }
     end
   end

--- a/app/helpers/meetings_directory_helper.rb
+++ b/app/helpers/meetings_directory_helper.rb
@@ -2,8 +2,11 @@ module MeetingsDirectoryHelper
   def meetings_directory(options = {})
     react_component(
       'MeetingsDirectory', 
+      filter: options[:filter],
       meetings: serialized_meetings(options[:meetings]),
-      districts: Proposal::DISTRICTS
+      districts: Proposal::DISTRICTS,
+      categories: serialized_categories,
+      subcategories: serialized_subcategories
     )
   end
 

--- a/app/helpers/meetings_directory_helper.rb
+++ b/app/helpers/meetings_directory_helper.rb
@@ -3,6 +3,7 @@ module MeetingsDirectoryHelper
     react_component(
       'MeetingsDirectory', 
       filter: options[:filter],
+      filterUrl: meetings_url,
       meetings: serialized_meetings(options[:meetings]),
       districts: Proposal::DISTRICTS,
       categories: serialized_categories,

--- a/app/services/resource_filter.rb
+++ b/app/services/resource_filter.rb
@@ -2,8 +2,8 @@ class ResourceFilter
   IGNORE_FILTER_PARAMS = ["source"]
   attr_reader :collection, :tag_cloud, :search_filter, :tag_filter, :params
 
-  def initialize(resource, params={})
-    @collection = resource.all
+  def initialize(resources, params={})
+    @collection = resources
     @params = params[:filter]
     @exclude_ids = params[:exclude_ids]
     @search_filter = params[:search] if params[:search].present?
@@ -13,7 +13,7 @@ class ResourceFilter
     filter_by_search
     filter_by_tag
     filter
-    @tag_cloud = @collection.tag_counts.order("#{resource.table_name}_count": :desc, name: :asc).limit(20)
+    @tag_cloud = @collection.tag_counts.order("#{resources.table_name}_count": :desc, name: :asc).limit(20)
   end
 
   private

--- a/app/services/resource_filter.rb
+++ b/app/services/resource_filter.rb
@@ -1,9 +1,9 @@
-class ProposalFilter
+class ResourceFilter
   IGNORE_FILTER_PARAMS = ["source"]
   attr_reader :collection, :tag_cloud, :search_filter, :tag_filter, :params
 
-  def initialize(params={})
-    @collection = Proposal.all
+  def initialize(resource, params={})
+    @collection = resource.all
     @params = params[:filter]
     @exclude_ids = params[:exclude_ids]
     @search_filter = params[:search] if params[:search].present?
@@ -13,7 +13,7 @@ class ProposalFilter
     filter_by_search
     filter_by_tag
     filter
-    @tag_cloud = @collection.tag_counts.order("proposals_count": :desc, name: :asc).limit(20)
+    @tag_cloud = @collection.tag_counts.order("#{resource.table_name}_count": :desc, name: :asc).limit(20)
   end
 
   private

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -3,7 +3,7 @@
 <section role="main">
   <div class="wrap row">
     <div class="small-12 columns">
-      <%= meetings_directory meetings: @meetings %>
+      <%= meetings_directory meetings: @meetings, filter: @filter %>
     </div>
   </div>
 </section>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -139,8 +139,8 @@ ignore_unused:
   - 'notifications.index.replies_to*'
   - 'helpers.page_entries_info.*' # kaminari
   - 'views.pagination.*' # kaminari
-  - 'components.proposal_filter_option.{city,district,official,citizenship}'
-  - 'components.proposal_filter_option_group.{category_id,district,scope,subcategory_id, source}'
+  - 'components.filter_option.{city,district,official,citizenship}'
+  - 'components.filter_option_group.{category_id,district,scope,subcategory_id, source}'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -14,12 +14,12 @@ ca:
       actions: Accions
       remove: Eliminar
       title: Títol
-    proposal_filter_option:
+    filter_option:
       citizenship: Ciutadania
       city: Tota la ciutat
       district: Un districte
       official: Programa (Ajuntament)
-    proposal_filter_option_group:
+    filter_option_group:
       category_id: Eix
       district: Districte
       scope: "Àmbit"

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -6,14 +6,6 @@ ca:
         label: Eix
       subcategory:
         label: Línia d'acció
-    meeting_proposals_autocomplete_input:
-      loading: Carregant...
-      no_results: No s'han trobat resultats.
-      search: Buscar
-    meeting_proposals_table:
-      actions: Accions
-      remove: Eliminar
-      title: Títol
     filter_option:
       citizenship: Ciutadania
       city: Tota la ciutat
@@ -25,3 +17,11 @@ ca:
       scope: "Àmbit"
       source: Origen
       subcategory_id: Línia d'acció
+    meeting_proposals_autocomplete_input:
+      loading: Carregant...
+      no_results: No s'han trobat resultats.
+      search: Buscar
+    meeting_proposals_table:
+      actions: Accions
+      remove: Eliminar
+      title: Títol

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -14,12 +14,12 @@ en:
       actions: Actions
       remove: Delete
       title: Title
-    proposal_filter_option:
+    filter_option:
       citizenship: Citizenship
       city: Whole city
       district: A district
       official: Program (Town Hall)
-    proposal_filter_option_group:
+    filter_option_group:
       category_id: Axis
       district: District
       scope: Scope

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -6,14 +6,6 @@ en:
         label: Axis
       subcategory:
         label: Action Line
-    meeting_proposals_autocomplete_input:
-      loading: Loading...
-      no_results: No results.
-      search: Search
-    meeting_proposals_table:
-      actions: Actions
-      remove: Delete
-      title: Title
     filter_option:
       citizenship: Citizenship
       city: Whole city
@@ -25,3 +17,11 @@ en:
       scope: Scope
       source: Source
       subcategory_id: Action Line
+    meeting_proposals_autocomplete_input:
+      loading: Loading...
+      no_results: No results.
+      search: Search
+    meeting_proposals_table:
+      actions: Actions
+      remove: Delete
+      title: Title

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -6,14 +6,6 @@ es:
         label: Eje
       subcategory:
         label: Línea de actuación
-    meeting_proposals_autocomplete_input:
-      loading: Cargando...
-      no_results: No se han encontrado resultados.
-      search: Buscar
-    meeting_proposals_table:
-      actions: Acciones
-      remove: Delete
-      title: Título
     filter_option:
       citizenship: Ciudadania
       city: Toda la ciudad
@@ -25,3 +17,11 @@ es:
       scope: "Ámbito"
       source: Origen
       subcategory_id: Línea de actuación
+    meeting_proposals_autocomplete_input:
+      loading: Cargando...
+      no_results: No se han encontrado resultados.
+      search: Buscar
+    meeting_proposals_table:
+      actions: Acciones
+      remove: Delete
+      title: Título

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -14,12 +14,12 @@ es:
       actions: Acciones
       remove: Delete
       title: Título
-    proposal_filter_option:
+    filter_option:
       citizenship: Ciudadania
       city: Toda la ciudad
       district: Un distrito
       official: Programa (Ayuntamiento)
-    proposal_filter_option_group:
+    filter_option_group:
       category_id: Eje
       district: Distrito
       scope: "Ámbito"

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -57,7 +57,7 @@ feature 'Proposals' do
 
     visit proposals_path
 
-    check 'proposal_filter_scope_city'
+    check 'filter_scope_city'
 
     expect(page).to have_content 'Proposal with city scope 1'
     expect(page).to have_content 'Proposal with city scope 2'

--- a/spec/services/resource_filter_spec.rb
+++ b/spec/services/resource_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ProposalFilter do
+describe ResourceFilter do
   describe "filter params" do
     before :each do
       @proposal1 = create(:proposal, scope: "city")
@@ -9,14 +9,14 @@ describe ProposalFilter do
     end
 
     it "should filter collection based on a single filter params" do
-      filter = ProposalFilter.new(filter: 'scope=district')
+      filter = ResourceFilter.new(Proposal, filter: 'scope=district')
       expect(filter.collection).to_not include(@proposal1)
       expect(filter.collection).to include(@proposal2)
       expect(filter.collection).to include(@proposal3)
     end
 
     it "should filter collection based on multiple filter params" do
-      filter = ProposalFilter.new(filter: 'scope=district:district=1')
+      filter = ResourceFilter.new(Proposal, filter: 'scope=district:district=1')
       expect(filter.collection).to_not include(@proposal1)
       expect(filter.collection).to include(@proposal2)
       expect(filter.collection).to_not include(@proposal3)

--- a/spec/services/resource_filter_spec.rb
+++ b/spec/services/resource_filter_spec.rb
@@ -9,14 +9,14 @@ describe ResourceFilter do
     end
 
     it "should filter collection based on a single filter params" do
-      filter = ResourceFilter.new(Proposal, filter: 'scope=district')
+      filter = ResourceFilter.new(Proposal.all, filter: 'scope=district')
       expect(filter.collection).to_not include(@proposal1)
       expect(filter.collection).to include(@proposal2)
       expect(filter.collection).to include(@proposal3)
     end
 
     it "should filter collection based on multiple filter params" do
-      filter = ResourceFilter.new(Proposal, filter: 'scope=district:district=1')
+      filter = ResourceFilter.new(Proposal.all, filter: 'scope=district:district=1')
       expect(filter.collection).to_not include(@proposal1)
       expect(filter.collection).to include(@proposal2)
       expect(filter.collection).to_not include(@proposal3)


### PR DESCRIPTION
# What and why

Meetings have a lot of fields now like `category`, `subcategory`, `scope` and so on. I have reused some components from proposals section and created a filter in the meetings public page.
# QA

First, repopulate the database using the new seeds. Navigate to the meetings public page and try some filters.
# GIF Tax

![](https://media.giphy.com/media/9KCCWYmC1xXu8/giphy.gif) 
# TODOs
- [x] Scope and district
- [x] Category and subcategory
- [x] Tags
- [x] Search
- [x] Map
- [x] Bug: link to meeting doesn't work
