### PR TITLE
Refer to both genders in authorship

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -46,7 +46,7 @@ ca:
   comments:
     comment:
       admin: Administrador
-      author: Autor
+      author: Autor/a
       deleted: Aquest comentari ha estat eliminat
       moderator: Moderador
       responses:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -46,7 +46,7 @@ es:
   comments:
     comment:
       admin: Administrador
-      author: Autor
+      author: Autor/a
       deleted: Este comentario ha sido eliminado
       moderator: Moderador
       responses:


### PR DESCRIPTION
# What and why?

This improves several copies on the page in order to better follow the communication directives.
