### PR TITLE
Proposal show page

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -52,4 +52,8 @@ class Meeting < ActiveRecord::Base
   def self.search(terms)
     self.pg_search(terms)
   end
+
+  def supports
+    proposals.sum(:votes)
+  end
 end

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -36,6 +36,10 @@
           <i class="icon-comments"></i>&nbsp;
           <%= link_to t("proposals.show.comments", count: @proposal.comments_count), "#comments" %>
           <span class="bullet">&nbsp;&bull;&nbsp;</span>
+          <i class="icon-like"></i>&nbsp;
+          <span class="js-comments-count positive"><%= @proposal.comments.positive.count %></span> <%= t('comments.form.alignment.positive') %>
+          <i class="icon-unlike"></i>&nbsp;
+          <span class="js-comments-count negative"><%= @proposal.comments.negative.count %></span> <%= t('comments.form.alignment.negative') %>
           <span class="js-flag-actions">
             <%= render 'proposals/flag_actions', proposal: @proposal %>
           </span>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -5,6 +5,7 @@
             social_title: @proposal.title,
             social_description: text_with_links(@proposal.summary) %>
 <% end %>
+
 <% cache [locale_and_user_status(@proposal), @proposal, @proposal.author, Flag.flagged?(current_user, @proposal), @proposal_votes] do %>
 
   <section class="proposal-show">
@@ -43,12 +44,9 @@
           <span class="js-flag-actions">
             <%= render 'proposals/flag_actions', proposal: @proposal %>
           </span>
-          <br>
-            <%= t("proposals.show.code") %>
-            <%= @proposal.code %>
         </div>
 
-        <blockquote><%= text_with_links @proposal.summary %></blockquote>
+        <%= text_with_links @proposal.summary %>
 
         <% if @proposal.external_url.present? %>
           <div class="document-link">
@@ -82,6 +80,21 @@
         <h3><%= t("proposals.show.share") %></h3>
         <%= social_share_button_tag(@proposal.title) %>
       </aside>
+    </div>
+
+    <div class="row">
+      <div class="small-12 medium-9 column">
+        <h2><%= t("proposals.show.meetings_title") %></h2>
+        <ul class="small-block-grid-2 medium-block-grid-3 large-block-grid-4">
+          <% @proposal.meetings.sample(8).each do |meeting| %>
+            <li class="meeting">
+              <div class="date"><%= l meeting.held_at %></div>
+              <div class="title"><%= link_to meeting.title, meeting %></div>
+              <div class="description"><%= meeting.description.truncate(50) %></div>
+            </li>
+          <% end %>
+        </ul>
+      </ul>
     </div>
   </section>
 <% end %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -90,7 +90,7 @@
             <li class="meeting">
               <div class="date"><%= l meeting.held_at %></div>
               <div class="title"><%= link_to meeting.title, meeting %></div>
-              <div class="description"><%= meeting.description.truncate(50) %></div>
+              <div class="support"><%= t("proposals.show.meeting_supports", counter: meeting.supports) %></div>
             </li>
           <% end %>
         </ul>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -351,6 +351,7 @@ ca:
         other: "%{count} Comentaris"
         zero: Sense comentaris
       comments_title: Comentaris
+      meetings_title: Cites presencials relacionats
       edit_proposal_link: Edita proposta
       flag: Aquesta proposta ha estat marcada com inapropiada per diversos usuaris.
       login_to_comment: Necessites %{signin} o %{signup} per fer comentaris.

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -351,10 +351,11 @@ ca:
         other: "%{count} Comentaris"
         zero: Sense comentaris
       comments_title: Comentaris
-      meetings_title: Cites presencials relacionats
       edit_proposal_link: Edita proposta
       flag: Aquesta proposta ha estat marcada com inapropiada per diversos usuaris.
       login_to_comment: Necessites %{signin} o %{signup} per fer comentaris.
+      meeting_supports: "%{counter} supports presencials"
+      meetings_title: Cites presencials relacionats
       share: Compartir
     update:
       form:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -345,7 +345,6 @@ ca:
     show:
       author_deleted: Usuari eliminat
       back_link: Tornar
-      code: 'Codi de la proposta:'
       comments:
         one: 1 Comentari
         other: "%{count} Comentaris"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,10 +351,11 @@ en:
         other: "%{count} comments"
         zero: No comments
       comments_title: Comments
-      meetings_title: Related meetings
       edit_proposal_link: Edit
       flag: This proposal has been flagged as inappropriate by several users.
       login_to_comment: You must %{signin} or %{signup} to leave a comment.
+      meeting_supports: "%{counter} presencial supports"
+      meetings_title: Related meetings
       share: Share
     update:
       form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,6 +351,7 @@ en:
         other: "%{count} comments"
         zero: No comments
       comments_title: Comments
+      meetings_title: Related meetings
       edit_proposal_link: Edit
       flag: This proposal has been flagged as inappropriate by several users.
       login_to_comment: You must %{signin} or %{signup} to leave a comment.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -345,7 +345,6 @@ en:
     show:
       author_deleted: User deleted
       back_link: Go back
-      code: 'Proposal code:'
       comments:
         one: 1 comment
         other: "%{count} comments"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -351,10 +351,11 @@ es:
         other: "%{count} Comentarios"
         zero: Sin comentarios
       comments_title: Comentarios
-      meetings_title: Encuentros presenciales relacionados
       edit_proposal_link: Editar propuesta
       flag: Esta propuesta ha sido marcada como inapropiada por varios usuarios.
       login_to_comment: Necesitas %{signin} o %{signup} para comentar.
+      meeting_supports: "%{counter} apoyos presenciales"
+      meetings_title: Encuentros presenciales relacionados
       share: Compartir
     update:
       form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -351,6 +351,7 @@ es:
         other: "%{count} Comentarios"
         zero: Sin comentarios
       comments_title: Comentarios
+      meetings_title: Encuentros presenciales relacionados
       edit_proposal_link: Editar propuesta
       flag: Esta propuesta ha sido marcada como inapropiada por varios usuarios.
       login_to_comment: Necesitas %{signin} o %{signup} para comentar.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -345,7 +345,6 @@ es:
     show:
       author_deleted: Usuario eliminado
       back_link: Volver
-      code: 'Código de la propuesta:'
       comments:
         one: 1 Comentario
         other: "%{count} Comentarios"

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -69,7 +69,6 @@ feature 'Proposals' do
     visit proposal_path(proposal)
 
     expect(page).to have_content proposal.title
-    expect(page).to have_content proposal.code
     expect(page).to have_content "http://external_documention.es"
     expect(page).to have_content proposal.author.name
     expect(page).to have_content I18n.l(proposal.created_at.to_date)


### PR DESCRIPTION
# What and Why

I have added extra information to the proposals show page:
- Positive/Negative comments counter
- Related meetings list

We don't have graphical information about `categories` and `subcategories` for now.
# QA

Visit proposal's page and check information. You may need to repopulate database to create meetings.
# GIF Tax

![](https://media.giphy.com/media/8VR88d4XXCdBS/giphy.gif)
