### PR TITLE
Remove video url for proposals

### DIFF
--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -52,11 +52,20 @@ class ProposalFilters extends React.Component {
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.filterService.changeFilterGroup(filterGroupName, filterGroupValue) }>
           <FilterOption filterName="meetings" />
         </FilterOptionGroup>
+        {this.renderTagCloudFilter()}
+      </form>
+    )
+  }
+
+  renderTagCloudFilter() {
+    if (this.props.tagsEnabled) {
+      return (
         <TagCloudFilter 
           currentTags={this.state.tags} 
           tagCloud={this.props.filter.tag_cloud} 
           onSetFilterTags={(tags) => this.filterService.setFilterTags(tags)} />
-      </form>
-    )
+      )
+    }
+    return null;
   }
 }

--- a/app/helpers/proposal_filters_helper.rb
+++ b/app/helpers/proposal_filters_helper.rb
@@ -6,7 +6,8 @@ module ProposalFiltersHelper
       filterUrl: proposals_url,
       districts: Proposal::DISTRICTS,
       categories: serialized_categories,
-      subcategories: serialized_subcategories
+      subcategories: serialized_subcategories,
+      tagsEnabled: feature?(:proposal_tags)
     ) 
   end
 end

--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -15,7 +15,7 @@
           <% if proposal.external_url.present? %>
             <p><%= text_with_links proposal.external_url %></p>
           <% end %>
-          <% if proposal.video_url.present? %>
+          <% if feature?(:proposal_video_url) && proposal.video_url.present? %>
             <p><%= text_with_links proposal.video_url %></p>
           <% end %>
         </div>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -31,16 +31,18 @@
       <%= f.text_field :external_url, placeholder: t("proposals.form.proposal_external_url"), label: false %>
     </div>
 
-    <div class="small-12 column">
-      <%= f.label :tag_list, t("proposals.form.tags_label") %>
-      <p class="note"><%= t("proposals.form.tags_instructions") %></p>
-      <span class="tags">
-        <% @featured_tags.each do |tag| %>
-          <a class="js-add-tag-link"><%= tag.name %></a>
-        <% end %>
-      </span>
-      <%= f.text_field :tag_list, value: @proposal.tag_list.to_s, label: false, placeholder: t("proposals.form.tags_placeholder"), class: 'js-tag-list' %>
-    </div>
+    <% if feature?(:proposal_tags) %>
+      <div class="small-12 column">
+        <%= f.label :tag_list, t("proposals.form.tags_label") %>
+        <p class="note"><%= t("proposals.form.tags_instructions") %></p>
+        <span class="tags">
+          <% @featured_tags.each do |tag| %>
+            <a class="js-add-tag-link"><%= tag.name %></a>
+          <% end %>
+        </span>
+        <%= f.text_field :tag_list, value: @proposal.tag_list.to_s, label: false, placeholder: t("proposals.form.tags_placeholder"), class: 'js-tag-list' %>
+      </div>
+    <% end %>
 
     <% if current_user.unverified? %>
       <div class="small-12 column">

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -20,11 +20,13 @@
       <%= category_picker(@proposal) %>
     </div>
 
-    <div class="small-12 column">
-      <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
-      <p class="note"><%= t("proposals.form.proposal_video_url_note") %></p>
-      <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false %>
-    </div>
+    <% if feature?(:proposal_video_url) %>
+      <div class="small-12 column">
+        <%= f.label :video_url, t("proposals.form.proposal_video_url") %>
+        <p class="note"><%= t("proposals.form.proposal_video_url_note") %></p>
+        <%= f.text_field :video_url, placeholder: t("proposals.form.proposal_video_url"), label: false %>
+      </div>
+    <% end %>
 
     <div class="small-12 column">
       <%= f.label :external_url, t("proposals.form.proposal_external_url") %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -49,7 +49,9 @@
             <div class="truncate"></div>
           </div>
           <%= render "proposals/meta", proposal: proposal %>
-          <%= render "shared/tags", taggable: proposal, limit: 5 %>
+          <% if feature?(:proposal_tags) %>
+            <%= render "shared/tags", taggable: proposal, limit: 5 %>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -63,7 +63,9 @@
         <% end %>
 
         <%= render "proposals/meta", proposal: @proposal %>
-        <%= render 'shared/tags', taggable: @proposal %>
+        <% if feature?(:proposal_tags) %>
+          <%= render 'shared/tags', taggable: @proposal %>
+        <% end %>
 
         <div class="js-moderator-proposal-actions margin">
           <%= render 'proposals/actions', proposal: @proposal %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -56,7 +56,7 @@
           </div>
         <% end %>
 
-        <% if @proposal.video_url.present? %>
+        <% if feature?(:proposal_video_url) && @proposal.video_url.present? %>
           <div class="video-link">
             <%= text_with_links @proposal.video_url %>
           </div>

--- a/config/application.yml
+++ b/config/application.yml
@@ -53,6 +53,7 @@ defaults: &defaults
   feature.debates: false
   feature.spending_proposals: false
   feature.proposal_tags: false
+  feature.proposal_video_url: false
 
 development:
   <<: *defaults

--- a/config/application.yml
+++ b/config/application.yml
@@ -52,6 +52,7 @@ defaults: &defaults
 
   feature.debates: false
   feature.spending_proposals: false
+  feature.proposal_tags: false
 
 development:
   <<: *defaults

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -7,6 +7,10 @@ feature 'Admin proposals' do
     login_as(admin.user)
   end
 
+  before :each do
+    Setting['feature.proposal_video_url'] = true
+  end
+
   scenario 'List shows all relevant info' do
     proposal = create(:proposal, :hidden)
     visit admin_proposals_path

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -7,6 +7,10 @@ feature 'Proposals' do
     login_as_manager
   end
 
+  before :each do
+    Setting['feature.proposal_video_url'] = true
+  end
+
   let!(:subcategory) { create(:subcategory) }
   let(:category) { subcategory.category }
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -7,6 +7,7 @@ feature 'Proposals' do
 
   before(:each) do
     Setting['feature.proposal_tags'] = true
+    Setting['feature.proposal_video_url'] = true
   end
 
   scenario 'Index' do

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -5,7 +5,7 @@ feature 'Proposals' do
   let!(:subcategory) { create(:subcategory) }
   let(:category) { subcategory.category }
 
-  before(:all) do
+  before(:each) do
     Setting['feature.proposal_tags'] = true
   end
 

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -5,6 +5,10 @@ feature 'Proposals' do
   let!(:subcategory) { create(:subcategory) }
   let(:category) { subcategory.category }
 
+  before(:all) do
+    Setting['feature.proposal_tags'] = true
+  end
+
   scenario 'Index' do
     featured_proposals = create_featured_proposals
     proposals = [create(:proposal), create(:proposal), create(:proposal)]


### PR DESCRIPTION
# What and why

We don't need proposal's video url for now so I decided to hide it using a feature flag.
# QA

Check if video url is not shown in any view
# GIF Tax

![](https://media.giphy.com/media/EGn6QuuvGO9BS/giphy.gif)
