### PR TITLE
Add puma worker killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,6 +134,7 @@ group :production do
   gem 'rack-attack'
   gem 'newrelic_rpm'
   gem 'puma'
+  gem 'puma_worker_killer'
   gem 'heroku-deflater'
   gem 'rails_12factor'
   gem 'rollbar', '~> 1.2.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
     gaffe (1.0.2)
       rails (>= 3.2.0)
     geocoder (1.2.14)
+    get_process_mem (0.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     groupdate (2.5.0)
@@ -317,6 +318,9 @@ GEM
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     puma (2.15.3)
+    puma_worker_killer (0.0.4)
+      get_process_mem (~> 0.2)
+      puma (~> 2.7)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -596,6 +600,7 @@ DEPENDENCIES
   pg_search
   poltergeist
   puma
+  puma_worker_killer
   quiet_assets
   rack-attack
   rack-cache

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,6 +8,18 @@ rackup      DefaultRackup
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
 
+before_fork do
+  if defined?(PumaWorkerKiller)
+    PumaWorkerKiller.config do |config|
+      config.ram           = 1024 # mb
+      config.frequency     = 5    # seconds
+      config.percent_usage = 0.98
+      config.rolling_restart_frequency = 12 * 3600 # 12 hours in seconds
+    end
+    PumaWorkerKiller.start
+  end
+end
+
 on_worker_boot do
   # Worker specific setup for Rails 4.1+
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -11,7 +11,7 @@ environment ENV['RACK_ENV'] || 'development'
 before_fork do
   if defined?(PumaWorkerKiller)
     PumaWorkerKiller.config do |config|
-      config.ram           = 1024 # mb
+      config.ram           = ENV["AVAILABLE_RAM"].try(:to_i) || 512 # mb
       config.frequency     = 5    # seconds
       config.percent_usage = 0.98
       config.rolling_restart_frequency = 12 * 3600 # 12 hours in seconds


### PR DESCRIPTION
This will keep our RAM usage under limit by killing processes that consume too much ram (after serving their requests, of course!).
