### PR TITLE
Add extra information to proposal views

### DIFF
--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -27,7 +27,6 @@ class ProposalFilters extends React.Component {
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) }>
           <FilterOption filterName="official" />
           <FilterOption filterName="citizenship" />
-          <FilterOption filterName="meetings" />
         </FilterOptionGroup>
         <ScopeFilterOptionGroup 
           filterGroupValue={this.state.filters.get('scope')} 
@@ -46,6 +45,13 @@ class ProposalFilters extends React.Component {
           subcategories={this.props.subcategories}
           filterGroupValue={this.state.filters.get('subcategory_id')}
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) } />
+        <FilterOptionGroup 
+          filterGroupName="other" 
+          filterGroupValue={this.state.filters.get('other')}
+          isExclusive={true}
+          onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) }>
+          <FilterOption filterName="meetings" />
+        </FilterOptionGroup>
         <TagCloudFilter 
           currentTags={this.state.tags} 
           tagCloud={this.props.filter.tag_cloud} 

--- a/app/services/resource_filter.rb
+++ b/app/services/resource_filter.rb
@@ -1,5 +1,5 @@
 class ResourceFilter
-  IGNORE_FILTER_PARAMS = ["source"]
+  IGNORE_FILTER_PARAMS = ["source", "other"]
   attr_reader :collection, :tag_cloud, :search_filter, :tag_filter, :params
 
   def initialize(resources, params={})
@@ -62,7 +62,7 @@ class ResourceFilter
         end
       end
 
-      if @params["source"] && @params["source"].include?("meetings")
+      if @params["other"] && @params["other"].include?("meetings")
         proposal_in_meetings_ids = MeetingProposal.pluck(:proposal_id).uniq
         @collection = @collection.where(id: proposal_in_meetings_ids)
       end

--- a/app/views/proposals/_meta.html.erb
+++ b/app/views/proposals/_meta.html.erb
@@ -1,0 +1,11 @@
+<div class="meta">
+  <% if proposal.scope == "city" %>
+    <%= I18n.t("components.filter_option.city") %>
+  <% else %>
+    <%= proposal.decorate.district_name %>
+  <% end %>
+  <span class="bullet">&nbsp;&bull;&nbsp;</span>
+  <%= proposal.category.decorate.name %>
+  <span class="bullet">&nbsp;&bull;&nbsp;</span>
+  <%= proposal.subcategory.decorate.name %>
+</div>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -15,29 +15,31 @@
             <span class="bullet">&nbsp;&bull;&nbsp;</span>
             <%= l proposal.created_at.to_date %>
 
-            <% if proposal.author.hidden? || proposal.author.erased? %>
-              <span class="bullet">&nbsp;&bull;&nbsp;</span>
-              <span class="author">
-                <%= t("proposals.show.author_deleted") %>
-              </span>
-            <% else %>
-              <span class="bullet">&nbsp;&bull;&nbsp;</span>
-              <span class="author">
-                <%= proposal.author.name %>
-              </span>
-              <% if proposal.author.official? %>
+            <% unless proposal.official? %>
+              <% if proposal.author.hidden? || proposal.author.erased? %>
                 <span class="bullet">&nbsp;&bull;&nbsp;</span>
-                <span class="label round level-<%= proposal.author.official_level %>">
-                  <%= proposal.author.official_position %>
+                <span class="author">
+                  <%= t("proposals.show.author_deleted") %>
+                </span>
+              <% else %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <span class="author">
+                  <%= proposal.author.name %>
+                </span>
+                <% if proposal.author.official? %>
+                  <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                  <span class="label round level-<%= proposal.author.official_level %>">
+                    <%= proposal.author.official_position %>
+                  </span>
+                <% end %>
+              <% end %>
+
+              <% if proposal.author.verified_organization? %>
+                <span class="bullet">&nbsp;&bull;&nbsp;</span>
+                <span class="label round is-association">
+                  <%= t("shared.collective") %>
                 </span>
               <% end %>
-            <% end %>
-
-            <% if proposal.author.verified_organization? %>
-              <span class="bullet">&nbsp;&bull;&nbsp;</span>
-              <span class="label round is-association">
-                <%= t("shared.collective") %>
-              </span>
             <% end %>
           </p>
           <div class="proposal-description">

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -46,17 +46,7 @@
             </p>
             <div class="truncate"></div>
           </div>
-          <div class="meta">
-            <% if proposal.scope == "city" %>
-              <%= I18n.t("components.filter_option.city") %>
-            <% else %>
-              <%= proposal.decorate.district_name %>
-            <% end %>
-            <span class="bullet">&nbsp;&bull;&nbsp;</span>
-            <%= proposal.category.decorate.name %>
-            <span class="bullet">&nbsp;&bull;&nbsp;</span>
-            <%= proposal.subcategory.decorate.name %>
-          </div>
+          <%= render "meta", proposal: proposal %>
           <%= render "shared/tags", taggable: proposal, limit: 5 %>
         </div>
       </div>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -60,6 +60,7 @@
           </div>
         <% end %>
 
+        <%= render "meta", proposal: @proposal %>
         <%= render 'shared/tags', taggable: @proposal %>
 
         <div class="js-moderator-proposal-actions margin">

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -29,7 +29,9 @@
         <% end %>
 
         <div class="proposal-info">
-          <%= render '/shared/author_info', resource: @proposal %>
+          <% unless proposal.official? %>
+            <%= render '/shared/author_info', resource: @proposal %>
+          <% end %>
 
           <span class="bullet">&nbsp;&bull;&nbsp;</span>
           <%= l @proposal.created_at.to_date %>

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -15,6 +15,7 @@ ca:
     filter_option_group:
       category_id: Eix
       district: Districte
+      other: Altres
       scope: "Àmbit"
       source: Origen
       subcategory_id: Línia estratègica

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -15,6 +15,7 @@ en:
     filter_option_group:
       category_id: Axis
       district: District
+      other: Other
       scope: Scope
       source: Source
       subcategory_id: Strategic Line

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -15,6 +15,7 @@ es:
     filter_option_group:
       category_id: Eje
       district: Distrito
+      other: Otros
       scope: "Ámbito"
       source: Origen
       subcategory_id: Línea estratégica

--- a/config/locales/errors.ca.yml
+++ b/config/locales/errors.ca.yml
@@ -1,10 +1,11 @@
+---
 ca:
   errors:
     internal_server_error:
+      description: Els nostres tècnics ja han estat informats. Si us plau, reintenta-ho passat uns minuts.
       title: Sembla que hi ha hagut un petit problema!
-      description: "Els nostres tècnics ja han estat informats. Si us plau, reintenta-ho passat uns minuts."
-    not_found:
-      title: No s'ha trobat la pàgina que busques!
-      description: "Aquesta adreça és incorrecta o ha esta eliminada."
     links:
-      proposals: "Entra i participa"
+      proposals: Entra i participa
+    not_found:
+      description: Aquesta adreça és incorrecta o ha esta eliminada.
+      title: No s'ha trobat la pàgina que busques!


### PR DESCRIPTION
# What and why

I have included small tasks in this pull request:
- If proposal is official the author information is not shown.
- I added a partial called `meta` with `scope`, `category` and `subcategory` information
- Add `meetings` filters to a filter group called Other.
# QA

Just repopulate the database and check if the infromation is diplayed correctly.
# GIF Tax

![](https://media.giphy.com/media/J47tA95IMBlra/giphy.gif)
