### PR TITLE
Moderator can destroy meetings

### DIFF
--- a/app/controllers/moderation/meetings_controller.rb
+++ b/app/controllers/moderation/meetings_controller.rb
@@ -46,6 +46,11 @@ class Moderation::MeetingsController < Moderation::BaseController
     end
   end
 
+  def destroy
+    resource.destroy
+    redirect_to moderation_meetings_url, notice: t('flash.actions.destroy.notice', resource_name: "#{resource_name.capitalize}")
+  end
+
   private
 
   def meeting_params

--- a/app/views/moderation/meetings/index.html.erb
+++ b/app/views/moderation/meetings/index.html.erb
@@ -34,6 +34,7 @@
         <div class="right">
           <%= link_to t("meetings.index.edit"), edit_moderation_meeting_path(meeting), class: 'button radius small' %>
           <%= link_to t("meetings.index.close"), new_moderation_meeting_close_path(meeting), class: 'button radius small' %>
+          <%= link_to t('meetings.index.delete'), moderation_meeting_path(meeting), method: :delete,  class: "button tiny radius alert", data: { confirm: t('admin.actions.confirm') } %>
         </div>
         <br>
         <div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -239,6 +239,7 @@ ca:
     index:
       close: Tancar
       edit: Editar
+      delete: Esborrar
       new: Crear cita
       title: Cites presencials
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,6 +239,7 @@ en:
     index:
       close: Close
       edit: Edit
+      delete: Delete
       new: Create meeting
       title: Meetings
     new:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -239,6 +239,7 @@ es:
     index:
       close: Cerrar
       edit: Editar
+      delete: Borrar
       new: Crear cita
       title: Citas presenciales
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,7 +206,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :meetings, except: [:show, :destroy] do
+    resources :meetings, except: [:show] do
       resource :close, controller: 'meetings/close', only: [:new, :create]
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -113,8 +113,7 @@ if ENV["SEED"]
                                 category: subcategory.category,
                                 scope: scope,
                                 district: district,
-                                official: official,
-                                terms_of_service: "1")
+                                official: official)
     puts "    #{proposal.title}"
   end
 

--- a/spec/features/moderation/meetings_spec.rb
+++ b/spec/features/moderation/meetings_spec.rb
@@ -170,4 +170,19 @@ feature 'Moderate meetings' do
     expect(page).to have_content "Meeting updated successfully."
     expect(page).to_not have_content "A finished meeting"
   end
+
+  scenario 'Delete a meeting', :js do 
+    moderator = create(:moderator)
+    login_as(moderator.user)
+
+    proposal_1 = create(:proposal, title: "A proposal to discuss #1")
+    proposal_2 = create(:proposal, title: "A proposal to discuss #2")
+    create(:meeting, title: "A meeting", proposals: [proposal_1, proposal_2])
+
+    visit moderation_meetings_path
+    click_link 'Delete'
+
+    expect(page).to have_content "Meeting deleted successfully."
+    expect(page).to_not have_content "A meeting"
+  end
 end


### PR DESCRIPTION
# What and why

Some meetings are duplicated so a moderator needs to delete them. Solve issue #205 
# QA

Visit meetings and use the delete button to destroy a meeting.
# GIF Tax

![](https://media.giphy.com/media/1iTItUOuJLsbev28/giphy.gif)
