### PR TITLE
Add friendly urls for proposals and meetings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ gem "faker"
 
 gem 'rails-i18n'
 gem 'active_model_serializers'
+gem 'friendly_id', '~> 5.1.0'
 
 # React gems
 gem 'react-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
       activesupport (~> 4.1)
       railties (~> 4.1)
       tzinfo (~> 1.2, >= 1.2.2)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)
@@ -554,6 +556,7 @@ DEPENDENCIES
   foreman
   foundation-rails
   foundation_rails_helper
+  friendly_id (~> 5.1.0)
   fuubar
   groupdate
   heroku-deflater

--- a/app/assets/javascripts/components/meetings_list.es6.jsx
+++ b/app/assets/javascripts/components/meetings_list.es6.jsx
@@ -18,8 +18,8 @@ class MeetingsList extends React.Component {
           {
             meetings.map((meeting) => {
               return (
-                <li className="meeting" key={ `meeting_${meeting.id}` } >
-                  <a href={`/meetings/${meeting.id}`} className="meeting-title" >
+                <li className="meeting" key={ `meeting_${meeting.slug}` } >
+                  <a href={`/meetings/${meeting.slug}`} className="meeting-title" >
                     { meeting.title }
                   </a>
                   <div className="tags">

--- a/app/assets/javascripts/components/meetings_map.es6.jsx
+++ b/app/assets/javascripts/components/meetings_map.es6.jsx
@@ -66,7 +66,7 @@ class MeetingsMap extends React.Component {
         marker.addListener('click', () => {
           let infoWindow = new google.maps.InfoWindow({
               content: `<div class="meeting-infowindow">
-                          <a href="/meetings/${meeting.id}" class="meeting-title">${meeting.title}</a>
+                          <a href="/meetings/${meeting.slug}" class="meeting-title">${meeting.title}</a>
                           <p class="tags"><span class="radius secondary label">${meeting.held_at}</span></p>
                           <div>${ meeting.description }</div>
                         </div>`

--- a/app/helpers/meetings_directory_helper.rb
+++ b/app/helpers/meetings_directory_helper.rb
@@ -22,6 +22,7 @@ module MeetingsDirectoryHelper
     meetings.map do |meeting|
       {
         id: meeting.id,
+        slug: meeting.slug,
         title: meeting.title,
         description: meeting.description,
         address: meeting.address,

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -40,7 +40,7 @@ class Meeting < ActiveRecord::Base
     ranked_by: '(:tsearch)'
   }
 
-  friendly_id :title, use: :slugged
+  friendly_id :title, use: [:slugged, :finders]
 
   def searchable_values
     values = {

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -1,4 +1,5 @@
 class Meeting < ActiveRecord::Base
+  extend FriendlyId
   include PgSearch
   include SearchCache
   include Categorizable
@@ -38,6 +39,8 @@ class Meeting < ActiveRecord::Base
     ignoring: :accents,
     ranked_by: '(:tsearch)'
   }
+
+  friendly_id :title, use: :slugged
 
   def searchable_values
     values = {

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -69,7 +69,7 @@ class Proposal < ActiveRecord::Base
     order_within_rank: "proposals.cached_votes_up DESC"
   }
 
-  friendly_id :title, use: :slugged
+  friendly_id :title, use: [:slugged, :finders]
 
   def searchable_values
     values = {

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -2,6 +2,7 @@ class Proposal < ActiveRecord::Base
 
   DISTRICTS = YAML::load_file("#{Rails.root}/config/districts.yml")["districts"].to_a.map(&:reverse).map {|a,b| [a.to_s, b.to_s]}.sort
 
+  extend FriendlyId
   include Flaggable
   include Taggable
   include Conflictable
@@ -67,6 +68,8 @@ class Proposal < ActiveRecord::Base
     ranked_by: '(:tsearch)',
     order_within_rank: "proposals.cached_votes_up DESC"
   }
+
+  friendly_id :title, use: :slugged
 
   def searchable_values
     values = {

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20160128145643_create_friendly_id_slugs.rb
+++ b/db/migrate/20160128145643_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20160128145954_add_slug_to_proposals.rb
+++ b/db/migrate/20160128145954_add_slug_to_proposals.rb
@@ -1,0 +1,6 @@
+class AddSlugToProposals < ActiveRecord::Migration
+  def change
+    add_column :proposals, :slug, :string
+    add_index :proposals, :slug, unique: true
+  end
+end

--- a/db/migrate/20160128150007_add_slug_to_meetings.rb
+++ b/db/migrate/20160128150007_add_slug_to_meetings.rb
@@ -1,0 +1,6 @@
+class AddSlugToMeetings < ActiveRecord::Migration
+  def change
+    add_column :meetings, :slug, :string
+    add_index :meetings, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160125092947) do
+ActiveRecord::Schema.define(version: 20160128150007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -164,6 +164,19 @@ ActiveRecord::Schema.define(version: 20160125092947) do
   add_index "flags", ["user_id", "flaggable_type", "flaggable_id"], name: "access_inappropiate_flags", using: :btree
   add_index "flags", ["user_id"], name: "index_flags_on_user_id", using: :btree
 
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string   "slug",                      null: false
+    t.integer  "sluggable_id",              null: false
+    t.string   "sluggable_type", limit: 50
+    t.string   "scope"
+    t.datetime "created_at"
+  end
+
+  add_index "friendly_id_slugs", ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, using: :btree
+  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", using: :btree
+  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
+  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
+
   create_table "geozones", force: :cascade do |t|
     t.string   "name"
     t.string   "html_map_coordinates"
@@ -219,8 +232,10 @@ ActiveRecord::Schema.define(version: 20160125092947) do
     t.integer  "subcategory_id"
     t.string   "scope",             default: "district"
     t.integer  "district"
+    t.string   "slug"
   end
 
+  add_index "meetings", ["slug"], name: "index_meetings_on_slug", unique: true, using: :btree
   add_index "meetings", ["tsv"], name: "index_meetings_on_tsv", using: :gin
 
   create_table "meetings_proposals", force: :cascade do |t|
@@ -281,6 +296,7 @@ ActiveRecord::Schema.define(version: 20160125092947) do
     t.string   "scope",                        default: "district"
     t.integer  "district"
     t.boolean  "official",                     default: false
+    t.string   "slug"
   end
 
   add_index "proposals", ["author_id", "hidden_at"], name: "index_proposals_on_author_id_and_hidden_at", using: :btree
@@ -290,6 +306,7 @@ ActiveRecord::Schema.define(version: 20160125092947) do
   add_index "proposals", ["hidden_at"], name: "index_proposals_on_hidden_at", using: :btree
   add_index "proposals", ["hot_score"], name: "index_proposals_on_hot_score", using: :btree
   add_index "proposals", ["question"], name: "index_proposals_on_question", using: :btree
+  add_index "proposals", ["slug"], name: "index_proposals_on_slug", unique: true, using: :btree
   add_index "proposals", ["summary"], name: "index_proposals_on_summary", using: :btree
   add_index "proposals", ["title"], name: "index_proposals_on_title", using: :btree
   add_index "proposals", ["tsv"], name: "index_proposals_on_tsv", using: :gin

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -46,7 +46,7 @@ feature 'Proposals' do
       expect(page).to have_content user.name
       expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
 
-      expect(current_path).to eq(management_proposal_path(Proposal.last))
+      expect(current_path).to eq(management_proposal_path(Proposal.last.id))
     end
 
     scenario "Should not allow unverified users to create proposals" do


### PR DESCRIPTION
# What and why

For SEO purposes I added friendly urls for both meetings and proposals. I have used the `FriendlyId` gem. It works fine.
Since `title` is not unique it generates weird urls for proposal and meetings with the same title like this:
`/meetings/corrupti-nulla-culpa-est-qui`
`/meetings/corrupti-nulla-culpa-est-qui-df17c8eb-652e-4973-9a32-707536bbb239`
# QA

For existing data you must call this to regenerate slugs: `find_each(&:save)`
Try to visit a proposal or meeting show page and check the url.
# GIF Tax

![](https://media.giphy.com/media/TmVqs1EEKnFjq/giphy.gif)
