### PR TITLE
Parameterize smtp settings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,26 +74,26 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Rails.application.secrets.server_name }
   # config.action_mailer.asset_host = "https://#{Rails.application.secrets.server_name}"
 
-  if ENV["SENDGRID_USERNAME"]
-    config.action_mailer.smtp_settings = {
-      :address        => 'smtp.sendgrid.net',
-      :port           => '587',
-      :authentication => :plain,
-      :user_name      => ENV['SENDGRID_USERNAME'],
-      :password       => ENV['SENDGRID_PASSWORD'],
-      :domain         => 'heroku.com',
-      :enable_starttls_auto => true
+  config.action_mailer.smtp_settings = {
+    :address        => Rails.application.secrets.smtp_address,
+    :port           => Rails.application.secrets.smtp_port,
+    :authentication => Rails.application.secrets.smtp_authentication,
+    :user_name      => Rails.application.secrets.smtp_username,
+    :password       => Rails.application.secrets.smtp_password,
+    :domain         => Rails.application.secrets.smtp_domain,
+    :enable_starttls_auto => Rails.application.secrets.smtp_starttls_auto
+  }
+
+  if Rails.application.secrets.sendgrid
+    config.action_mailer.default_options = {
+      "X-SMTPAPI" => {
+        filters:  {
+          clicktrack: { settings: { enable: 0 } },
+          opentrack:  { settings: { enable: 0 } }
+        }
+      }.to_json
     }
   end
-
-  config.action_mailer.default_options = {
-    "X-SMTPAPI" => {
-      filters:  {
-        clicktrack: { settings: { enable: 0 } },
-        opentrack:  { settings: { enable: 0 } }
-      }
-    }.to_json
-  }
 
 
   if ENV["MEMCACHEDCLOUD_SERVERS"]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -33,6 +33,15 @@ default: &default
 
   analytics_enabled: false
 
+  sendgrid: <%= !ENV["SMTP_USERNAME"].blank? %>
+  smtp_username: <%= ENV["SMTP_USERNAME"] || ENV["SENDGRID_USERNAME"] %>
+  smtp_password: <%= ENV["SMTP_PASSWORD"] || ENV["SENDGRID_PASSWORD"] %>
+  smtp_address: <%= ENV["SMTP_ADDRESS"] || "smtp.sendgrid.net" %>
+  smtp_domain: <%= ENV["SMTP_DOMAIN"] || "heroku.com" %>
+  smtp_port: "587"
+  smtp_starttls_auto: true
+  smtp_authentication: "plain"
+
 development:
   <<: *default
   secret_key_base: "56792feef405a59b18ea7db57b4777e855103882b926413d4afdfb8c0ea8aa86ea6649da4e729c5f5ae324c0ab9338f789174cf48c544173bc18fdc3b14262e4"


### PR DESCRIPTION
This allows us to use any mail provider, but falls back to sendgrid.
