### PR TITLE
Changing limits for proposals

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -20,13 +20,13 @@ defaults: &defaults
   max_votes_for_debate_edit: 1000
 
   # Max votes where a proposal is still editable
-  max_votes_for_proposal_edit: 1000
+  max_votes_for_proposal_edit: 10
 
   # Prefix for the Proposal codes
   proposal_code_prefix: 'BCN'
 
   # Number of votes needed for proposal success
-  votes_for_proposal_success: 53726
+  votes_for_proposal_success: 100
 
   # Users with this email domain will automatically be marked as level 1 officials
   # Emails under the domain's subdomains will also be included


### PR DESCRIPTION
Changing limits for proposals: 

10 votes max for editing a proposal
100 votes max for considering a proposal successful
