### PR TITLE
Proposal tags feature flag

### DIFF
--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -52,11 +52,20 @@ class ProposalFilters extends React.Component {
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) }>
           <FilterOption filterName="meetings" />
         </FilterOptionGroup>
+        {this.renderTagCloudFilter()}
+      </form>
+    )
+  }
+
+  renderTagCloudFilter() {
+    if (this.props.tagsEnabled) {
+      return (
         <TagCloudFilter 
           currentTags={this.state.tags} 
           tagCloud={this.props.filter.tag_cloud} 
           onSetFilterTags={(tags) => this.filterService.setFilterTags(tags)} />
-      </form>
-    )
+      )
+    }
+    return null;
   }
 }

--- a/app/helpers/proposal_filters_helper.rb
+++ b/app/helpers/proposal_filters_helper.rb
@@ -6,7 +6,8 @@ module ProposalFiltersHelper
       filterUrl: proposals_url,
       districts: Proposal::DISTRICTS,
       categories: serialized_categories,
-      subcategories: serialized_subcategories
+      subcategories: serialized_subcategories,
+      tagsEnabled: feature?(:proposal_tags)
     ) 
   end
 end

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -31,16 +31,18 @@
       <%= f.text_field :external_url, placeholder: t("proposals.form.proposal_external_url"), label: false %>
     </div>
 
-    <div class="small-12 column">
-      <%= f.label :tag_list, t("proposals.form.tags_label") %>
-      <p class="note"><%= t("proposals.form.tags_instructions") %></p>
-      <span class="tags">
-        <% @featured_tags.each do |tag| %>
-          <a class="js-add-tag-link"><%= tag.name %></a>
-        <% end %>
-      </span>
-      <%= f.text_field :tag_list, value: @proposal.tag_list.to_s, label: false, placeholder: t("proposals.form.tags_placeholder"), class: 'js-tag-list' %>
-    </div>
+    <% if feature?(:proposal_tags) %>
+      <div class="small-12 column">
+        <%= f.label :tag_list, t("proposals.form.tags_label") %>
+        <p class="note"><%= t("proposals.form.tags_instructions") %></p>
+        <span class="tags">
+          <% @featured_tags.each do |tag| %>
+            <a class="js-add-tag-link"><%= tag.name %></a>
+          <% end %>
+        </span>
+        <%= f.text_field :tag_list, value: @proposal.tag_list.to_s, label: false, placeholder: t("proposals.form.tags_placeholder"), class: 'js-tag-list' %>
+      </div>
+    <% end %>
 
     <% if current_user.unverified? %>
       <div class="small-12 column">

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -49,7 +49,9 @@
             <div class="truncate"></div>
           </div>
           <%= render "proposals/meta", proposal: proposal %>
-          <%= render "shared/tags", taggable: proposal, limit: 5 %>
+          <% if feature?(:proposal_tags) %>
+            <%= render "shared/tags", taggable: proposal, limit: 5 %>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -63,7 +63,9 @@
         <% end %>
 
         <%= render "proposals/meta", proposal: @proposal %>
-        <%= render 'shared/tags', taggable: @proposal %>
+        <% if feature?(:proposal_tags) %>
+          <%= render 'shared/tags', taggable: @proposal %>
+        <% end %>
 
         <div class="js-moderator-proposal-actions margin">
           <%= render 'proposals/actions', proposal: @proposal %>

--- a/config/application.yml
+++ b/config/application.yml
@@ -52,6 +52,7 @@ defaults: &defaults
 
   feature.debates: false
   feature.spending_proposals: false
+  feature.proposal_tags: false
 
 development:
   <<: *defaults

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -5,7 +5,7 @@ feature 'Proposals' do
   let!(:subcategory) { create(:subcategory) }
   let(:category) { subcategory.category }
 
-  before(:all) do
+  before(:each) do
     Setting['feature.proposal_tags'] = true
   end
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -5,6 +5,10 @@ feature 'Proposals' do
   let!(:subcategory) { create(:subcategory) }
   let(:category) { subcategory.category }
 
+  before(:all) do
+    Setting['feature.proposal_tags'] = true
+  end
+
   scenario 'Index' do
     featured_proposals = create_featured_proposals
     proposals = [create(:proposal), create(:proposal), create(:proposal)]


### PR DESCRIPTION
# What and why

We don't need `tags` for proposals so I have put them behind a feature flat.
# QA

Visit proposal pages and check if `tags` are hidden.
# GIF tax

![](https://media.giphy.com/media/oNhDOS8SauQSI/giphy.gif)
# TODOs
- [x] Remove tag cloud filter
- [x] Remove tags from proposal views
- [x] Remove tags from for
- [x] Tests
