### PR TITLE
Use proposal description instead of summary (2 of 3)

### DIFF
--- a/app/models/concerns/measurable.rb
+++ b/app/models/concerns/measurable.rb
@@ -11,10 +11,6 @@ module Measurable
       @responsible_name_max_length ||= self.columns.find { |c| c.name == 'responsible_name' }.limit || 60
     end
 
-    def question_max_length
-      140
-    end
-
     def description_max_length
       6000
     end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -26,8 +26,8 @@ class Proposal < ActiveRecord::Base
   has_many :recommendations
 
   validates :title, presence: true
-  validates :title, :summary, style: true, on: :create
-  validates :summary, presence: true, length: { maximum: 1000 }
+  validates :description, presence: true
+  validates :title, :description, style: true, on: :create
   validates :author, presence: true
   validates :responsible_name, presence: true
 
@@ -35,7 +35,6 @@ class Proposal < ActiveRecord::Base
   validates :description, length: { maximum: Proposal.description_max_length }
   validates :scope, inclusion: { in: %w(city district) }
   validates :district, inclusion: { in: District.all.map(&:id), allow_nil: true }
-  validates :question, length: { in: 10..Proposal.question_max_length }, allow_blank: true
   validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length }
 
   before_validation :set_responsible_name
@@ -55,8 +54,7 @@ class Proposal < ActiveRecord::Base
   pg_search_scope :pg_search, {
     against: {
       title:       'A',
-      question:    'B',
-      summary:     'C'
+      description: 'B'
     },
     associated_against: {
       tags: :name
@@ -74,8 +72,7 @@ class Proposal < ActiveRecord::Base
   def searchable_values
     values = {
       title       => 'A',
-      question    => 'B',
-      summary     => 'C'
+      description => 'B'
     }
     tag_list.each{ |tag| values[tag] = 'D' }
     values[author.username] = 'D'

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -56,8 +56,7 @@ class Proposal < ActiveRecord::Base
     against: {
       title:       'A',
       question:    'B',
-      summary:     'C',
-      description: 'D'
+      summary:     'C'
     },
     associated_against: {
       tags: :name
@@ -76,8 +75,7 @@ class Proposal < ActiveRecord::Base
     values = {
       title       => 'A',
       question    => 'B',
-      summary     => 'C',
-      description => 'D'
+      summary     => 'C'
     }
     tag_list.each{ |tag| values[tag] = 'D' }
     values[author.username] = 'D'
@@ -88,7 +86,7 @@ class Proposal < ActiveRecord::Base
     self.pg_search(terms)
   end
 
-  def description
+    def description
     super.try :html_safe
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -12,8 +12,6 @@ class Proposal < ActiveRecord::Base
   include Categorizable
   include Filterable
 
-  before_save :sync_description
-
   apply_simple_captcha
   acts_as_votable
   acts_as_paranoid column: :hidden_at
@@ -138,9 +136,4 @@ class Proposal < ActiveRecord::Base
       end
     end
 
-  private
-
-    def sync_description
-      self.description = self.summary
-    end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -12,6 +12,8 @@ class Proposal < ActiveRecord::Base
   include Categorizable
   include Filterable
 
+  before_save :sync_description
+
   apply_simple_captcha
   acts_as_votable
   acts_as_paranoid column: :hidden_at
@@ -141,4 +143,9 @@ class Proposal < ActiveRecord::Base
       end
     end
 
+  private
+
+    def sync_description
+      self.description = self.summary
+    end
 end

--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -11,7 +11,7 @@
         <strong><%= proposal.title %></strong>
         <br>
         <div class="moderation-description">
-          <p><%= proposal.summary %></p>
+          <p><%= proposal.description %></p>
           <% if proposal.external_url.present? %>
             <p><%= text_with_links proposal.external_url %></p>
           <% end %>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -8,10 +8,10 @@
     </div>
 
     <div class="small-12 column">
-      <%= f.label :summary, t("proposals.form.proposal_summary") %>
-      <p class="note"><%= t("proposals.form.proposal_summary_note") %></p>
-      <%= f.text_area :summary, rows: 4, maxlength: 350, label: false,
-                      placeholder: t('proposals.form.proposal_summary') %>
+      <%= f.label :description, t("proposals.form.proposal_description") %>
+      <p class="note"><%= t("proposals.form.proposal_description_note") %></p>
+      <%= f.text_area :description, rows: 4, maxlength: 350, label: false,
+                      placeholder: t('proposals.form.proposal_description') %>
     </div>
 
     <%= render 'shared/forms/district_fields', f: f, i18n_namespace: 'proposals.form.proposal' %>

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -47,7 +47,7 @@
             </p>
             <div class="proposal-description">
               <p>
-                <%= truncate strip_tags(proposal.summary), length: 300 %>
+                <%= truncate strip_tags(proposal.description), length: 300 %>
               </p>
               <div class="truncate"></div>
             </div>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -4,7 +4,7 @@
             social_url: proposal_url(@proposal),
             social_title: @proposal.title,
             social_media_image: asset_url('social-media-icon.png'),
-            social_description: text_with_links(@proposal.summary) %>
+            social_description: text_with_links(@proposal.description) %>
 <% end %>
 
 
@@ -50,7 +50,7 @@
         </div>
 
         <div class="proposal-description">
-          <%= text_with_links @proposal.summary %>
+          <%= text_with_links @proposal.description %>
         </div>
 
         <% if @proposal.external_url.present? %>

--- a/app/views/users/_proposals.html.erb
+++ b/app/views/users/_proposals.html.erb
@@ -4,7 +4,7 @@
       <td>
         <%= link_to proposal.title, proposal %>
         <br>
-        <%= proposal.summary %>
+        <%= proposal.description %>
       </td>
     </tr>
   <% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -303,19 +303,17 @@ ca:
         submit_button: Desa els canvis
       show_link: Veure proposta
     form:
+      proposal_description: Resum de la proposta
+      proposal_description_note: "(màxim 350 caràcters)"
       proposal_external_url: Enllaç a documentació addicional
       proposal_from_meeting: Aquesta proposta surt d'una cita presencial
       proposal_official: La proposta és oficial
-      proposal_question: Pregunta de la proposta
-      proposal_question_example_html: Ha de ser resumida en una pregunta la resposta sigui Sí o No. <em>Ex. 'Està vostè d'acord en vianants el carrer Major?'</em>
       proposal_responsible_name: Nom i cognoms de la persona que fa aquesta proposta
       proposal_responsible_name_note: "(individualment o com a representant d'un col·lectiu, no es mostrarà públicament)"
       proposal_scope: "Àmbit"
       proposal_scope_city: Tota la ciutat
       proposal_scope_district: Districtes
       proposal_scope_note: Es una mesura per a tota la ciutat o només per a un districte?
-      proposal_summary: Resum de la proposta
-      proposal_summary_note: "(màxim 350 caràcters)"
       proposal_title: Títol de la proposta
       proposal_video_url: Enllaç a vídeo extern
       proposal_video_url_note: Pots afegir un enllaç a YouTube o Vimeo

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -303,19 +303,17 @@ en:
         submit_button: Save changes
       show_link: View proposal
     form:
+      proposal_description: Proposal summary
+      proposal_description_note: "(maximum 350 characters)"
       proposal_external_url: Link to additional documentation
       proposal_from_meeting: This proposal leaves a meeting in person
       proposal_official: This proposal is oficial
-      proposal_question: Proposal question
-      proposal_question_example_html: Must be summarised in one question with a Yes or No answer. <em>E.g. 'Do you agree with the pedestrianisation of Calle Mayor?'</em>
       proposal_responsible_name: Full name of the person submitting the proposal
       proposal_responsible_name_note: "(individually or as representative of a collective; will not be displayed publically)"
       proposal_scope: Scope
       proposal_scope_city: Whole city
       proposal_scope_district: Districts
       proposal_scope_note: Is it a measure for the whole city or just for one district?
-      proposal_summary: Proposal summary
-      proposal_summary_note: "(maximum 350 characters)"
       proposal_title: Proposal title
       proposal_video_url: Link to external video
       proposal_video_url_note: You may add a link to YouTube or Vimeo

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -303,19 +303,17 @@ es:
         submit_button: Guardar cambios
       show_link: Ver propuesta
     form:
+      proposal_description: Resumen de la propuesta
+      proposal_description_note: "(máximo 300 caracteres)"
       proposal_external_url: Enlace a documentación adicional
       proposal_from_meeting: Esta propuesta sale de una cita presencial
       proposal_official: La propuesta es oficial
-      proposal_question: Pregunta de la propuesta
-      proposal_question_example_html: Debe ser resumida en una pregunta cuya respuesta sea Sí o No. <em>Ej. '¿Está usted de acuerdo en peatonalizar la calle Mayor?'</em>
       proposal_responsible_name: Nombre y apellidos de la persona que hace esta propuesta
       proposal_responsible_name_note: "(individualmente o como representante de un colectivo; no se mostrará públicamente)"
       proposal_scope: "Ámbito"
       proposal_scope_city: Toda la ciudad
       proposal_scope_district: Distritos
       proposal_scope_note: "¿Es una medida para toda la ciudad o solo para un distrito?"
-      proposal_summary: Resumen de la propuesta
-      proposal_summary_note: "(máximo 300 caracteres)"
       proposal_title: Título de la propuesta
       proposal_video_url: Enlace a vídeo externo
       proposal_video_url_note: Puedes añadir un enlace a YouTube o Vimeo

--- a/db/migrate/20160202153704_copy_proposals_summary_to_description.rb
+++ b/db/migrate/20160202153704_copy_proposals_summary_to_description.rb
@@ -1,0 +1,7 @@
+class CopyProposalsSummaryToDescription < ActiveRecord::Migration
+  def up
+    Proposal.transaction do
+      execute "UPDATE proposals SET description=summary"
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -124,7 +124,7 @@ if ENV["SEED"]
   places = YAML.load_file("#{Rails.root}/db/seeds/places.yml")[:places]
   proposals = Proposal.all
 
-  (1..1000).each do |i|
+  (1..100).each do |i|
     place = places.sample
     start_at = Faker::Time.forward(23, :morning)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -104,11 +104,9 @@ if ENV["SEED"]
 
     proposal = Proposal.create!(author: author,
                                 title: Faker::Lorem.paragraph.truncate(150),
-                                question: Faker::Lorem.sentence(3),
-                                summary: Faker::Lorem.paragraph(10).truncate(1000),
+                                description: Faker::Lorem.paragraph(10).truncate(1000),
                                 responsible_name: Faker::Name.name,
                                 external_url: Faker::Internet.url,
-                                description: description,
                                 created_at: rand((Time.now - 1.week) .. Time.now),
                                 tag_list: tags.sample(3).join(','),
                                 subcategory: subcategory,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -147,10 +147,8 @@ FactoryGirl.define do
 
   factory :proposal do
     sequence(:title)     { |n| "Proposal #{n} title" }
-    summary              'In summary, what we want is...'
     description          'Proposal description'
     scope                'city'
-    question             'Proposal question'
     external_url         'http://external_documention.es'
     video_url            'http://video_link.com'
     responsible_name     'John Snow'

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -16,7 +16,7 @@ feature 'Admin proposals' do
     visit admin_proposals_path
 
     expect(page).to have_content(proposal.title)
-    expect(page).to have_content(proposal.summary)
+    expect(page).to have_content(proposal.description)
     expect(page).to have_content(proposal.external_url)
     expect(page).to have_content(proposal.video_url)
   end

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -1,0 +1,203 @@
+# coding: utf-8
+require 'rails_helper'
+
+feature 'Proposals' do
+
+  background do
+    login_as_manager
+  end
+
+  before :each do
+    Setting['feature.proposal_video_url'] = true
+  end
+
+  let!(:subcategory) { create(:subcategory) }
+  let(:category) { subcategory.category }
+
+  context "Create" do
+
+    scenario 'Creating proposals on behalf of someone', :js do
+      user = create(:user, :level_two)
+      login_managed_user(user)
+
+      click_link "Create proposal"
+
+      within(".account-info") do
+        expect(page).to have_content "Identified as"
+        expect(page).to have_content "#{user.username}"
+        expect(page).to have_content "#{user.email}"
+        expect(page).to have_content "#{user.document_number}"
+      end
+
+      fill_in 'proposal_title', with: 'Help refugees'
+      fill_in 'proposal_description', with: 'In summary, what we want is...'
+      fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
+      fill_in 'proposal_video_url', with: 'http://youtube.com'
+      fill_in 'proposal_captcha', with: correct_captcha_text
+
+      find('li', text: category.name["en"]).click
+      find('li', text: subcategory.name["en"]).click
+
+      click_button 'Create proposal'
+
+      expect(page).to have_content 'Proposal created successfully.'
+
+      expect(page).to have_content 'Help refugees'
+      expect(page).to have_content 'In summary, what we want is...'
+      expect(page).to have_content 'http://rescue.org/refugees'
+      expect(page).to have_content 'http://youtube.com'
+      expect(page).to have_content user.name
+      expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
+
+      expect(current_path).to eq(management_proposal_path(Proposal.last.id))
+    end
+
+    scenario "Should not allow unverified users to create proposals" do
+      user = create(:user)
+      login_managed_user(user)
+
+      click_link "Create proposal"
+
+      expect(page).to have_content "User is not verified"
+    end
+  end
+
+  scenario "Searching" do
+    proposal1 = create(:proposal, title: "Show me what you got")
+    proposal2 = create(:proposal, title: "Get Schwifty")
+
+    user = create(:user, :level_two)
+    login_managed_user(user)
+
+    click_link "Support proposals"
+
+    fill_in "search", with: "what you got"
+    click_button "Search"
+
+    expect(current_path).to eq(management_proposals_path)
+
+    within("#proposals") do
+      expect(page).to have_css('.proposal', count: 1)
+      expect(page).to have_content(proposal1.title)
+      expect(page).to_not have_content(proposal2.title)
+      expect(page).to have_css("a[href='#{management_proposal_path(proposal1)}']", text: proposal1.title)
+    end
+  end
+
+  scenario "Listing" do
+    proposal1 = create(:proposal, title: "Show me what you got")
+    proposal2 = create(:proposal, title: "Get Schwifty")
+
+    user = create(:user, :level_two)
+    login_managed_user(user)
+
+    click_link "Support proposals"
+
+    expect(current_path).to eq(management_proposals_path)
+
+    within(".account-info") do
+      expect(page).to have_content "Identified as"
+      expect(page).to have_content "#{user.username}"
+      expect(page).to have_content "#{user.email}"
+      expect(page).to have_content "#{user.document_number}"
+    end
+
+    within("#proposals") do
+      expect(page).to have_css('.proposal', count: 2)
+      expect(page).to have_css("a[href='#{management_proposal_path(proposal1)}']", text: proposal1.title)
+      expect(page).to have_css("a[href='#{management_proposal_path(proposal2)}']", text: proposal2.title)
+    end
+  end
+
+  context "Voting" do
+
+    scenario 'Voting proposals on behalf of someone in index view', :js do
+      proposal = create(:proposal)
+
+      user = create(:user, :level_two)
+      login_managed_user(user)
+
+      click_link "Support proposals"
+
+      within("#proposals") do
+        find('.in-favor ').click
+
+        expect(page).to have_content "1 support"
+        expect(page).to have_content "You have already supported this proposal. Share it!"
+      end
+      expect(current_path).to eq(management_proposals_path)
+    end
+
+    xscenario 'Voting proposals on behalf of someone in show view', :js do
+      proposal = create(:proposal)
+
+      user = create(:user, :level_two)
+      login_managed_user(user)
+
+      click_link "Support proposals"
+
+      within("#proposals") do
+        click_link proposal.title
+      end
+
+      find('.in-favor button').click
+      expect(page).to have_content "1 support"
+      expect(page).to have_content "You have already supported this proposal. Share it!"
+      expect(current_path).to eq(management_proposal_path(proposal))
+    end
+
+    scenario "Should not allow unverified users to vote proposals" do
+      proposal = create(:proposal)
+
+      user = create(:user)
+      login_managed_user(user)
+
+      click_link "Support proposals"
+
+      expect(page).to have_content "User is not verified"
+    end
+  end
+
+  context "Printing" do
+
+    scenario 'Printing proposals', :js do
+      6.times { create(:proposal) }
+
+      click_link "Print proposals"
+
+      expect(page).to have_css('.proposal', count: 5)
+      expect(page).to have_css("a[href='javascript:window.print();']", text: 'Print')
+    end
+
+    scenario "Filtering proposals to be printed", :js do
+      create(:proposal, title: 'Worst proposal').update_column(:confidence_score, 2)
+      create(:proposal, title: 'Best proposal').update_column(:confidence_score, 10)
+      create(:proposal, title: 'Medium proposal').update_column(:confidence_score, 5)
+
+      user = create(:user, :level_two)
+      login_managed_user(user)
+
+      click_link "Print proposals"
+
+      expect(page).to have_selector('.js-order-selector[data-order="confidence_score"]')
+
+      within '#proposals' do
+        expect('Best proposal').to appear_before('Medium proposal')
+        expect('Medium proposal').to appear_before('Worst proposal')
+      end
+
+      select 'newest', from: 'order-selector'
+
+      expect(page).to have_selector('.js-order-selector[data-order="created_at"]')
+
+      expect(current_url).to include('order=created_at')
+      expect(current_url).to include('page=1')
+
+      within '#proposals' do
+        expect('Medium proposal').to appear_before('Best proposal')
+        expect('Best proposal').to appear_before('Worst proposal')
+      end
+    end
+
+  end
+end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -90,7 +90,7 @@ feature 'Proposals' do
     visit new_proposal_path
 
     fill_in 'proposal_title', with: 'Help refugees'
-    fill_in 'proposal_summary', with: 'In summary, what we want is...'
+    fill_in 'proposal_description', with: 'In summary, what we want is...'
     choose 'proposal_scope_district'
     select 'Ciutat Vella', from: 'proposal_district'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
@@ -118,7 +118,7 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Help refugees'
-    fill_in 'proposal_summary', with: 'In summary, what we want is...'
+    fill_in 'proposal_description', with: 'In summary, what we want is...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: correct_captcha_text
@@ -140,7 +140,7 @@ feature 'Proposals' do
     expect(page).to_not have_selector('#proposal_responsible_name')
 
     fill_in 'proposal_title', with: 'Help refugees'
-    fill_in 'proposal_summary', with: 'In summary, what we want is...'
+    fill_in 'proposal_description', with: 'In summary, what we want is...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_captcha', with: correct_captcha_text
     find('li', text: category.name["en"]).click
@@ -156,7 +156,7 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: "Great title"
-    fill_in 'proposal_summary', with: 'In summary, what we want is...'
+    fill_in 'proposal_description', with: 'In summary, what we want is...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: "wrongText!"
@@ -181,7 +181,7 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: ""
-    fill_in 'proposal_summary', with: 'In summary, what we want is...'
+    fill_in 'proposal_description', with: 'In summary, what we want is...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: correct_captcha_text
@@ -214,7 +214,7 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Testing an attack'
-    fill_in 'proposal_summary', with: '<p>This is alert("an attack");</p>'
+    fill_in 'proposal_description', with: '<p>This is alert("an attack");</p>'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: correct_captcha_text
@@ -236,7 +236,7 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Testing auto link'
-    fill_in 'proposal_summary', with: '<p>This is a link www.example.org</p>'
+    fill_in 'proposal_description', with: '<p>This is a link www.example.org</p>'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: correct_captcha_text
     find('li', text: category.name["en"]).click
@@ -255,7 +255,7 @@ feature 'Proposals' do
 
     visit new_proposal_path
     fill_in 'proposal_title', with: 'Testing auto link'
-    fill_in 'proposal_summary', with: '<script>alert("hey")</script>http://example.org'
+    fill_in 'proposal_description', with: '<script>alert("hey")</script>http://example.org'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: correct_captcha_text
     find('li', text: category.name["en"]).click
@@ -291,7 +291,7 @@ feature 'Proposals' do
       visit new_proposal_path
 
       fill_in 'proposal_title', with: 'A test with enough characters'
-      fill_in 'proposal_summary', with: 'In summary, what we want is...'
+      fill_in 'proposal_description', with: 'In summary, what we want is...'
       fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
       fill_in 'proposal_captcha', with: correct_captcha_text
@@ -314,7 +314,7 @@ feature 'Proposals' do
       visit new_proposal_path
 
       fill_in 'proposal_title', with: 'A test of dangerous strings'
-      fill_in 'proposal_summary', with: 'In summary, what we want is...'
+      fill_in 'proposal_description', with: 'In summary, what we want is...'
       fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
       fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
       fill_in 'proposal_captcha', with: correct_captcha_text
@@ -365,7 +365,7 @@ feature 'Proposals' do
     expect(current_path).to eq(edit_proposal_path(proposal))
 
     fill_in 'proposal_title', with: "End child poverty"
-    fill_in 'proposal_summary', with: 'Basically...'
+    fill_in 'proposal_description', with: 'Basically...'
     fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
     fill_in 'proposal_responsible_name', with: 'Isabel Garcia'
     fill_in 'proposal_captcha', with: correct_captcha_text
@@ -574,7 +574,7 @@ feature 'Proposals' do
 
       visit proposals_path
 
-      find('.proposal-filters .search-filter').set("Show what you got")
+      find('.proposal-filters .search-filter').set("you got")
 
       expect(page).to_not have_content "Do not display"
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -415,7 +415,7 @@ describe Proposal do
         expect(results).to eq([proposal])
       end
 
-      it "searches by description" do
+      xit "searches by description" do
         proposal = create(:proposal, description: 'in order to save the world one must think about...')
         results = Proposal.search('one must think')
         expect(results).to eq([proposal])
@@ -499,7 +499,7 @@ describe Proposal do
       it "orders by weight" do
         proposal_question    = create(:proposal, question:    'stop corruption')
         proposal_title       = create(:proposal,  title:       'stop corruption')
-        proposal_description = create(:proposal,  description: 'stop corruption')
+        #proposal_description = create(:proposal,  description: 'stop corruption')
         proposal_summary     = create(:proposal,  summary:     'stop corruption')
 
         results = Proposal.search('stop corruption')
@@ -507,7 +507,7 @@ describe Proposal do
         expect(results.first).to eq(proposal_title)
         expect(results.second).to eq(proposal_question)
         expect(results.third).to eq(proposal_summary)
-        expect(results.fourth).to eq(proposal_description)
+        #expect(results.fourth).to eq(proposal_description)
       end
 
       it "orders by weight and then by votes" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -13,8 +13,8 @@ describe Proposal do
     expect(proposal).to_not be_valid
   end
 
-  it "should not be valid without a summary" do
-    proposal.summary = nil
+  it "should not be valid without a description" do
+    proposal.description = nil
     expect(proposal).to_not be_valid
   end
 
@@ -61,18 +61,6 @@ describe Proposal do
 
     it "should not be valid with an arbitrary value" do
       proposal.scope = 'whatever'
-      expect(proposal).to_not be_valid
-    end
-  end
-
-  describe "#question" do
-    it "should not be valid when very short" do
-      proposal.question = "abc"
-      expect(proposal).to_not be_valid
-    end
-
-    it "should not be valid when very long" do
-      proposal.question = "a" * 141
       expect(proposal).to_not be_valid
     end
   end
@@ -409,21 +397,9 @@ describe Proposal do
         expect(results).to eq([proposal])
       end
 
-      it "searches by summary" do
-        proposal = create(:proposal, summary: 'basically...')
-        results = Proposal.search('basically')
-        expect(results).to eq([proposal])
-      end
-
-      xit "searches by description" do
+      it "searches by description" do
         proposal = create(:proposal, description: 'in order to save the world one must think about...')
         results = Proposal.search('one must think')
-        expect(results).to eq([proposal])
-      end
-
-      it "searches by question" do
-        proposal = create(:proposal, question: 'to be or not to be')
-        results = Proposal.search('to be or not to be')
         expect(results).to eq([proposal])
       end
 
@@ -439,7 +415,7 @@ describe Proposal do
     context "stemming" do
 
       it "searches word stems" do
-        proposal = create(:proposal, summary: 'biblioteca')
+        proposal = create(:proposal, description: 'biblioteca')
 
         results = Proposal.search('bibliotecas')
         expect(results).to eq([proposal])
@@ -456,12 +432,12 @@ describe Proposal do
     context "accents" do
 
       it "searches with accents" do
-        proposal = create(:proposal, summary: 'difusión')
+        proposal = create(:proposal, description: 'difusión')
 
         results = Proposal.search('difusion')
         expect(results).to eq([proposal])
 
-        proposal2 = create(:proposal, summary: 'estadisticas')
+        proposal2 = create(:proposal, description: 'estadisticas')
         results = Proposal.search('estadísticas')
         expect(results).to eq([proposal2])
       end
@@ -497,17 +473,13 @@ describe Proposal do
     context "order" do
 
       it "orders by weight" do
-        proposal_question    = create(:proposal, question:    'stop corruption')
         proposal_title       = create(:proposal,  title:       'stop corruption')
-        #proposal_description = create(:proposal,  description: 'stop corruption')
-        proposal_summary     = create(:proposal,  summary:     'stop corruption')
+        proposal_description = create(:proposal,  description: 'stop corruption')
 
         results = Proposal.search('stop corruption')
 
         expect(results.first).to eq(proposal_title)
-        expect(results.second).to eq(proposal_question)
-        expect(results.third).to eq(proposal_summary)
-        #expect(results.fourth).to eq(proposal_description)
+        expect(results.second).to eq(proposal_description)
       end
 
       it "orders by weight and then by votes" do
@@ -515,14 +487,11 @@ describe Proposal do
         title_least_voted   = create(:proposal, title: 'stop corruption', cached_votes_up: 2)
         title_most_voted    = create(:proposal, title: 'stop corruption', cached_votes_up: 10)
 
-        summary_most_voted  = create(:proposal, summary: 'stop corruption', cached_votes_up: 10)
-
         results = Proposal.search('stop corruption')
 
         expect(results.first).to eq(title_most_voted)
         expect(results.second).to eq(title_some_votes)
         expect(results.third).to eq(title_least_voted)
-        expect(results.fourth).to eq(summary_most_voted)
       end
 
       it "gives much more weight to word matches than votes" do


### PR DESCRIPTION
# What and why

We are using proposals `summary` as a description so I want to use the `description` field instead and deprecate `summary` and `question` fields.

I'm going to submit this pull request using three steps:
1. Copy `summary` content to `description` field and synchronize content.
2. Change all references from `summary` to `description`
3. Remove unused fields from the database. 
# GIF Tax

![](https://media.giphy.com/media/xTiTnHnNnrN08NvNni/giphy.gif)
