### PR TITLE
Add turbolinks param to pushState

### DIFF
--- a/app/assets/javascripts/services/filter_component_service.es6.jsx
+++ b/app/assets/javascripts/services/filter_component_service.es6.jsx
@@ -92,7 +92,9 @@ class FilterComponentService {
 
       url = `${location.href.replace(/\?.*/, "")}?${queryParams.join('&')}`;
 
-      history.replaceState(data, '', url);
+      data.turbolinks = true;
+
+      history.pushState(data, '', url);
     }
   }
 }


### PR DESCRIPTION
# What and why

Back button wasn't working properly after replacing/pushing state. @josepjaume found this: https://github.com/rails/turbolinks/issues/363#issuecomment-85626145
# QA

Play with proposal or meeting filters and use the back button.
# GIF tax

![](https://media.giphy.com/media/znQi1PuK17Lhe/giphy.gif)
