### PR TITLE
Proposal filters revision

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require parallax
 //= require react
 //= require react_ujs
+//= require services
 //= require components
 //= require ckeditor/init
 //= require_directory ./ckeditor

--- a/app/assets/javascripts/components/meetings_filter.es6.jsx
+++ b/app/assets/javascripts/components/meetings_filter.es6.jsx
@@ -11,17 +11,8 @@ class MeetingsFilter extends React.Component {
   render() {
     return (
       <form>
-        <div className="row collapse prefix-radius">
-          <div className="small-2 large-1 columns">
-            <span className="prefix"><i className="icon-search"></i></span>
-          </div>
-          <div className="small-10 large-11 columns">
-            <input 
-              placeholder="Cercar" 
-              onChange={(event) => this.filterByText(event.target.value)} 
-              onKeyDown={(event) => this.onKeyDown(event)} />
-          </div>
-        </div>
+        <SearchFilter 
+          onSetFilterText={ (searchText) => this.setFilterText(searchText) } />
         <ScopeFilterOptionGroup 
           filterGroupValue={this.state.filters.get('scope')} 
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
@@ -47,29 +38,6 @@ class MeetingsFilter extends React.Component {
     )
   }
 
-  onKeyDown(event) {
-    let key = event.keyCode;
-
-    if (key === 13) { // Prevent form submission
-      event.preventDefault();
-    }
-  }
-
-  filterByText(searchText) {
-    if (this.searchTimeoutId) {
-      clearTimeout(this.searchTimeoutId);
-    }
-
-    this.searchTimeoutId = setTimeout(() => {
-      this.applyFilters(
-        this.state.filters.toObject(), 
-        this.state.tags.toArray(),
-        searchText
-      );
-      this.setState({ searchText });
-    }, 300);
-  }
-
   changeFilterGroup(filterGroupName, filterGroupValue) {
     let filters = this.state.filters.set(filterGroupName, filterGroupValue);
     if (filterGroupName === 'category_id') {
@@ -84,6 +52,15 @@ class MeetingsFilter extends React.Component {
       this.state.searchText
     );
     this.setState({ filters });
+  }
+
+  setFilterText(searchText) {
+    this.applyFilters(
+      this.state.filters.toObject(), 
+      this.state.tags.toArray(),
+      searchText
+    );
+    this.setState({ searchText });
   }
 
   setFilterTags(tags) {

--- a/app/assets/javascripts/components/meetings_filter.es6.jsx
+++ b/app/assets/javascripts/components/meetings_filter.es6.jsx
@@ -1,123 +1,50 @@
 class MeetingsFilter extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
       searchText: this.props.filter.search_filter,
       tags: Immutable.Set(this.props.filter.tag_filter || []),
       filters : Immutable.Map(this.props.filter.params || {})
     };
+
+    this.filterService = new FilterComponentService(this, {
+      requestUrl: this.props.filterUrl,
+      requestDataType: 'json',
+      onResultsCallback: (result) => {
+        this.props.onFilterResult(result);
+      }
+    });
   }
 
   render() {
     return (
       <form>
         <SearchFilter 
-          onSetFilterText={ (searchText) => this.setFilterText(searchText) } />
+          searchText={this.state.searchText}
+          onSetFilterText={ (searchText) => this.filterService.setFilterText(searchText) } />
         <ScopeFilterOptionGroup 
           filterGroupValue={this.state.filters.get('scope')} 
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <DistrictFilterOptionGroup 
           scopeSelected={this.state.filters.get('scope')}
           districts={this.props.districts} 
           filterGroupValue={this.state.filters.get('district')}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <CategoryFilterOptionGroup
           categories={this.props.categories}
           filterGroupValue={this.state.filters.get('category_id')} 
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <SubcategoryFilterOptionGroup
           selectedCategory={this.state.filters.get('category_id')}
           subcategories={this.props.subcategories}
           filterGroupValue={this.state.filters.get('subcategory_id')}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <TagCloudFilter 
           currentTags={this.state.tags} 
           tagCloud={this.props.filter.tag_cloud} 
-          onSetFilterTags={(tags) => this.setFilterTags(tags)} />
+          onSetFilterTags={(tags) => this.filterService.setFilterTags(tags)} />
       </form>
     )
   }
-
-  changeFilterGroup(filterGroupName, filterGroupValue) {
-    let filters = this.state.filters.set(filterGroupName, filterGroupValue);
-    if (filterGroupName === 'category_id') {
-      filters = filters.delete('subcategory_id')
-    }
-    if (filterGroupName === 'scope' && filterGroupValue !== 'district') {
-      filters = filters.delete('district');
-    }
-    this.applyFilters(
-      filters.toObject(), 
-      this.state.tags.toArray(),
-      this.state.searchText
-    );
-    this.setState({ filters });
-  }
-
-  setFilterText(searchText) {
-    this.applyFilters(
-      this.state.filters.toObject(), 
-      this.state.tags.toArray(),
-      searchText
-    );
-    this.setState({ searchText });
-  }
-
-  setFilterTags(tags) {
-    this.applyFilters(
-      this.state.filters.toObject(), 
-      tags.toArray(), 
-      this.state.searchText
-    );
-    this.setState({ tags });
-  }
-
-  applyFilters(filters, tags, searchText) {
-    let filterString = [], 
-        data;
-
-    for (let filterGroupName in filters) {
-      if(filters[filterGroupName].length > 0) {
-        filterString.push(`${filterGroupName}=${filters[filterGroupName].join(',')}`);
-      }
-    }
-
-    filterString = filterString.join(':');
-
-    data = {
-      search: searchText,
-      tag: tags,
-      filter: filterString 
-    }
-
-    this.replaceUrl(data);
-
-    $.ajax(this.props.filterUrl, { data, dataType: "json" }).then((result) => {
-      this.props.onFilterResult(result);
-    });
-  }
-
-  replaceUrl(data) {
-    if (Modernizr.history) {
-      let queryParams = [],
-          url;
-
-      if (data.searchText) {
-        queryParams.push(`search=${data.searchText}`);
-      }
-
-      if (data.tag) {
-        queryParams.push(`tag=${data.tag}`);
-      }
-
-      if (data.filter) {
-        queryParams.push(`filter=${data.filter}`);
-      }
-
-      url = `${location.href.replace(/\?.*/, "")}?${queryParams.join('&')}`;
-
-      history.replaceState(data, '', url);
-    }
-  }
-
 }

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -27,6 +27,7 @@ class ProposalFilters extends React.Component {
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) }>
           <FilterOption filterName="official" />
           <FilterOption filterName="citizenship" />
+          <FilterOption filterName="meetings" />
         </FilterOptionGroup>
         <ScopeFilterOptionGroup 
           filterGroupValue={this.state.filters.get('scope')} 

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -16,7 +16,7 @@ class ProposalFilters extends React.Component {
 
   render() {
     return (
-      <form>
+      <form className="proposal-filters">
         <SearchFilter 
           value={this.props.filter.search_filter}
           onSetFilterText={ (searchText) => this.filterService.setFilterText(searchText) } />

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -1,130 +1,55 @@
 class ProposalFilters extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
       searchText: this.props.filter.search_filter,
       tags: Immutable.Set(this.props.filter.tag_filter || []),
       filters : Immutable.Map(this.props.filter.params || {})
     };
+
+    this.filterService = new FilterComponentService(this, {
+      requestUrl: this.props.filterUrl,
+      requestDataType: 'script'
+    });
   }
 
   render() {
     return (
       <form>
         <SearchFilter 
-          onSetFilterText={ (searchText) => this.setFilterText(searchText) } />
+          value={this.props.filter.search_filter}
+          onSetFilterText={ (searchText) => this.filterService.setFilterText(searchText) } />
         <FilterOptionGroup 
           filterGroupName="source" 
           filterGroupValue={this.state.filters.get('source')}
           isExclusive={true}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) }>
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) }>
           <FilterOption filterName="official" />
           <FilterOption filterName="citizenship" />
         </FilterOptionGroup>
         <ScopeFilterOptionGroup 
           filterGroupValue={this.state.filters.get('scope')} 
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <DistrictFilterOptionGroup 
           scopeSelected={this.state.filters.get('scope')}
           districts={this.props.districts} 
           filterGroupValue={this.state.filters.get('district')}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <CategoryFilterOptionGroup
           categories={this.props.categories}
           filterGroupValue={this.state.filters.get('category_id')} 
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <SubcategoryFilterOptionGroup
           selectedCategory={this.state.filters.get('category_id')}
           subcategories={this.props.subcategories}
           filterGroupValue={this.state.filters.get('subcategory_id')}
-          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.changeFilterGroup(filterGroupName, filterGroupValue) } />
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
         <TagCloudFilter 
           currentTags={this.state.tags} 
           tagCloud={this.props.filter.tag_cloud} 
-          onSetFilterTags={(tags) => this.setFilterTags(tags)} />
+          onSetFilterTags={(tags) => this.filterService.setFilterTags(tags)} />
       </form>
-    );
-  }
-
-  changeFilterGroup(filterGroupName, filterGroupValue) {
-    let filters = this.state.filters.set(filterGroupName, filterGroupValue);
-    if (filterGroupName === 'category_id') {
-      filters = filters.delete('subcategory_id')
-    }
-    if (filterGroupName === 'scope' && filterGroupValue !== 'district') {
-      filters = filters.delete('district');
-    }
-    this.applyFilters(
-      filters.toObject(), 
-      this.state.tags.toArray(),
-      this.state.searchText
-    );
-    this.setState({ filters });
-  }
-
-  setFilterText(searchText) {
-    this.applyFilters(
-      this.state.filters.toObject(), 
-      this.state.tags.toArray(),
-      searchText
-    );
-    this.setState({ searchText });
-  }
-
-  setFilterTags(tags) {
-    this.applyFilters(
-      this.state.filters.toObject(), 
-      tags.toArray(), 
-      this.state.searchText
-    );
-    this.setState({ tags });
-  }
-
-  applyFilters(filters, tags, searchText) {
-    let filterString = [], 
-        data;
-
-    for (let filterGroupName in filters) {
-      if(filters[filterGroupName].length > 0) {
-        filterString.push(`${filterGroupName}=${filters[filterGroupName].join(',')}`);
-      }
-    }
-
-    filterString = filterString.join(':');
-
-    data = {
-      search: searchText,
-      tag: tags,
-      filter: filterString 
-    }
-
-    $('#proposals').html('Loading...');
-
-    this.replaceUrl(data);
-
-    $.ajax(this.props.filterUrl, { data, dataType: "script" });
-  }
-
-  replaceUrl(data) {
-    if (Modernizr.history) {
-      let queryParams = [],
-          url;
-
-      if (data.searchText) {
-        queryParams.push(`search=${this.state.search}`);
-      }
-
-      if (data.tag) {
-        queryParams.push(`tag=${data.tag}`);
-      }
-
-      if (data.filter) {
-        queryParams.push(`filter=${data.filter}`);
-      }
-
-      url = `${location.href.replace(/\?.*/, "")}?${queryParams.join('&')}`;
-
-      history.replaceState(data, '', url);
-    }
+    )
   }
 }

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -2,7 +2,7 @@ class ProposalFilters extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      search: this.props.filter.search_filter,
+      searchText: this.props.filter.search_filter,
       tags: Immutable.Set(this.props.filter.tag_filter || []),
       filters : Immutable.Map(this.props.filter.params || {})
     };
@@ -11,6 +11,8 @@ class ProposalFilters extends React.Component {
   render() {
     return (
       <form>
+        <SearchFilter 
+          onSetFilterText={ (searchText) => this.setFilterText(searchText) } />
         <FilterOptionGroup 
           filterGroupName="source" 
           filterGroupValue={this.state.filters.get('source')}
@@ -52,16 +54,33 @@ class ProposalFilters extends React.Component {
     if (filterGroupName === 'scope' && filterGroupValue !== 'district') {
       filters = filters.delete('district');
     }
-    this.applyFilters(filters.toObject(), this.state.tags.toArray());
+    this.applyFilters(
+      filters.toObject(), 
+      this.state.tags.toArray(),
+      this.state.searchText
+    );
     this.setState({ filters });
   }
 
+  setFilterText(searchText) {
+    this.applyFilters(
+      this.state.filters.toObject(), 
+      this.state.tags.toArray(),
+      searchText
+    );
+    this.setState({ searchText });
+  }
+
   setFilterTags(tags) {
-    this.applyFilters(this.state.filters.toObject(), tags.toArray());
+    this.applyFilters(
+      this.state.filters.toObject(), 
+      tags.toArray(), 
+      this.state.searchText
+    );
     this.setState({ tags });
   }
 
-  applyFilters(filters, tags) {
+  applyFilters(filters, tags, searchText) {
     let filterString = [], 
         data;
 
@@ -74,13 +93,15 @@ class ProposalFilters extends React.Component {
     filterString = filterString.join(':');
 
     data = {
-      search: this.state.search,
+      search: searchText,
       tag: tags,
       filter: filterString 
     }
 
     $('#proposals').html('Loading...');
+
     this.replaceUrl(data);
+
     $.ajax(this.props.filterUrl, { data, dataType: "script" });
   }
 
@@ -89,7 +110,7 @@ class ProposalFilters extends React.Component {
       let queryParams = [],
           url;
 
-      if (this.state.search) {
+      if (data.searchText) {
         queryParams.push(`search=${this.state.search}`);
       }
 

--- a/app/assets/javascripts/components/search_filter.es6.jsx
+++ b/app/assets/javascripts/components/search_filter.es6.jsx
@@ -7,6 +7,7 @@ class SearchFilter extends React.Component {
         </div>
         <div className="small-10 large-11 columns">
           <input 
+            className="search-filter"
             value={this.props.searchText}
             placeholder={I18n.t("components.search_filter.search_input_placeholder")}
             onChange={(event) => this.filterByText(event.target.value)} 

--- a/app/assets/javascripts/components/search_filter.es6.jsx
+++ b/app/assets/javascripts/components/search_filter.es6.jsx
@@ -7,6 +7,7 @@ class SearchFilter extends React.Component {
         </div>
         <div className="small-10 large-11 columns">
           <input 
+            value={this.props.searchText}
             placeholder={I18n.t("components.search_filter.search_input_placeholder")}
             onChange={(event) => this.filterByText(event.target.value)} 
             onKeyDown={(event) => this.onKeyDown(event)} />
@@ -16,13 +17,7 @@ class SearchFilter extends React.Component {
   }
 
   filterByText(searchText) {
-    if (this.searchTimeoutId) {
-      clearTimeout(this.searchTimeoutId);
-    }
-
-    this.searchTimeoutId = setTimeout(() => {
-      this.props.onSetFilterText(searchText);
-    }, 300);
+    this.props.onSetFilterText(searchText);
   }
 
   onKeyDown(event) {

--- a/app/assets/javascripts/components/search_filter.es6.jsx
+++ b/app/assets/javascripts/components/search_filter.es6.jsx
@@ -1,0 +1,36 @@
+class SearchFilter extends React.Component {
+  render() {
+    return (
+      <div className="row collapse prefix-radius">
+        <div className="small-2 large-1 columns">
+          <span className="prefix"><i className="icon-search"></i></span>
+        </div>
+        <div className="small-10 large-11 columns">
+          <input 
+            placeholder={I18n.t("components.search_filter.search_input_placeholder")}
+            onChange={(event) => this.filterByText(event.target.value)} 
+            onKeyDown={(event) => this.onKeyDown(event)} />
+        </div>
+      </div>
+    );
+  }
+
+  filterByText(searchText) {
+    if (this.searchTimeoutId) {
+      clearTimeout(this.searchTimeoutId);
+    }
+
+    this.searchTimeoutId = setTimeout(() => {
+      this.props.onSetFilterText(searchText);
+    }, 300);
+  }
+
+  onKeyDown(event) {
+    let key = event.keyCode;
+
+    if (key === 13) { // Prevent form submission
+      event.preventDefault();
+    }
+  }
+
+}

--- a/app/assets/javascripts/services.js
+++ b/app/assets/javascripts/services.js
@@ -1,0 +1,1 @@
+//= require_tree ./services

--- a/app/assets/javascripts/services/filter_component_service.es6.jsx
+++ b/app/assets/javascripts/services/filter_component_service.es6.jsx
@@ -1,0 +1,98 @@
+class FilterComponentService {
+  constructor(component, options) {
+    this.component = component;
+    this.requestUrl = options.requestUrl;
+    this.requestDataType = options.requestDataType;
+    this.onResultsCallback = options.onResultsCallback;
+  }
+
+  changeFilterGroup(filterGroupName, filterGroupValue) {
+    let filters = this.component.state.filters.set(filterGroupName, filterGroupValue);
+    if (filterGroupName === 'category_id') {
+      filters = filters.delete('subcategory_id')
+    }
+    if (filterGroupName === 'scope' && filterGroupValue !== 'district') {
+      filters = filters.delete('district');
+    }
+    this.applyFilters(
+      filters.toObject(), 
+      this.component.state.tags.toArray(),
+      this.component.state.searchText
+    );
+    this.component.setState({ filters });
+  }
+
+  setFilterText(searchText) {
+    this.applyFilters(
+      this.component.state.filters.toObject(), 
+      this.component.state.tags.toArray(),
+      searchText
+    );
+    this.component.setState({ searchText });
+  }
+
+  setFilterTags(tags) {
+    this.applyFilters(
+      this.component.state.filters.toObject(), 
+      tags.toArray(), 
+      this.component.state.searchText
+    );
+    this.component.setState({ tags });
+  }
+
+  applyFilters(filters, tags, searchText) {
+    let filterString = [], 
+        data;
+
+    for (let filterGroupName in filters) {
+      if(filters[filterGroupName].length > 0) {
+        filterString.push(`${filterGroupName}=${filters[filterGroupName].join(',')}`);
+      }
+    }
+
+    filterString = filterString.join(':');
+
+    data = {
+      search: searchText,
+      tag: tags,
+      filter: filterString 
+    }
+
+    this.replaceUrl(data);
+
+    if (this.searchTimeoutId) {
+      clearTimeout(this.searchTimeoutId);
+    }
+
+    this.searchTimeoutId = setTimeout(() => {
+      $.ajax(this.requestUrl, { data, dataType: this.requestDataType }).then((result) => {
+        if (this.onResultsCallback) {
+          this.onResultsCallback(result);
+        }
+      });
+    }, 300);
+  }
+
+  replaceUrl(data) {
+    if (Modernizr.history) {
+      let queryParams = [],
+          url;
+
+      if (data.search) {
+        queryParams.push(`search=${data.search}`);
+      }
+
+      if (data.tag && data.tag.length > 0) {
+        queryParams.push(`tag=${data.tag}`);
+      }
+
+      if (data.filter) {
+        queryParams.push(`filter=${data.filter}`);
+      }
+
+      url = `${location.href.replace(/\?.*/, "")}?${queryParams.join('&')}`;
+
+      history.replaceState(data, '', url);
+    }
+  }
+}

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -18,6 +18,7 @@ class ProposalsController < ApplicationController
     @featured_proposals = @proposals.sort_by_confidence_score.limit(3) if (@filter.search_filter.blank? && @filter.tag_filter.blank?)
     if @featured_proposals.present?
       set_featured_proposal_votes(@featured_proposals)
+      @featured_proposals = @featured_proposals.send("sort_by_#{@current_order}")
       @proposals = @proposals.where('proposals.id NOT IN (?)', @featured_proposals.map(&:id))
     end
 

--- a/app/services/resource_filter.rb
+++ b/app/services/resource_filter.rb
@@ -61,6 +61,11 @@ class ResourceFilter
           @collection = @collection.where(attr => value)
         end
       end
+
+      if @params["source"] && @params["source"].include?("meetings")
+        proposal_in_meetings_ids = MeetingProposal.pluck(:proposal_id).uniq
+        @collection = @collection.where(id: proposal_in_meetings_ids)
+      end
     end
   end
 end

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -1,9 +1,4 @@
 <% provide :title do %><%= t('proposals.index.title') %><% end %>
-<% content_for :header_addon do %>
-  <%= render "shared/search_form",
-             search_path: proposals_path(page: 1),
-             i18n_namespace: "proposals.index.search_form" %>
-<% end %>
 
 <section role="main">
   <div class="wrap row">

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -140,7 +140,7 @@ ignore_unused:
   - 'notifications.index.replies_to*'
   - 'helpers.page_entries_info.*' # kaminari
   - 'views.pagination.*' # kaminari
-  - 'components.filter_option.{city,district,official,citizenship}'
+  - 'components.filter_option.{city,district,official,citizenship,meetings}'
   - 'components.filter_option_group.{category_id,district,scope,subcategory_id, source}'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -11,6 +11,7 @@ ca:
       city: Tota la ciutat
       district: Un districte
       official: Programa (Ajuntament)
+      meetings: Trobades presencials
     filter_option_group:
       category_id: Eix
       district: Districte

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -10,8 +10,8 @@ ca:
       citizenship: Ciutadania
       city: Tota la ciutat
       district: Un districte
-      official: Programa (Ajuntament)
       meetings: Trobades presencials
+      official: Programa (Ajuntament)
     filter_option_group:
       category_id: Eix
       district: Districte

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -25,3 +25,5 @@ ca:
       actions: Accions
       remove: Eliminar
       title: Títol
+    search_filter:
+      search_input_placeholder: Cercar

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -11,6 +11,7 @@ en:
       city: Whole city
       district: A district
       official: Program (Town Hall)
+      meetings: Meetings
     filter_option_group:
       category_id: Axis
       district: District

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -25,3 +25,5 @@ en:
       actions: Actions
       remove: Delete
       title: Title
+    search_filter:
+      search_input_placeholder: Search

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -10,8 +10,8 @@ en:
       citizenship: Citizenship
       city: Whole city
       district: A district
-      official: Program (Town Hall)
       meetings: Meetings
+      official: Program (Town Hall)
     filter_option_group:
       category_id: Axis
       district: District

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -25,3 +25,5 @@ es:
       actions: Acciones
       remove: Delete
       title: Título
+    search_filter:
+      search_input_placeholder: Buscar

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -10,8 +10,8 @@ es:
       citizenship: Ciudadania
       city: Toda la ciudad
       district: Un distrito
-      official: Programa (Ayuntamiento)
       meetings: Encuentros presenciales
+      official: Programa (Ayuntamiento)
     filter_option_group:
       category_id: Eje
       district: Distrito

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -11,6 +11,7 @@ es:
       city: Toda la ciudad
       district: Un distrito
       official: Programa (Ayuntamiento)
+      meetings: Encuentros presenciales
     filter_option_group:
       category_id: Eje
       district: Distrito

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -121,6 +121,7 @@ if ENV["SEED"]
   puts "Creating Meetings"
 
   places = YAML.load_file("#{Rails.root}/db/seeds/places.yml")[:places]
+  proposals = Proposal.all
 
   (1..1000).each do |i|
     place = places.sample
@@ -150,7 +151,8 @@ if ENV["SEED"]
       subcategory: subcategory,
       category: subcategory.category,
       scope: scope,
-      district: district
+      district: district,
+      proposal_ids: proposals.sample(3).collect(&:id)
     )
     puts "    #{meeting.title}"
   end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -533,17 +533,14 @@ feature 'Proposals' do
 
     context "Basic search" do
 
-      scenario 'Search by text' do
+      scenario 'Search by text', :js do
         proposal1 = create(:proposal, title: "Get Schwifty")
         proposal2 = create(:proposal, title: "Schwifty Hello")
         proposal3 = create(:proposal, title: "Do not show me")
 
         visit proposals_path
 
-        within "#search_form" do
-          fill_in "search", with: "Schwifty"
-          click_button "Search"
-        end
+        find('.proposal-filters .search-filter').set("Schwifty")
 
         within("#proposals") do
           expect(page).to have_css('.proposal', count: 2)
@@ -553,18 +550,6 @@ feature 'Proposals' do
           expect(page).to_not have_content(proposal3.title)
         end
       end
-
-      scenario "Maintain search criteria" do
-        visit proposals_path
-
-        within "#search_form" do
-          fill_in "search", with: "Schwifty"
-          click_button "Search"
-        end
-
-        expect(page).to have_selector("input[name='search'][value='Schwifty']")
-      end
-
     end
 
     scenario "Order by relevance by default", :js do
@@ -573,8 +558,8 @@ feature 'Proposals' do
       proposal3 = create(:proposal, title: "Show you got",      cached_votes_up: 100)
 
       visit proposals_path
-      fill_in "search", with: "Show what you got"
-      click_button "Search"
+
+      find('.proposal-filters .search-filter').set("Show what you got")
 
       within("#proposals") do
         expect(all(".proposal")[0].text).to match "Show what you got"
@@ -590,27 +575,27 @@ feature 'Proposals' do
       proposal4 = create(:proposal, title: "Do not display",    cached_votes_up: 1,   created_at: 1.week.ago)
 
       visit proposals_path
-      fill_in "search", with: "Show what you got"
-      click_button "Search"
+
+      find('.proposal-filters .search-filter').set("Show what you got")
+
+      expect(page).to_not have_content "Do not display"
+
       click_link 'newest'
 
       within("#proposals") do
         expect(all(".proposal")[0].text).to match "Show you got"
         expect(all(".proposal")[1].text).to match "Show you got"
         expect(all(".proposal")[2].text).to match "Show what you got"
-        expect(page).to_not have_content "Do not display"
       end
     end
 
-    scenario 'After a search do not show featured proposals' do
+    scenario 'After a search do not show featured proposals', :js do
       featured_proposals = create_featured_proposals
       proposal = create(:proposal, title: "Abcdefghi")
 
       visit proposals_path
-      within "#search_form" do
-        fill_in "search", with: proposal.title
-        click_button "Search"
-      end
+
+      find('.proposal-filters .search-filter').set(proposal.title)
 
       expect(page).to_not have_selector('#proposals .proposal-featured')
       expect(page).to_not have_selector('#featured-proposals')

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -561,10 +561,10 @@ feature 'Proposals' do
 
       find('.proposal-filters .search-filter').set("Show what you got")
 
-      within("#proposals") do
-        expect(all(".proposal")[0].text).to match "Show what you got"
-        expect(all(".proposal")[1].text).to match "Show you got"
-        expect(all(".proposal")[2].text).to match "Show you got"
+      within("#featured-proposals") do
+        expect(all(".featured-proposal")[0].text).to match "Show you got"
+        expect(all(".featured-proposal")[1].text).to match "Show you got"
+        expect(all(".featured-proposal")[2].text).to match "Show what you got"
       end
     end
 


### PR DESCRIPTION
# What and why

I had small diferences between meetings and proposal filters so I created reusable components for both of them. Also I have included the search component into proposal filters deprecating the old search form.

Finally I added a new origin filters called `meetings`. It can be used to filter proposals discussed in a meeting.
# QA

First, re-seed the database to create meetings and proposals relationships. Then navigate to proposals page and try to filter and search.
# GIF Tax

![](https://media.giphy.com/media/XuOOXWY29Y4z6/giphy.gif)
# TODOs
- [x] Search component
- [x] Filter service
- [x] Add filter for proposal in meetings
- [x] Tests
