### PR TITLE
Raise 404 on feature disabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  rescue_from FeatureFlags::FeatureDisabled do |exception|
+    if Rails.env.production?
+      raise ActionController::RoutingError.new('Not Found')
+    else
+      raise exception
+    end
+  end
+
   layout :set_layout
   respond_to :html
 


### PR DESCRIPTION
This will prevent exceptions from being sent to our exception tracker.
