### PR TITLE
Take into account locale when caching proposals

### DIFF
--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id(proposal) %>" class="proposal clear <%= proposal_class_names proposal %>">
     <div class="row">
       <div class="small-12 medium-9 column">
-        <%= cache [proposal, proposal.author] do %>
+        <%= cache [proposal, proposal.author, I18n.locale] do %>
           <div class="proposal-content">
             <% if proposal.official? %>
               <span class="official-badge"></span>


### PR DESCRIPTION
This fixes proposals showing wrong locales in titles as stated in #225.
