### PR TITLE
Change link to button with feedback

### DIFF
--- a/app/views/debates/_votes.html.erb
+++ b/app/views/debates/_votes.html.erb
@@ -1,7 +1,7 @@
 <% voted_classes = css_classes_for_vote(@debate_votes, debate) %>
 <div class="votes">
   <div class="in-favor inline-block">
-    <%= link_to vote_debate_path(debate, value: 'yes'),
+    <%= button_to vote_debate_path(debate, value: 'yes'),
         class: "like #{voted_classes[:in_favor]}", title: t('votes.agree'), method: "post", remote: true do %>
       <i class="icon-like"></i>
       <span><%= votes_percentage('likes', debate) %></span>

--- a/app/views/proposals/_featured_votes.html.erb
+++ b/app/views/proposals/_featured_votes.html.erb
@@ -5,7 +5,7 @@
         <%= t("proposals.proposal.already_supported") %>
       </div>
     <% else %>
-      <%= link_to vote_featured_proposal_path(proposal, value: 'yes'),
+      <%= button_to vote_featured_proposal_path(proposal, value: 'yes'),
           class: "button button-support tiny radius expand",
           title: t('proposals.proposal.support_title'), method: "post", remote: true do %>
         <%= t("proposals.proposal.support") %>

--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -20,9 +20,10 @@
         <%= t("proposals.proposal.already_supported") %>
       </div>
     <% else %>
-      <%= link_to vote_url,
+      <%= button_to vote_url,
           class: "button button-support tiny radius expand",
-          title: t('proposals.proposal.support_title'), method: "post", remote: true do %>
+            title: t('proposals.proposal.support_title'), method: "post", remote: true,
+            data: { disable_with: '...' } do %>
         <%= t("proposals.proposal.support") %>
       <% end %>
     <% end %>

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -120,7 +120,7 @@ feature 'Proposals' do
       click_link "Support proposals"
 
       within("#proposals") do
-        find('.in-favor a').click
+        find('.in-favor ').click
 
         expect(page).to have_content "1 support"
         expect(page).to have_content "You have already supported this proposal. Share it!"
@@ -140,7 +140,7 @@ feature 'Proposals' do
         click_link proposal.title
       end
 
-      find('.in-favor a').click
+      find('.in-favor button').click
       expect(page).to have_content "1 support"
       expect(page).to have_content "You have already supported this proposal. Share it!"
       expect(current_path).to eq(management_proposal_path(proposal))

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -23,37 +23,37 @@ feature 'Votes' do
       within("#debates") do
         within("#debate_#{debate1.id}_votes") do
           within(".in-favor") do
-            expect(page).to have_css("a.voted")
-            expect(page).to_not have_css("a.no-voted")
+            expect(page).to have_css(".voted")
+            expect(page).to_not have_css(".no-voted")
           end
 
           within(".against") do
-            expect(page).to have_css("a.no-voted")
-            expect(page).to_not have_css("a.voted")
+            expect(page).to have_css(".no-voted")
+            expect(page).to_not have_css(".voted")
           end
         end
 
         within("#debate_#{debate2.id}_votes") do
           within(".in-favor") do
-            expect(page).to_not have_css("a.voted")
-            expect(page).to_not have_css("a.no-voted")
+            expect(page).to_not have_css(".voted")
+            expect(page).to_not have_css(".no-voted")
           end
 
           within(".against") do
-            expect(page).to_not have_css("a.no-voted")
-            expect(page).to_not have_css("a.voted")
+            expect(page).to_not have_css(".no-voted")
+            expect(page).to_not have_css(".voted")
           end
         end
 
         within("#debate_#{debate3.id}_votes") do
           within(".in-favor") do
-            expect(page).to have_css("a.no-voted")
-            expect(page).to_not have_css("a.voted")
+            expect(page).to have_css(".no-voted")
+            expect(page).to_not have_css(".voted")
           end
 
           within(".against") do
-            expect(page).to have_css("a.voted")
-            expect(page).to_not have_css("a.no-voted")
+            expect(page).to have_css(".voted")
+            expect(page).to_not have_css(".no-voted")
           end
         end
       end
@@ -71,31 +71,31 @@ feature 'Votes' do
 
         within('.in-favor') do
           expect(page).to have_content "0%"
-          expect(page).to_not have_css("a.voted")
-          expect(page).to_not have_css("a.no-voted")
+          expect(page).to_not have_css(".voted")
+          expect(page).to_not have_css(".no-voted")
         end
 
         within('.against') do
           expect(page).to have_content "0%"
-          expect(page).to_not have_css("a.voted")
-          expect(page).to_not have_css("a.no-voted")
+          expect(page).to_not have_css(".voted")
+          expect(page).to_not have_css(".no-voted")
         end
       end
 
       scenario 'Update', :js do
         visit debate_path(@debate)
 
-        find('.in-favor a').click
+        find('.in-favor button').click
         find('.against a').click
 
         within('.in-favor') do
           expect(page).to have_content "0%"
-          expect(page).to have_css("a.no-voted")
+          expect(page).to have_css(".no-voted")
         end
 
         within('.against') do
           expect(page).to have_content "100%"
-          expect(page).to have_css("a.voted")
+          expect(page).to have_css(".voted")
         end
 
         expect(page).to have_content "1 vote"
@@ -104,9 +104,9 @@ feature 'Votes' do
       scenario 'Trying to vote multiple times', :js do
         visit debate_path(@debate)
 
-        find('.in-favor a').click
+        find('.in-favor button').click
         expect(page).to have_content "1 vote"
-        find('.in-favor a').click
+        find('.in-favor button').click
         expect(page).to_not have_content "2 votes"
 
         within('.in-favor') do
@@ -128,28 +128,28 @@ feature 'Votes' do
 
         within('.in-favor') do
           expect(page).to have_content "50%"
-          expect(page).to have_css("a.voted")
+          expect(page).to have_css(".voted")
         end
 
         within('.against') do
           expect(page).to have_content "50%"
-          expect(page).to have_css("a.no-voted")
+          expect(page).to have_css(".no-voted")
         end
       end
 
       xscenario 'Create from debate show', :js do
         visit debate_path(@debate)
 
-        find('.in-favor a').click
+        find('.in-favor button').click
 
         within('.in-favor') do
           expect(page).to have_content "100%"
-          expect(page).to have_css("a.voted")
+          expect(page).to have_css(".voted")
         end
 
         within('.against') do
           expect(page).to have_content "0%"
-          expect(page).to have_css("a.no-voted")
+          expect(page).to have_css(".no-voted")
         end
 
         expect(page).to have_content "1 vote"
@@ -160,16 +160,16 @@ feature 'Votes' do
 
         within("#debates") do
 
-          find('.in-favor a').click
+          find('.in-favor button').click
 
           within('.in-favor') do
             expect(page).to have_content "100%"
-            expect(page).to have_css("a.voted")
+            expect(page).to have_css(".voted")
           end
 
           within('.against') do
             expect(page).to have_content "0%"
-            expect(page).to have_css("a.no-voted")
+            expect(page).to have_css(".no-voted")
           end
 
           expect(page).to have_content "1 vote"
@@ -219,10 +219,10 @@ feature 'Votes' do
         visit proposal_path(@proposal)
 
         within('.supports') do
-          find('.in-favor a').click
+          find('.in-favor button').click
           expect(page).to have_content "1 support"
 
-          expect(page).to_not have_selector ".in-favor a"
+          expect(page).to_not have_selector ".in-favor button"
         end
       end
 
@@ -241,7 +241,7 @@ feature 'Votes' do
         visit proposal_path(@proposal)
 
         within('.supports') do
-          find('.in-favor a').click
+          find('.in-favor button').click
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this proposal. Share it!"
@@ -253,7 +253,7 @@ feature 'Votes' do
         visit proposals_path
 
         within("#proposal_#{@proposal.id}") do
-          find('.in-favor a').click
+          find('.in-favor button').click
 
           expect(page).to have_content "1 support"
           expect(page).to have_content "You have already supported this proposal. Share it!"
@@ -265,7 +265,7 @@ feature 'Votes' do
         visit proposals_path
 
         within("#featured_proposal_#{@proposal.id}") do
-          find('.in-favor a').click
+          find('.in-favor button').click
         end
         expect(page).to have_content "You have already supported this proposal. Share it!"
         expect(current_path).to eq(proposals_path)

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -153,17 +153,17 @@ module CommonActions
 
   def expect_message_you_need_to_sign_in
     expect(page).to have_content 'You must Sign in or Sign up to continue'
-    expect(page).to have_selector('.in-favor a', visible: false)
+    expect(page).to have_selector('.in-favor button', visible: false)
   end
 
   def expect_message_to_many_anonymous_votes
     expect(page).to have_content 'Too many anonymous votes to admit vote'
-    expect(page).to have_selector('.in-favor a', visible: false)
+    expect(page).to have_selector('.in-favor button', visible: false)
   end
 
   def expect_message_only_verified_can_vote_proposals
     expect(page).to have_content 'Only verified users can vote on proposals'
-    expect(page).to have_selector('.in-favor a', visible: false)
+    expect(page).to have_selector('.in-favor button', visible: false)
   end
 
   def create_featured_proposals


### PR DESCRIPTION
This will prevent browsers from crawling the link (browsers never send forms), and at the same time, will show feedback to the user. This can be especially useful on flaky connections.
