### PR TITLE
Remove view proposals from category in documents

### DIFF
--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,8 +1,3 @@
 <h2 id="<%= dom_id(category) %>"><%= category.name_with_code %></h2>
 <p><%= category.description.html_safe %></p>
-
-<p class="clearfix see-proposals">
-  <%= link_to t('categories.filter'), category.proposals_path %>
-</p>
-
 <%= render partial: 'subcategory', collection: category.subcategories %>


### PR DESCRIPTION
# What and why

We don't need those buttons because each category have subcategories and that's enough filtering buttons.
# QA

Visit documents page and check if "View proposals" button only appear in subcategories.
# GIF tax

![](https://media.giphy.com/media/gT5xXlsYWJCG4/giphy.gif)
