### PR TITLE
Sign in user after confirmation

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -38,6 +38,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
       set_official_position if resource.has_official_email?
       resource.confirm # Last change: confirm happens here for people with passwords instead of af the top of the show action
       set_flash_message(:notice, :confirmed) if is_flashing_format?
+      sign_in(resource)
       respond_with_navigational(resource){ redirect_to after_confirmation_path_for(resource_name, resource) }
     else
       respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
@@ -54,6 +55,10 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
     def set_official_position
       resource.add_official_position! (Setting['official_level_1_name']), 1
+    end
+
+    def after_confirmation_path_for(resource_name, resource)
+      "/welcome"
     end
 
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -117,7 +117,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 3.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email


### PR DESCRIPTION
I've been reproducing the registration flow and I particularly find having to log after confirmation a little bit annoying.

This PR fixes it by auto-logging the user after confirming.

This opens a security concern, though:

http://stackoverflow.com/a/18655887

TLDR: Anyone that could read your inbox could log in using that same confirmation token.

What do you think?
