### PR TITLE
Renaming menus, titles and filters

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -33,7 +33,7 @@ ca:
     edit:
       form:
         submit_button: Actualitzar eix
-    filter: Veure propostes
+    filter: Veure propostes d'actuació
     form:
       category_description: Descripció
       category_name: Nom
@@ -41,7 +41,7 @@ ca:
     new:
       form:
         submit_button: Crear eix
-    title: Documents
+    title: Pla Municipal
   comments:
     comment:
       admin: Administrador
@@ -130,7 +130,7 @@ ca:
         submit_button: Comença un debat
       info: Si el que vols és fer una proposta, aquesta és la secció incorrecta, entra en %{info_link}.
       info_link: crear nova proposta
-      more_info: Més informació
+      more_info: Informa't
       recommendation_four: Gaudeix d'aquest espai, de les veus que l'omplen, també és teu.
       recommendation_one: No escriguis el títol del debat o frases senceres en majúscules. A internet això es considera cridar. I a ningú li agrada que li cridin.
       recommendation_three: Les crítiques despietades són molt benvingudes. Aquest és un espai de pensament. Però et recomanem conservar l'elegància i la intel·ligència. El món és millor amb elles presents.
@@ -180,16 +180,16 @@ ca:
     footer:
       accessibility: Accessibilitat
       conditions: Condicions d'ús
-      more_info: Més informació
+      more_info: Informa't
       privacy: Política de privacitat
     header:
       administration: Administrar
       debates: Debats
       external_link_blog: Notícies
       locale: 'Idioma:'
-      meetings: Cites
+      meetings: Cites presencials
       moderation: Moderar
-      more_information: Més informació
+      more_information: Informa't
       my_account_link: El meu compte
       my_activity_link: La meva activitat
       new_notifications:

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -10,8 +10,8 @@ ca:
       citizenship: Ciutadania
       city: Tota la ciutat
       district: Un districte
-      meetings: Trobades presencials
-      official: Programa (Ajuntament)
+      meetings: Cites presencials
+      official: Ajuntament
     filter_option_group:
       category_id: Eix
       district: Districte

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -11,7 +11,7 @@ en:
       city: Whole city
       district: A district
       meetings: Meetings
-      official: Program (Town Hall)
+      official: Town Hall
     filter_option_group:
       category_id: Axis
       district: District

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -11,7 +11,7 @@ es:
       city: Toda la ciudad
       district: Un distrito
       meetings: Encuentros presenciales
-      official: Programa (Ayuntamiento)
+      official: Ayuntamiento
     filter_option_group:
       category_id: Eje
       district: Distrito

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,7 @@ en:
     edit:
       form:
         submit_button: Update axis
-    filter: Show proposals
+    filter: View acting proposals
     form:
       category_description: Description
       category_name: Name
@@ -41,7 +41,7 @@ en:
     new:
       form:
         submit_button: Create axis
-    title: Documents
+    title: City Plan
   comments:
     comment:
       admin: Administrator
@@ -130,7 +130,7 @@ en:
         submit_button: Start a debate
       info: If you want to make a proposal, this is the wrong section, enter %{info_link}.
       info_link: create new proposal
-      more_info: More information
+      more_info: Information
       recommendation_four: Enjoy this space and the voices that fill it. It belongs to you too.
       recommendation_one: Do not use capital letters for the debate title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at.
       recommendation_three: Ruthless criticism is very welcome. This is a space for reflection. But we recommend that you stick to elegance and intelligence. The world is a better place with these virtues in it.
@@ -180,16 +180,16 @@ en:
     footer:
       accessibility: Accessibility
       conditions: Terms and conditions of use
-      more_info: More information
+      more_info: Information
       privacy: Privacy Policy
     header:
       administration: Administration
       debates: Debates
       external_link_blog: News
       locale: 'Language:'
-      meetings: Meetings
+      meetings: Presencial meetings
       moderation: Moderation
-      more_information: More information
+      more_information: Information
       my_account_link: My account
       my_activity_link: My activity
       new_notifications:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -33,7 +33,7 @@ es:
     edit:
       form:
         submit_button: Actualizar eje
-    filter: Ver propuestas
+    filter: Ver propuestas de actuación
     form:
       category_description: Descripción
       category_name: Nombre
@@ -41,7 +41,7 @@ es:
     new:
       form:
         submit_button: Crear eje
-    title: Documentos
+    title: Plan Municipal
   comments:
     comment:
       admin: Administrador
@@ -130,7 +130,7 @@ es:
         submit_button: Empieza un debate
       info: Si lo que quieres es hacer una propuesta, esta es la sección incorrecta, entra en %{info_link}.
       info_link: crear nueva propuesta
-      more_info: Más información
+      more_info: Informate 
       recommendation_four: Disfruta de este espacio, de las voces que lo llenan, también es tuyo.
       recommendation_one: No escribas el título del debate o frases enteras en mayúsculas. En internet eso se considera gritar. Y a nadie le gusta que le griten.
       recommendation_three: Las críticas despiadadas son muy bienvenidas. Este es un espacio de pensamiento. Pero te recomendamos conservar la elegancia y la inteligencia. El mundo es mejor con ellas presentes.
@@ -180,14 +180,14 @@ es:
     footer:
       accessibility: Accesibilidad
       conditions: Condiciones de uso
-      more_info: Más información
+      more_info: Informate
       privacy: Política de privacidad
     header:
       administration: Administrar
       debates: Debates
       external_link_blog: Noticias
       locale: 'Idioma:'
-      meetings: Citas
+      meetings: Citas presenciales
       moderation: Moderar
       more_information: Más información
       my_account_link: Mi cuenta


### PR DESCRIPTION
# What and why

Renaming menus, titles and filters that changed on the last couple of days. 
# QA

Visit the menu, instead of Cites, Documents and such you'll see "Cites presencials",  "Pla Munnicipal", etc. 
# GIF tax

![](https://media.giphy.com/media/OJZ2h4G8hmO9G/giphy.gif)
