### PR TITLE
Fix turbolinks and document.ready problem

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -72,7 +72,8 @@ var initialize_modules = function() {
 $(function(){
   Turbolinks.enableProgressBar();
 
-  $(document).ready(initialize_modules);
+  initialize_modules();
+
   $(document).on('ajax:complete', initialize_modules);
   $(document).on('ready page:load page:restore', function(){
     $('[data-parallax="scroll"]').parallax();


### PR DESCRIPTION
# What and why

`$(document).ready` is not necessary there because `$(function () {})` it's the same. I think it was some kind of weird bug with turbolinks because it called `initialize_modules` 1 + `n` times where `n` was the number of page reloads using turbolinks.
# QA

Try to navigate without being logged in. Then register an user and try an existing username. The message should appear 1 time.
# GIF tax

![](https://media.giphy.com/media/OFIsBxe3v7mKI/giphy.gif)
