### PR TITLE
Remove unused user action copy

### DIFF
--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -80,14 +80,6 @@
               <% end %>
               <%= t("account.show.user_permission_support_proposal") %>
             </li>
-            <li>
-              <% if current_user.level_three_verified? %>
-                <i class="icon-check"></i>
-              <% else %>
-                <i class="icon-x"></i>
-              <% end %>
-              <%= t("account.show.user_permission_votes") %>
-            </li>
           </ul>
 
           <p>

--- a/app/views/verification/residence/new.html.erb
+++ b/app/views/verification/residence/new.html.erb
@@ -16,7 +16,6 @@
         <li><i class="icon-check"></i>&nbsp;<%= t("verification.user_permission_debates") %></li>
         <li><i class="icon-check"></i>&nbsp;<%= t("verification.user_permission_proposal") %></li>
         <li><i class="icon-check"></i>&nbsp;<%= t("verification.user_permission_support_proposal") %></li>
-        <li><i class="icon-check"></i>&nbsp;<%= t("verification.user_permission_votes") %></li>
       </ul>
     </div>
 

--- a/app/views/welcome/welcome.html.erb
+++ b/app/views/welcome/welcome.html.erb
@@ -8,7 +8,6 @@
     <li><i class="icon-check"></i>&nbsp;<%= t("welcome.welcome.user_permission_debates") %></li>
     <li><i class="icon-check"></i>&nbsp;<%= t("welcome.welcome.user_permission_proposal") %></li>
     <li><i class="icon-x"></i>&nbsp;<%= t("welcome.welcome.user_permission_support_proposal") %></li>
-    <li><i class="icon-x"></i>&nbsp;<%= t("welcome.welcome.user_permission_votes") %></li>
   </ul>
 
   <p>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -23,7 +23,6 @@ ca:
       user_permission_title: Participació
       user_permission_verify: Per poder realitzar totes les accions verifica el teu compte.
       user_permission_verify_info: "* Només usuaris empadronats al municipi de Barcelona."
-      user_permission_votes: Participar en les votacions finals *
       username_label: Nom d'usuari
       verified_account: Compte verificat
       verify_my_account: Verificar el meu compte
@@ -483,4 +482,3 @@ ca:
       user_permission_verify: Per poder realitzar totes les accions %{verify}.
       user_permission_verify_info: "* Només usuaris empadronats al municipi de Barcelona."
       user_permission_verify_url: verifica el teu compte
-      user_permission_votes: Participar en les votacions finals *

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,6 @@ en:
       user_permission_title: Participation
       user_permission_verify: To perform all the actions verify your account.
       user_permission_verify_info: "* Only for users on the Barcelona City Census."
-      user_permission_votes: Participate on final voting
       username_label: Username
       verified_account: Account verified
       verify_my_account: Verify my account
@@ -487,4 +486,3 @@ en:
       user_permission_verify: To perform all the actions %{verify}.
       user_permission_verify_info: "* Only for users on the Barcelona City Census."
       user_permission_verify_url: verify your account
-      user_permission_votes: Participate on final voting

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -23,7 +23,6 @@ es:
       user_permission_title: Participación
       user_permission_verify: Para poder realizar todas las acciones verifica tu cuenta.
       user_permission_verify_info: "* Sólo usuarios empadronados en el municipio de Barcelona."
-      user_permission_votes: Participar en las votaciones finales*
       username_label: Nombre de usuario
       verified_account: Cuenta verificada
       verify_my_account: Verificar mi cuenta
@@ -487,4 +486,3 @@ es:
       user_permission_verify: Para poder realizar todas las acciones %{verify}.
       user_permission_verify_info: "* Sólo usuarios empadronados en el municipio de Barcelona."
       user_permission_verify_url: verifica tu cuenta
-      user_permission_votes: Participar en las votaciones finales*


### PR DESCRIPTION
# What and why

Our users cannot participate in the finale voting system so I have removed the copy.
# QA

Register a new user and check there is only three actions.
# GIF tax

![](https://media.giphy.com/media/yvgaJzI8Q01Ow/giphy.gif)
