### PR TITLE
Fix hover effect for vote button after ajax request

### DIFF
--- a/app/assets/javascripts/votes.js.coffee
+++ b/app/assets/javascripts/votes.js.coffee
@@ -1,16 +1,16 @@
 App.Votes =
 
-  hoverize: (votes) ->
-    $(votes).hover ->
-      $("div.anonymous-votes", votes).show();
-      $("div.organizations-votes", votes).show();
-      $("div.not-logged", votes).show();
-    , ->
-      $("div.anonymous-votes", votes).hide();
-      $("div.organizations-votes", votes).hide();
-      $("div.not-logged", votes).hide();
+  hoverize: (selector, delegateTo) ->
+    $(selector).on "mouseenter", delegateTo, ->
+      $(this).find("div.anonymous-votes").show()
+      $(this).find("div.organizations-votes").show()
+      $(this).find("div.not-logged").show()
+    $(selector).on "mouseleave", delegateTo, ->
+      $(this).find("div.anonymous-votes").hide()
+      $(this).find("div.organizations-votes").hide()
+      $(this).find("div.not-logged").hide()
 
   initialize: ->
-    App.Votes.hoverize votes for votes in $("div.votes")
-    App.Votes.hoverize votes for votes in $("div.supports")
+    App.Votes.hoverize $("#debates"), "div.votes"
+    App.Votes.hoverize $("#proposals, #featured-proposals"), "div.supports"
     false

--- a/app/assets/javascripts/votes.js.coffee
+++ b/app/assets/javascripts/votes.js.coffee
@@ -11,6 +11,6 @@ App.Votes =
       $(this).find("div.not-logged").hide()
 
   initialize: ->
-    App.Votes.hoverize $("#debates"), "div.votes"
-    App.Votes.hoverize $("#proposals, #featured-proposals"), "div.supports"
+    App.Votes.hoverize $("#debates, .debate-show"), "div.votes"
+    App.Votes.hoverize $("#proposals, #featured-proposals, .proposal-show"), "div.supports"
     false


### PR DESCRIPTION
# What and why

When filtering proposals an ajax request is made. Those proposals had a hover effect to show/hide "user must be verified" popup. Instead of bindings `n` events I used delegation. It's by far more efficient and there is no problem with ajax content.
# QA

Try filtering proposals and check the vote button hover effect.
# GIF Tax

![](https://media.giphy.com/media/wvurizcBk3tmM/giphy.gif)
