### PR TITLE
Fix search input after page reload in proposal filters

### DIFF
--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -18,7 +18,7 @@ class ProposalFilters extends React.Component {
     return (
       <form className="proposal-filters">
         <SearchFilter 
-          value={this.props.filter.search_filter}
+          searchText={this.state.searchText}
           onSetFilterText={ (searchText) => this.filterService.setFilterText(searchText) } />
         <FilterOptionGroup 
           filterGroupName="source" 


### PR DESCRIPTION
# What and why

Reloading the proposal's page with an active search MUST fill the input.
# QA

Navigate to proposal's page, make a search and reload the page. The input field must be filled in.
# GIF tax

![](https://media.giphy.com/media/3KDSYgkPMr2Ok/giphy.gif)
