### PR TITLE
Add session menu to registration

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,7 @@
 class Users::SessionsController < Devise::SessionsController
 
+  skip_before_action :ensure_signup_complete, only: [:destroy]
+
   private
 
     def after_sign_in_path_for(resource)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,16 +10,7 @@
   </div>
 
   <div class="header-wrapper">
-    <div class="session-menu">
-      <div class="row">
-        <div class="small-12 large-12 columns">
-          <ul>
-            <%= render "shared/admin_login_items" %>
-            <%= render "devise/menu/login_items" %>
-          </ul>
-        </div>
-      </div>
-    </div>
+    <%= render 'layouts/session_menu' %>
 
     <% if content_for?(:header) %>
       <%= yield(:header) %>

--- a/app/views/layouts/_session_menu.html.erb
+++ b/app/views/layouts/_session_menu.html.erb
@@ -1,0 +1,10 @@
+<div class="session-menu">
+  <div class="row">
+    <div class="small-12 large-12 columns">
+      <ul>
+        <%= render "shared/admin_login_items" %>
+        <%= render "devise/menu/login_items" %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -13,6 +13,7 @@
   </head>
 
   <body class="auth-page">
+    <%= render 'layouts/session_menu' %>
     <%= cookies_warning %>
     <div class="wrapper">
       <div class="row">


### PR DESCRIPTION
This adds the session menu to registration as well to prevent lockins (for example, creating a user via twitter that doesn't have a valid email).
