### PR TITLE
Fixing analytics for SSL

### DIFF
--- a/app/views/layouts/_scripts.html.erb
+++ b/app/views/layouts/_scripts.html.erb
@@ -2,7 +2,7 @@
 <link href='https://fonts.googleapis.com/css?family=Vollkorn' rel='stylesheet' type='text/css'>
 
 <% if Rails.application.secrets.analytics_enabled %>
-  <script type='text/javascript' charset='utf-8' src='http://www.barcelona.cat/assets/core/javascripts/core.js'></script> 
+  <script type='text/javascript' charset='utf-8' src='https://w9.barcelona.cat/assets/core/javascripts/core.js'></script> 
   <script type='text/javascript'>bcn.statistics({keys: ['UA-61717963-24'] });</script>
 <% end %>
 


### PR DESCRIPTION
# What and why

Fixing analytics for SSL
# QA

Opening JS console shouldn't see any error. Seeing the SSL icon should be OK (no mixed content). 
# GIF tax

![](https://media.giphy.com/media/8m6ZzP5yEZGlG/giphy.gif)
