### PR TITLE
Remove description from subcategory picker and add info link

### DIFF
--- a/app/assets/javascripts/components/subcategory_picker.es6.jsx
+++ b/app/assets/javascripts/components/subcategory_picker.es6.jsx
@@ -18,8 +18,7 @@ class SubcategoryPicker extends React.Component {
         <li className={classNames.join(' ')}
             key={subcategory.id}
             onClick={() => component.select(subcategory)}>
-          {subcategory.name}
-          <div dangerouslySetInnerHTML={{__html: subcategory.description }}></div>
+          {subcategory.name} <a href={`/categories#subcategory_${subcategory.id}`} target="_blank"><i className="fa fa-info-circle"></i></a>
         </li>
       );
     });


### PR DESCRIPTION
# What and why

In production we detected an usability issue when adding new proposals. The subcategory description is too long to be displayed in the proposals form.

I have removed the description and added an info link.
# QA

Try to create a new proposal and select one Axis. Subcategory description should not appear.
# GIF Tax

![](https://media.giphy.com/media/uwCP3mfWCfn56/giphy.gif)
