### PR TITLE
Force plain text paste to ckeditor

### DIFF
--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -109,7 +109,8 @@ CKEDITOR.editorConfig = function( config )
 
   config.toolbar_mini = [
     { name: 'paragraph', groups: [ 'list' ], items: [ 'NumberedList', 'BulletedList' ] },
-    { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ], items: [ 'Bold', 'Italic', 'Underline', 'Strike' ] }
+    { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ], items: [ 'Bold', 'Italic', 'Underline', 'Strike' ] },
+    { name: 'insert', items: [ 'Table' ] }
   ];
   config.toolbar = "mini";
 

--- a/app/assets/javascripts/ckeditor/config.js
+++ b/app/assets/javascripts/ckeditor/config.js
@@ -112,4 +112,6 @@ CKEDITOR.editorConfig = function( config )
     { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ], items: [ 'Bold', 'Italic', 'Underline', 'Strike' ] }
   ];
   config.toolbar = "mini";
+
+  config.forcePasteAsPlainText = true;
 };


### PR DESCRIPTION
# What and why

Copy/paste from word is a bad practice because the result is unexpected and can brake the page's content.
I have forced the plain text paste for ckeditor inputs.
# QA

Try to copy/paste a table from word. It doesn't work!
# GIF Tax

![](https://media.giphy.com/media/TvwL1h88aoaqI/giphy.gif)
