### PR TITLE
Email setmanal de resum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,6 +135,7 @@ group :test do
   gem "webmock"
   gem 'rspec-retry'
   gem "coveralls"
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -631,6 +631,7 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.2)
+    timecop (0.8.0)
     tins (1.6.0)
     tolk (1.9.3)
       rails (>= 4.0, < 4.3)
@@ -782,6 +783,7 @@ DEPENDENCIES
   social-share-button!
   spring
   spring-commands-rspec
+  timecop
   tolk
   turbolinks
   turnout

--- a/app/assets/stylesheets/email.scss
+++ b/app/assets/stylesheets/email.scss
@@ -83,4 +83,35 @@
     }
     margin-bottom: 10px;
   }
+
+  ul{
+    li{
+      margin-bottom: rem-calc(5);
+    }
+  }
+
+  .weekly-summary{
+    h3{
+      padding-top: rem-calc(20);
+    }
+
+    .title{
+      text-align: center;
+
+      h2{
+        padding-top: rem-calc(20);
+        padding-bottom: 0;
+      }
+
+      h3{
+        margin: 0;
+        padding-top: rem-calc(5);
+        padding-bottom: rem-calc(5);
+        &.name{
+          font-weight: normal;
+        }
+      }
+    }
+
+  }
 }

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -17,7 +17,7 @@ class ProposalsController < ApplicationController
 
   def index
     @filter = ResourceFilter.new(params)
-    @proposals = @current_order == "recommended" ? current_user.recommended_proposals : Proposal
+    @proposals = @current_order == "recommended" ? Recommender.new(current_user).proposals : Proposal.all
 
     @proposals = @filter.filter_collection(@proposals.includes(:category, :subcategory, :author => [:organization]))
 
@@ -39,9 +39,7 @@ class ProposalsController < ApplicationController
                  for_render.
                  includes(:author)
 
-    if @current_order == "recommended"
-      @proposals = @proposals.order("recommendations.score / (proposals.cached_votes_up + 1) desc")
-    else
+    if @current_order != "recommended"
       @proposals = @proposals.send("sort_by_#{@current_order}")
     end
 

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -3,6 +3,10 @@ class DeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers
   default template_path: 'devise/mailer'
 
+  before_filter do
+    @hide_footer_link = true
+  end
+
   protected
 
   def devise_mail(record, action, opts={})

--- a/app/mailers/summary_mailer.rb
+++ b/app/mailers/summary_mailer.rb
@@ -1,0 +1,16 @@
+class SummaryMailer < ApplicationMailer
+  def weekly(user, from = 1.week.ago, to = Time.now)
+    @from = from
+    @to = to
+    @summary = ActivitySummary.new(user, @from, @to)
+    @official_random_proposals = Proposal.where(official: true).order('random()').limit(5)
+    @random_proposals = Proposal.order('random()').where(official: false).limit(5)
+    @upcoming_meetings = Meeting.upcoming.limit(5)
+    @user = user
+
+    with_user(user) do
+      mail(to: user.email, subject: t('summary_mailer.weekly.subject',
+                                      from: I18n.l(@from.to_date), to: I18n.l(@to.to_date)))
+    end
+  end
+end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -117,7 +117,8 @@ class Proposal < ActiveRecord::Base
   end
 
   def after_commented
-    save # updates the hot_score because there is a before_save
+    touch
+    calculate_scores
   end
 
   def calculate_scores

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ActiveRecord::Base
   has_many :recommendations
   has_many :recommended_proposals, through: :recommendations, source: :proposal
 
+
   validates :username, presence: true, if: :username_required?
   validates :username, uniqueness: true, if: :username_required?
   validates :document_number, uniqueness: { scope: :document_type }, allow_blank: true

--- a/app/services/activity_summary.rb
+++ b/app/services/activity_summary.rb
@@ -1,0 +1,101 @@
+# This class creates a summary of a user's related activites and relevant
+# information. It can be used to show a dashboard or send a newsletter.
+#
+class ActivitySummary
+  # Public: Initializes an Activity summary with a User subject and a timestamp
+  # from where to scope the activity to.
+  #
+  # user - The User to generate the activity sumary to.
+  # from - A DateTime from when to generate the activity to.
+  # to - A DateTime to when to generate the activity to.
+  def initialize(user, from = 1.week.ago, to = Time.now)
+    @user = user
+    @from = from
+    @to = to
+  end
+
+  # Public: Returns the most active proposals during a time period, based on
+  # their hot score.
+  #
+  # limit - A limit of results to return.
+  #
+  # Returns an ActiveRecord::Relation
+  def most_active(limit = 5)
+    @most_active ||= Proposal.
+                   where('updated_at > ?', @from).
+                   where('updated_at <= ?', @to).
+                   order('hot_score desc').
+                   limit(limit)
+  end
+
+  # Public: Returns the most active proposals created by you on a time period.
+  #
+  # limit - A limit of results to return.
+  #
+  # Returns an ActiveRecord::Relation
+  def own_active(limit = 5)
+    @own_active ||= most_active.where(author_id: @user)
+  end
+
+  # Public: Returns the recent comments on the proposals in which you're the author.
+  #
+  # limit - A limit of results to return.
+  #
+  # Returns an ActiveRecord::Relation
+  def recent_comments_on_own_proposals(limit = 5)
+    @recent_comments ||= Comment.
+                       where(commentable: Proposal.where(author: @user)).
+                       where.not(user: @user).
+                       where('updated_at > ?', @from).
+                       where('updated_at <= ?', @to).
+                       order('updated_at desc').
+                       limit(limit)
+  end
+
+  # Public: Returns the recent comments on the proposals that you've supported.
+  #
+  # limit - A limit of results to return.
+  #
+  # Returns an ActiveRecord::Relation
+  def recent_comments_on_voted_proposals(limit = 5)
+    @recent_comments ||= Comment.
+                       where(commentable: @user.get_voted(Proposal)).
+                       where('updated_at > ?', @from).
+                       where('updated_at <= ?', @to).
+                       order('updated_at desc').
+                       limit(limit)
+  end
+
+  # Public: Returns a set of recommendations for a particular user.
+  # limit - A limit of results to return.
+  #
+  # Returns an ActiveRecord::Relation
+  def recommendations(limit = 5)
+    Recommender.new(@user).proposals.limit(limit)
+  end
+
+  # Public: Returns the most active proposals you've voted.
+  #
+  # limit - A limit of results to return.
+  #
+  # Returns an ActiveRecord::Relation
+  def most_active_voted(limit = 5)
+    most_active.where(id: @user.get_voted(Proposal))
+  end
+
+  # Public: Returns the amount of votes a Proposal received during a time period.
+  def votes_count(proposal)
+    proposal.votes_for.
+      where('created_at > ?', @from).
+      where('created_at <= ?', @to).
+      count
+  end
+
+  # Public: Returns the amount of votes a Proposal received during a time period.
+  def comments_count(proposal)
+    proposal.comments.
+      where('created_at > ?', @from).
+      where('created_at <= ?', @to).
+      count
+  end
+end

--- a/app/services/activity_summary.rb
+++ b/app/services/activity_summary.rb
@@ -58,12 +58,13 @@ class ActivitySummary
   #
   # Returns an ActiveRecord::Relation
   def recent_comments_on_voted_proposals(limit = 5)
-    @recent_comments ||= Comment.
-                       where(commentable: @user.get_voted(Proposal)).
-                       where('updated_at > ?', @from).
-                       where('updated_at <= ?', @to).
-                       order('updated_at desc').
-                       limit(limit)
+    @recent_comments_on_voted_proposals ||= Comment.
+                                          where(commentable: @user.get_voted(Proposal)).
+                                          where.not(commentable: @user.proposals).
+                                          where('updated_at > ?', @from).
+                                          where('updated_at <= ?', @to).
+                                          order('updated_at desc').
+                                          limit(limit)
   end
 
   # Public: Returns a set of recommendations for a particular user.

--- a/app/services/recommender.rb
+++ b/app/services/recommender.rb
@@ -1,0 +1,9 @@
+class Recommender
+  def initialize(user)
+    @user = user
+  end
+
+  def proposals
+    @proposals ||= @user.recommended_proposals.order("recommendations.score / (proposals.cached_votes_up + 1) desc")
+  end
+end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -26,6 +26,11 @@
             </tr>
             <tr>
               <td class="footer">
+                <% unless @hide_footer_link %>
+                  <p>
+                    <%= t("mailers.config.manage_email_subscriptions") %> <%= link_to t("account.show.title"), account_url %>
+                  </p>
+                <% end %>
                 <p><%= Setting['org_name'] %></p>
               </td>
             </tr>

--- a/app/views/mailer/comment.html.erb
+++ b/app/views/mailer/comment.html.erb
@@ -13,7 +13,3 @@
 <blockquote>
   <%= text_with_links @comment.body %>
 </blockquote>
-
-<p>
-  <%= t("mailers.config.manage_email_subscriptions") %> <%= link_to t("account.show.title"), account_url %>
-</p>

--- a/app/views/mailer/reply.html.erb
+++ b/app/views/mailer/reply.html.erb
@@ -13,7 +13,3 @@
 <p>
   <%= text_with_links @reply.body %>
 </p>
-
-<p>
-  <%= t("mailers.config.manage_email_subscriptions") %> <%= link_to t("account.show.title"), account_url %>
-</p>

--- a/app/views/summary_mailer/_comments.html.erb
+++ b/app/views/summary_mailer/_comments.html.erb
@@ -1,0 +1,7 @@
+<ul>
+  <% comments.each do |comment| %>
+    <li class="comment">
+      <%= truncate(comment.body, length: 140) %> - <strong><%= comment.author.name %></strong>, <em><%= t("time.ago", time_in_words: time_ago_in_words(comment.created_at)) %></em>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/summary_mailer/_proposals.html.erb
+++ b/app/views/summary_mailer/_proposals.html.erb
@@ -1,0 +1,9 @@
+<ul>
+  <% proposals.each do |proposal|  %>
+    <li>
+      <%= link_to(proposal.title, proposal) %>
+      <br />
+      (<%= t '.activity', votes: summary.votes_count(proposal), comments: summary.comments_count(proposal) %>)
+    </li>
+  <% end %>
+</ul>

--- a/app/views/summary_mailer/weekly.html.erb
+++ b/app/views/summary_mailer/weekly.html.erb
@@ -1,0 +1,82 @@
+<div class="weekly-summary">
+  <div class="title">
+    <h2><%= t '.title' %></h2>
+    <h3 class="date"><%= l @from.to_date %> - <%= l @to.to_date %></h3>
+    <h3 class="name"><%= @user.name %></h3>
+  </div>
+
+  <% if @summary.own_active.any? %>
+    <h3><%= t '.own_active' %></h3>
+    <%= render partial: 'proposals', locals: { proposals: @summary.own_active, summary: @summary } %>
+  <% end %>
+
+  <% if @summary.recent_comments_on_own_proposals.any? %>
+    <h3><%= t '.recent_comments_on_own_proposals' %></h3>
+
+    <% @summary.recent_comments_on_own_proposals.group_by { |c| c.commentable }.each do |proposal, comments|  %>
+      <h4><%= link_to(proposal.title, proposal) %></h4>
+      <ul>
+        <% comments.each do |comment| %>
+          <li class="comment">
+            <%= truncate(comment.body, length: 140) %> - <strong><%= comment.author.name %></strong>, <em><%= t("time.ago", time_in_words: time_ago_in_words(comment.created_at)) %></em>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <% if @summary.recent_comments_on_voted_proposals.any? %>
+    <h3><%= t '.recent_comments_on_voted_proposals' %></h3>
+
+    <% @summary.recent_comments_on_voted_proposals.group_by { |c| c.commentable }.each do |proposal, comments|  %>
+      <h4><%= link_to(proposal.title, proposal) %></h4>
+      <ul>
+        <% comments.each do |comment| %>
+          <li>
+            <%= truncate(comment.body, length: 140) %> - <strong><%= comment.author.name %></strong>, <em><%= t("time.ago", time_in_words: time_ago_in_words(comment.created_at)) %></em>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+
+  <% if @summary.most_active.any? %>
+    <h3><%= t '.most_active' %></h3>
+    <%= render partial: 'proposals', locals: { proposals: @summary.most_active, summary: @summary } %>
+
+    <h3><%= t '.official_random_proposals' %></h3>
+    <ul>
+      <% @official_random_proposals.each do |proposal|  %>
+        <li>
+          <%= link_to(proposal.title, proposal) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if @random_proposals.any? %>
+    <h3><%= t '.random_proposals' %></h3>
+    <ul>
+      <% @random_proposals.each do |proposal|  %>
+        <li>
+          <%= link_to(proposal.title, proposal) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if @upcoming_meetings.any? %>
+    <h3><%= t '.upcoming_meetings' %></h3>
+    <ul>
+      <% @upcoming_meetings.each do |meeting|  %>
+        <li>
+          <%= link_to(meeting.title, meeting) %>
+          <% if meeting.held_at %>
+            <br />
+            (<%=l meeting.held_at %>, <%= time_ago_in_words(meeting.held_at)  %>)
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/summary_mailer/weekly.html.erb
+++ b/app/views/summary_mailer/weekly.html.erb
@@ -15,13 +15,7 @@
 
     <% @summary.recent_comments_on_own_proposals.group_by { |c| c.commentable }.each do |proposal, comments|  %>
       <h4><%= link_to(proposal.title, proposal) %></h4>
-      <ul>
-        <% comments.each do |comment| %>
-          <li class="comment">
-            <%= truncate(comment.body, length: 140) %> - <strong><%= comment.author.name %></strong>, <em><%= t("time.ago", time_in_words: time_ago_in_words(comment.created_at)) %></em>
-          </li>
-        <% end %>
-      </ul>
+      <%= render partial: 'comments', locals: { comments: comments }%>
     <% end %>
   <% end %>
 
@@ -30,13 +24,7 @@
 
     <% @summary.recent_comments_on_voted_proposals.group_by { |c| c.commentable }.each do |proposal, comments|  %>
       <h4><%= link_to(proposal.title, proposal) %></h4>
-      <ul>
-        <% comments.each do |comment| %>
-          <li>
-            <%= truncate(comment.body, length: 140) %> - <strong><%= comment.author.name %></strong>, <em><%= t("time.ago", time_in_words: time_ago_in_words(comment.created_at)) %></em>
-          </li>
-        <% end %>
-      </ul>
+      <%= render partial: 'comments', locals: { comments: comments }%>
     <% end %>
   <% end %>
 

--- a/app/workers/weekly_summary_worker.rb
+++ b/app/workers/weekly_summary_worker.rb
@@ -1,0 +1,15 @@
+class WeeklySummaryWorker
+  include Sidekiq::Worker
+
+  def perform
+    from = 1.week.ago
+    to = Time.now
+
+    User.where(weekly_summary: true).find_each do |user|
+      SummaryMailer.weekly(user, from, to).deliver
+    end
+
+    time = Time.now.next_week(:monday).to_datetime.change({ hour: 7, min: 30, sec: 0 })
+    self.class.perform_at(time)
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -102,6 +102,7 @@ ignore_missing:
   - 'devise.failure.invalid'
   - 'devise.registrations.destroyed'
   - 'date.day_names'
+  - 'time.*'
 
 ## Consider these keys used:
 ignore_unused:

--- a/config/locales/mailers.ca.yml
+++ b/config/locales/mailers.ca.yml
@@ -7,21 +7,29 @@ ca:
       subject: Algú ha comentat al teu %{commentable}
       title: Comentari nou
     config:
-      manage_email_subscriptions: Pots deixar de rebre aquests correus electrònics
-        canviant la configuració a
+      manage_email_subscriptions: Pots deixar de rebre aquests correus electrònics canviant la configuració a
     email_verification:
       click_here_to_verify: a aquest enllaç
-      instructions_2_html: Aquest correu electrònic és per verificar el teu compte
-        amb <b>%{document_type} %{document_number}.</b> Si aquestes no són teves dades,
-        si us plau no facis clic e l'enllaç anterior i ignora aquest correu electrònic.
-      instructions_html: Per acabar de verificar el teu compte, cal que facis clic
-        %{verification_link}.
+      instructions_2_html: Aquest correu electrònic és per verificar el teu compte amb <b>%{document_type} %{document_number}.</b> Si aquestes no són teves dades, si us plau no facis clic e l'enllaç anterior i ignora aquest correu electrònic.
+      instructions_html: Per acabar de verificar el teu compte, cal que facis clic %{verification_link}.
       subject: Verifica la teva adreça electrònica
       thanks: Moltes gràcies.
       title: Verifica el teu compte amb l'enllaç següent
     reply:
       hi: Hola
-      new_reply_by_html: Hi ha una resposta nova de <b>%{commenter}</b> al teu comentari
-        a
+      new_reply_by_html: Hi ha una resposta nova de <b>%{commenter}</b> al teu comentari a
       subject: Algú ha respost al teu comentari
       title: Resposta nova al teu comentari
+  summary_mailer:
+    proposals:
+      activity: "%{votes} vots, %{comments} comentaris"
+    weekly:
+      most_active: Propostes més actives
+      official_random_proposals: Algunes propostes de l'Ajuntament
+      own_active: Les teves propostes més actives
+      random_proposals: Algunes propostes de la ciutadania
+      recent_comments_on_own_proposals: Comentaris recents a les teves propostes
+      recent_comments_on_voted_proposals: Comentaris recents a propostes a les que has donat suport
+      subject: Resum d'activitat (%{from} - %{to})
+      title: Resum d'activitat
+      upcoming_meetings: Properes cites presencials

--- a/config/locales/mailers.ca.yml
+++ b/config/locales/mailers.ca.yml
@@ -22,7 +22,7 @@ ca:
       title: Resposta nova al teu comentari
   summary_mailer:
     proposals:
-      activity: "%{votes} vots, %{comments} comentaris"
+      activity: "%{votes} suports nous, %{comments} comentaris nous"
     weekly:
       most_active: Propostes més actives
       official_random_proposals: Algunes propostes de l'Ajuntament

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -7,21 +7,29 @@ en:
       subject: Someone has commented on your %{commentable}
       title: New comment
     config:
-      manage_email_subscriptions: You can stop receiving these emails by changing
-        your settings in
+      manage_email_subscriptions: You can stop receiving these emails by changing your settings in
     email_verification:
       click_here_to_verify: this link
-      instructions_2_html: This email will verify your account with <b>%{document_type}
-        %{document_number}</b>. If these are not your data, please do not click on
-        the previous link and ignore this email.
-      instructions_html: To complete the verification of your user account, you must
-        click %{verification_link}.
+      instructions_2_html: This email will verify your account with <b>%{document_type} %{document_number}</b>. If these are not your data, please do not click on the previous link and ignore this email.
+      instructions_html: To complete the verification of your user account, you must click %{verification_link}.
       subject: Confirm your email
       thanks: Thank you very much.
       title: Confirm your account using the following link
     reply:
       hi: Hi
-      new_reply_by_html: There is a new response from <b>%{commenter}</b> to your
-        comment on
+      new_reply_by_html: There is a new response from <b>%{commenter}</b> to your comment on
       subject: Someone has responded to your comment
       title: New response to your comment
+  summary_mailer:
+    proposals:
+      activity: "%{votes} votes %{comments} comments"
+    weekly:
+      most_active: Proposals more active this week
+      official_random_proposals: Some proposals of the City
+      own_active: Your active proposals
+      random_proposals: Some proposals citizenship
+      recent_comments_on_own_proposals: Recent comments on your proposals
+      recent_comments_on_voted_proposals: Recent comments on the proposals that have supported
+      subject: Activity summary (%{from} - %{to})
+      title: Activity Summary
+      upcoming_meetings: Upcoming events attended

--- a/config/locales/mailers.es.yml
+++ b/config/locales/mailers.es.yml
@@ -7,21 +7,29 @@ es:
       subject: Alguien ha comentado en tu %{commentable}
       title: Nuevo comentario
     config:
-      manage_email_subscriptions: Puedes dejar de recibir estos correos electrónicos
-        cambiando tu configuración en
+      manage_email_subscriptions: Puedes dejar de recibir estos correos electrónicos cambiando tu configuración en
     email_verification:
       click_here_to_verify: en este enlace
-      instructions_2_html: Este correo electrónico es para verificar tu cuenta con
-        <b>%{document_type} %{document_number}</b>. Si esos no son tus datos, por
-        favor, no pulses el enlace anterior e ignora este correo electrónico.
-      instructions_html: Para terminar de verificar tu cuenta, necesitamos que pulses
-        %{verification_link}.
+      instructions_2_html: Este correo electrónico es para verificar tu cuenta con <b>%{document_type} %{document_number}</b>. Si esos no son tus datos, por favor, no pulses el enlace anterior e ignora este correo electrónico.
+      instructions_html: Para terminar de verificar tu cuenta, necesitamos que pulses %{verification_link}.
       subject: Verifica tu correo electrónico
       thanks: Muchas gracias.
       title: Verifica tu cuenta con el siguiente enlace
     reply:
       hi: "¡Hola!"
-      new_reply_by_html: Hay una nueva respuesta de <b>%{commenter}</b> a tu comentario
-        en
+      new_reply_by_html: Hay una nueva respuesta de <b>%{commenter}</b> a tu comentario en
       subject: Alguien ha respondido a tu comentario
       title: Nueva respuesta a tu comentario
+  summary_mailer:
+    proposals:
+      activity: "%{votes} votos, %{comments} comentarios"
+    weekly:
+      most_active: Propuestas más activas
+      official_random_proposals: Algunas propuestas del Ayuntamiento
+      own_active: Tus propuestas más activas
+      random_proposals: Algunas propuestas de la ciudadanía
+      recent_comments_on_own_proposals: Comentarios recientes en tus propuestas
+      recent_comments_on_voted_proposals: Comentarios recientes en propuestas a las que has apoyado
+      subject: Resumen de actividad (%{from} - %{to})
+      title: Resumen de actividad
+      upcoming_meetings: Próximas citas presenciales

--- a/config/locales/mailers.es.yml
+++ b/config/locales/mailers.es.yml
@@ -22,7 +22,7 @@ es:
       title: Nueva respuesta a tu comentario
   summary_mailer:
     proposals:
-      activity: "%{votes} votos, %{comments} comentarios"
+      activity: "%{votes} soportes nuevos, %{comments} comentarios nuevos"
     weekly:
       most_active: Propuestas más activas
       official_random_proposals: Algunas propuestas del Ayuntamiento

--- a/config/locales/rails.ca.yml
+++ b/config/locales/rails.ca.yml
@@ -10,3 +10,4 @@ ca:
     formats:
       datetime: "%d/%m/%Y %H:%M:%S"
       default: "%H:%M"
+    ago: fa %{time_in_words}

--- a/spec/mailers/previews/summary_mailer_preview.rb
+++ b/spec/mailers/previews/summary_mailer_preview.rb
@@ -1,0 +1,8 @@
+# Preview all emails at http://localhost:3000/rails/mailers/summary_mailer
+class SummaryPreview < ActionMailer::Preview
+  def weekly
+    email = SummaryMailer.weekly(User.last)
+    email.message.send(:inline_styles)
+    email
+  end
+end

--- a/spec/mailers/summary_mailer_spec.rb
+++ b/spec/mailers/summary_mailer_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe SummaryMailer, type: :mailer do
+  describe "weekly" do
+    it "sends a weekly report" do
+      user = create(:user)
+      proposals = create_list(:proposal, 4)
+      past_meetings = create_list(:meeting, 3, held_at: Date.yesterday)
+      upcoming_meetings = create_list(:meeting, 3, held_at: Date.tomorrow)
+
+      mail = SummaryMailer.weekly(user)
+      mail.deliver_now
+
+      last_email = ActionMailer::Base.deliveries.last
+      expect(mail_content(last_email)).to include(*proposals.map(&:title))
+      expect(mail_content(last_email)).to include(*upcoming_meetings.map(&:title))
+      expect(mail_content(last_email)).to_not include(*past_meetings.map(&:title))
+    end
+  end
+end

--- a/spec/services/activity_summary_spec.rb
+++ b/spec/services/activity_summary_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+describe ActivitySummary do
+  let(:user) { create(:user) }
+  let(:since) { 7.days.ago }
+  let(:subject) { described_class.new(user, since) }
+
+  before do
+    allow(ProposalScoreCalculatorWorker).
+      to receive(:perform_async).with(anything).and_return true
+  end
+
+  describe "#most_active_proposals" do
+    let!(:past_proposals){ create_list(:proposal, 3, hot_score: 15, updated_at: 30.days.ago) }
+    let!(:hot_proposals){ create_list(:proposal, 3, hot_score: 10) }
+    let!(:inactive_proposals){ create_list(:proposal, 3, hot_score: 3) }
+
+    it "includes the most active" do
+      expect(subject.most_active(3)).to include(*hot_proposals)
+    end
+  end
+
+  describe "#own_active_proposals" do
+    let!(:own_hot_proposals){ create_list(:proposal, 3, hot_score: 8, author: user) }
+    let!(:own_proposals){ create_list(:proposal, 3, hot_score: 5, author: user) }
+    let!(:hot_proposals){ create_list(:proposal, 3, hot_score: 10) }
+    let!(:past_proposals){ create_list(:proposal, 3, hot_score: 15, updated_at: 30.days.ago) }
+
+    it "includes the user's proposals" do
+      expect(subject.own_active(3)).to include(*own_hot_proposals)
+    end
+  end
+
+  describe "#latest_comments" do
+    let!(:own_proposal) { create(:proposal, author: user) }
+    let!(:proposal) { create(:proposal) }
+
+    let!(:past_comments_on_proposals) do
+      create_list(:comment, 3, updated_at: 3.days.ago)
+    end
+
+    let!(:recent_comments_on_own_proposals) do
+      create_list(:comment, 3, commentable: own_proposal, updated_at: 3.days.ago)
+    end
+
+    let!(:past_comments_on_own_proposals) do
+      create_list(:comment, 3, commentable: own_proposal, updated_at: 5.days.ago)
+    end
+
+    it "includes latest comments in your proposals" do
+      expect(subject.recent_comments_on_own_proposals(3)).to include(*recent_comments_on_own_proposals)
+    end
+  end
+
+  describe "#most_active_voted" do
+    let!(:proposals) { create_list(:proposal, 3, hot_score: 20) }
+    let!(:voted_proposals) { create_list(:proposal, 3, hot_score: 10) }
+
+    before do
+      voted_proposals.each{ |proposal| user.likes proposal }
+    end
+
+    it "includes latest comments in your proposals" do
+      expect(subject.most_active_voted(3)).to include(*voted_proposals)
+    end
+  end
+
+  describe "#votes_count" do
+    let(:user2){ create(:user) }
+    let(:user3){ create(:user) }
+    let(:user4){ create(:user) }
+    let(:proposal) { create(:proposal) }
+
+    it "returns the amount of votes a proposal received during a time period" do
+      Timecop.freeze(15.days.ago) do
+        user2.likes proposal
+      end
+
+      user3.likes proposal
+      user4.likes proposal
+
+      expect(subject.votes_count(proposal)).to eq(2)
+    end
+  end
+
+  describe "#comments_count" do
+    let(:proposal) { create(:proposal) }
+
+    it "returns the amount of votes a proposal received during a time period" do
+      Timecop.freeze(15.days.ago) do
+        create(:comment, commentable: proposal)
+      end
+
+      create_list(:comment, 2, commentable: proposal)
+
+      expect(subject.comments_count(proposal)).to eq(2)
+    end
+  end
+end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -1,6 +1,10 @@
 module CommonActions
   def last_email_content
     mail = ActionMailer::Base.deliveries.last
+    mail_content(mail)
+  end
+
+  def mail_content(mail)
     mail.body.parts.find {|p| p.content_type.match(/html/)}.body.raw_source
   end
 


### PR DESCRIPTION
Per mantenir els usuaris actius i dur-los a votar a més propostes, així com llegir les noves que van apareixent, hauríem d'enviar un correu setmanal de resum.

Respecte què ha de contenir el correu, aquestes són algunes idees:
- Activitat a les teves propostes (comentaris, vots)
- Activitat a les propostes que has votat (comentaris i vots)
- Propostes suggerides basades en la feina de: https://github.com/AjuntamentdeBarcelona/decidim.barcelona/issues/204
- Resum de les propostes més votades de la setmana (suggerit per @Alotria)

Todo:
- [ ] Google Analytics campaign

S'agraeix feedback!
## GIF motivacional!

![](https://ak-hdl.buzzfed.com/static/2014-02/enhanced/webdr08/16/18/anigif_enhanced-buzz-26250-1392595024-8.gif)
