### PR TITLE
Better implementation of resource filter

### DIFF
--- a/app/assets/javascripts/components/meetings_directory.es6.jsx
+++ b/app/assets/javascripts/components/meetings_directory.es6.jsx
@@ -4,6 +4,7 @@ class MeetingsDirectory extends React.Component {
     this.state = {
       meetings: this.props.meetings,
       filter: this.props.filter,
+      tagCloud: this.props.tagCloud,
       loading: false
     };
   }
@@ -20,8 +21,10 @@ class MeetingsDirectory extends React.Component {
               meetings={this.state.meetings} 
               categories={this.props.categories}
               subcategories={this.props.subcategories} 
+              tagCloud={this.state.tagCloud}
+              tagsEnabled={this.props.tagsEnabled}
               onLoading={() => this.setState({ loading: true })}
-              onFilterResult={({ meetings, filter }) => this.setState({ meetings, filter, loading: false })} />
+              onFilterResult={({ meetings, filter, tag_cloud }) => this.setState({ meetings, filter, tagCloud: tag_cloud, loading: false })} />
           </aside>
         </div>
 

--- a/app/assets/javascripts/components/meetings_filter.es6.jsx
+++ b/app/assets/javascripts/components/meetings_filter.es6.jsx
@@ -35,14 +35,22 @@ class MeetingsFilter extends React.Component {
           categories={this.props.categories}
           filterGroupValue={this.state.filters.get('category_id')} 
           onChangeFilterGroup={(filterGroupName, filterGroupValue) => this.onChangeFilterGroup(filterGroupName, filterGroupValue) } />
-        <TagCloudFilter 
-          currentTags={this.state.tags} 
-          tagCloud={this.props.filter.tag_cloud} 
-          onSetFilterTags={(tags) => this.onSetFilterTags(tags)} />
-
+        {this.renderTagCloudFilter()}
         {this.renderCleanFilterLink()}
       </form>
     )
+  }
+
+  renderTagCloudFilter() {
+    if (this.props.tagsEnabled) {
+      return (
+        <TagCloudFilter 
+          currentTags={this.state.tags} 
+          tagCloud={this.props.tagCloud} 
+          onSetFilterTags={(tags) => this.onSetFilterTags(tags)} />
+      )
+    }
+    return null;
   }
 
   onSetFilterText(searchText) {

--- a/app/assets/javascripts/components/proposal_filters.es6.jsx
+++ b/app/assets/javascripts/components/proposal_filters.es6.jsx
@@ -65,7 +65,7 @@ class ProposalFilters extends React.Component {
       return (
         <TagCloudFilter 
           currentTags={this.state.tags} 
-          tagCloud={this.props.filter.tag_cloud} 
+          tagCloud={this.props.tagCloud} 
           onSetFilterTags={(tags) => this.onSetFilterTags(tags)} />
       )
     }

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -2,8 +2,7 @@ class Api::ProposalsController < ApplicationController
   skip_authorization_check
 
   def index
-    filter = ResourceFilter.new(Proposal.all, params)
-    @proposals = filter.collection
+    @proposals = ResourceFilter.new(params).filter_collection(Proposal.all)
 
     respond_to do |format|
       format.json { render json: @proposals }

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -3,15 +3,17 @@ class MeetingsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @filter = ResourceFilter.new(Meeting.upcoming, params)
-    @meetings = @filter.collection
+    @filter = ResourceFilter.new(params)
+    @meetings = @filter.filter_collection(Meeting.upcoming)
+    @tag_cloud = @filter.tag_cloud(@meetings)
 
     respond_to do |format|
       format.html
       format.json do 
         render json: {
           meetings: ActiveModel::ArraySerializer.new(@meetings, each_serializer: MeetingSerializer).as_json,
-          filter: @filter
+          filter: @filter,
+          tag_cloud: @tag_cloud
         }
       end
     end

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -5,7 +5,10 @@ class MeetingsController < ApplicationController
   def index
     @filter = ResourceFilter.new(params)
     @meetings = @filter.filter_collection(Meeting.upcoming)
-    @tag_cloud = @filter.tag_cloud(@meetings)
+
+    if Setting["feature.meeting_tags"]
+      @tag_cloud = @filter.tag_cloud(@meetings)
+    end
 
     respond_to do |format|
       format.html

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -13,8 +13,9 @@ class ProposalsController < ApplicationController
   respond_to :html, :js
 
   def index
-    @filter = ResourceFilter.new(Proposal.includes(:category, :subcategory, :author => [:organization]), params)
-    @proposals = @filter.collection
+    @filter = ResourceFilter.new(params)
+    @proposals = @filter.filter_collection(Proposal.includes(:category, :subcategory, :author => [:organization]))
+    @tag_cloud = @filter.tag_cloud(@proposals)
 
     @featured_proposals = @proposals.sort_by_confidence_score.limit(FEATURED_PROPOSALS_LIMIT) if (@filter.search_filter.blank? && @filter.tag_filter.blank?)
     if @featured_proposals.present?

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -15,7 +15,10 @@ class ProposalsController < ApplicationController
   def index
     @filter = ResourceFilter.new(params)
     @proposals = @filter.filter_collection(Proposal.includes(:category, :subcategory, :author => [:organization]))
-    @tag_cloud = @filter.tag_cloud(@proposals)
+
+    if Setting["feature.proposal_tags"]
+      @tag_cloud = @filter.tag_cloud(@proposals)
+    end
 
     @featured_proposals = @proposals.sort_by_confidence_score.limit(FEATURED_PROPOSALS_LIMIT) if (@filter.search_filter.blank? && @filter.tag_filter.blank?)
     if @featured_proposals.present?

--- a/app/helpers/meetings_directory_helper.rb
+++ b/app/helpers/meetings_directory_helper.rb
@@ -2,12 +2,14 @@ module MeetingsDirectoryHelper
   def meetings_directory(options = {})
     react_component(
       'MeetingsDirectory',
-      filter: serialized_filters(options[:filter]),
+      filter: options[:filter],
       filterUrl: meetings_url,
       meetings: serialized_meetings(options[:meetings]),
       districts: Proposal::DISTRICTS,
       categories: serialized_categories,
-      subcategories: serialized_subcategories
+      subcategories: serialized_subcategories,
+      tagCloud: options[:tag_cloud],
+      tagsEnabled: feature?(:meeting_tags)
     )
   end
 

--- a/app/helpers/proposal_filters_helper.rb
+++ b/app/helpers/proposal_filters_helper.rb
@@ -2,21 +2,13 @@ module ProposalFiltersHelper
   def proposal_filters(options = {})
     react_component(
       'ProposalFilters', 
-      filter: serialized_filters(options[:filter]),
+      filter: options[:filter],
       filterUrl: proposals_url,
       districts: Proposal::DISTRICTS,
       categories: serialized_categories,
       subcategories: serialized_subcategories,
+      tagCloud: options[:tag_cloud],
       tagsEnabled: feature?(:proposal_tags)
     ) 
-  end
-
-  def serialized_filters(filters)
-    {
-      search_filter: filters.search_filter,
-      tag_filter: filters.tag_filter,
-      params: filters.params,
-      tag_cloud: filters.tag_cloud
-    }
   end
 end

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -3,7 +3,7 @@
 <section role="main">
   <div class="wrap row">
     <div class="small-12 columns">
-      <%= meetings_directory meetings: @meetings, filter: @filter %>
+      <%= meetings_directory meetings: @meetings, filter: @filter, tag_cloud: @tag_cloud %>
     </div>
   </div>
 </section>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -8,7 +8,7 @@
         <div class="sidebar-section proposal-filter-menu collapsed">
           <h2 class="title"><%= t 'proposals.index.filter.title' %> <span class="toggle-menu"></span></h2>
           <div class="sidebar-section-content">
-            <%= proposal_filters filter: @filter %>
+            <%= proposal_filters filter: @filter, tag_cloud: @tag_cloud %>
           </div>
         </div>
       </aside>

--- a/app/views/proposals/index.js.erb
+++ b/app/views/proposals/index.js.erb
@@ -1,3 +1,3 @@
 $('#proposals').html('<%= j render("proposals") %>');
 App.LocationChanger.initialize();
-$(document).trigger('tags:reload', '<%= @filter.tag_cloud.to_json.html_safe %>');
+$(document).trigger('tags:reload', '<%= @tag_cloud.to_json.html_safe %>');

--- a/config/application.yml
+++ b/config/application.yml
@@ -56,6 +56,7 @@ defaults: &defaults
   feature.spending_proposals: false
   feature.proposal_tags: false
   feature.proposal_video_url: false
+  feature.meeting_tags: true
 
 development:
   <<: *defaults

--- a/spec/services/resource_filter_spec.rb
+++ b/spec/services/resource_filter_spec.rb
@@ -9,17 +9,19 @@ describe ResourceFilter do
     end
 
     it "should filter collection based on a single filter params" do
-      filter = ResourceFilter.new(Proposal.all, filter: 'scope=district')
-      expect(filter.collection).to_not include(@proposal1)
-      expect(filter.collection).to include(@proposal2)
-      expect(filter.collection).to include(@proposal3)
+      filter = ResourceFilter.new(filter: 'scope=district')
+      collection = filter.filter_collection(Proposal.all)
+      expect(collection).to_not include(@proposal1)
+      expect(collection).to include(@proposal2)
+      expect(collection).to include(@proposal3)
     end
 
     it "should filter collection based on multiple filter params" do
-      filter = ResourceFilter.new(Proposal.all, filter: 'scope=district:district=1')
-      expect(filter.collection).to_not include(@proposal1)
-      expect(filter.collection).to include(@proposal2)
-      expect(filter.collection).to_not include(@proposal3)
+      filter = ResourceFilter.new(filter: 'scope=district:district=1')
+      collection = filter.filter_collection(Proposal.all)
+      expect(collection).to_not include(@proposal1)
+      expect(collection).to include(@proposal2)
+      expect(collection).to_not include(@proposal3)
     end
   end
 end


### PR DESCRIPTION
# What and why

Instance variables are bad and `ResourceFilter` service was being serialized with a lot of information. I don't want to delegate the responsibility of serialize a ruby object to our template helpers.

I changed the `ResourceFilter` to include the minimum instance variables and added two methods: `filter_collection` and `tag_cloud`. Now the service is more explicit and we must ask it to retrieve the collection when it's really needed.
# QA

I haven't changed any feature so the filters must work properly.
# GIF Tax

![](https://media.giphy.com/media/IVlu4aCc2ujXW/giphy.gif)
