### PR TITLE
District is a model

### DIFF
--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -2,16 +2,16 @@ class ProposalDecorator < ApplicationDecorator
   delegate_all
 
   def district_name
-    district[0] if district
+    district.name if district
   end
 
   def district_id
-    district[1] if district
+    district.id if district
   end
 
   private
 
   def district
-    @district ||= Proposal::DISTRICTS.detect { |district| object.district == district[1].to_i }
+    @district ||= District.find(object.district)
   end
 end

--- a/app/helpers/meetings_directory_helper.rb
+++ b/app/helpers/meetings_directory_helper.rb
@@ -5,7 +5,7 @@ module MeetingsDirectoryHelper
       filter: options[:filter],
       filterUrl: meetings_url,
       meetings: serialized_meetings(options[:meetings]),
-      districts: Proposal::DISTRICTS,
+      districts: District.all.map{ |district| [district.name, district.id] },
       categories: serialized_categories,
       subcategories: serialized_subcategories,
       tagCloud: options[:tag_cloud],

--- a/app/helpers/proposal_filters_helper.rb
+++ b/app/helpers/proposal_filters_helper.rb
@@ -4,7 +4,7 @@ module ProposalFiltersHelper
       'ProposalFilters', 
       filter: options[:filter],
       filterUrl: proposals_url,
-      districts: Proposal::DISTRICTS,
+      districts: District.all.map{ |district| [district.name, district.id] },
       categories: serialized_categories,
       subcategories: serialized_subcategories,
       tagCloud: options[:tag_cloud],

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -1,0 +1,15 @@
+class District
+  include ActiveModel::Model
+
+  def self.all
+    @all ||= YAML::load_file("#{Rails.root}/config/districts.yml")["districts"].map do |id, attrs|
+      new({id: id.to_i}.merge(attrs))
+    end
+  end
+
+  def self.find(id)
+    all.find{ |district| id.to_i == district.id.to_i }
+  end
+
+  attr_accessor :id, :name
+end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -20,7 +20,7 @@ class Meeting < ActiveRecord::Base
   validates :address, presence: true
   validates :held_at, presence: true
   validates :scope, inclusion: { in: %w(city district) }
-  validates :district, inclusion: { in: Proposal::DISTRICTS.map(&:last).map(&:to_i), allow_nil: true }
+  validates :district, inclusion: { in: District.all.map(&:id), allow_nil: true }
 
   pg_search_scope :pg_search, {
     against: {

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -1,7 +1,4 @@
 class Proposal < ActiveRecord::Base
-
-  DISTRICTS = YAML::load_file("#{Rails.root}/config/districts.yml")["districts"].to_a.map(&:reverse).map {|a,b| [a.to_s, b.to_s]}.sort
-
   extend FriendlyId
   include Flaggable
   include Taggable
@@ -32,7 +29,7 @@ class Proposal < ActiveRecord::Base
   validates :title, length: { in: 4..Proposal.title_max_length }
   validates :description, length: { maximum: Proposal.description_max_length }
   validates :scope, inclusion: { in: %w(city district) }
-  validates :district, inclusion: { in: DISTRICTS.map(&:last).map(&:to_i), allow_nil: true }
+  validates :district, inclusion: { in: District.all.map(&:id), allow_nil: true }
   validates :question, length: { in: 10..Proposal.question_max_length }, allow_blank: true
   validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length }
 

--- a/app/views/pages/download.html.erb
+++ b/app/views/pages/download.html.erb
@@ -13,10 +13,10 @@
           </span>
         </li>
 
-        <% Proposal::DISTRICTS.each do |name, key| %>
+        <% District.all.each do |district| %>
           <li>
             <span>
-              <%= link_to t('.download-district', district: name), download_for(key) %>
+              <%= link_to t('.download-district', district: district.name), download_for(district.id) %>
             </span>
           </li>
         <% end %>

--- a/app/views/shared/forms/_district_fields.html.erb
+++ b/app/views/shared/forms/_district_fields.html.erb
@@ -10,6 +10,6 @@
 </div>
 
 <div class="small-12 column">
-  <%= f.select :district, Proposal::DISTRICTS %>
+  <%= f.select :district, District.all.map{|d| [d.name, d.id] } %>
 </div>
 

--- a/config/districts.yml
+++ b/config/districts.yml
@@ -1,11 +1,21 @@
 districts:
-  1: "Ciutat Vella"
-  2: "Eixample"
-  3: "Sants Montjuïc"
-  4: "Les Corts"
-  5: "Sarrià - Sant Gervasi"
-  6: "Gràcia"
-  7: "Horta - Guinardó"
-  8: "Nou Barris"
-  9: "Sant Andreu"
-  10: "Sant Martí"
+  1:
+    name: "Ciutat Vella"
+  2:
+    name: "Eixample"
+  3:
+    name: "Sants Montjuïc"
+  4:
+    name: "Les Corts"
+  5:
+    name: "Sarrià - Sant Gervasi"
+  6:
+    name: "Gràcia"
+  7:
+    name: "Horta - Guinardó"
+  8:
+    name: "Nou Barris"
+  9:
+    name: "Sant Andreu"
+  10:
+    name: "Sant Martí"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -91,7 +91,7 @@ if ENV["SEED"]
 
     if [true, false].sample
       scope = 'district'
-      district = Proposal::DISTRICTS.map(&:last).sample
+      district = District.all.map(&:id).sample
     else
       scope = 'city'
       district = nil
@@ -130,7 +130,7 @@ if ENV["SEED"]
 
     if [true, false].sample
       scope = 'district'
-      district = Proposal::DISTRICTS.map(&:last).sample
+      district = District.all.map(&:id).sample
     else
       scope = 'city'
       district = nil

--- a/lib/proposal_xls_importer.rb
+++ b/lib/proposal_xls_importer.rb
@@ -40,7 +40,7 @@ class ProposalXLSImporter
     proposal = Proposal.new(attrs)
     result = proposal.save
     unless result
-      district = Proposal::DISTRICTS.detect { |district| proposal.district == district[1].to_i }
+      district = District.find(proposal.district)
       puts " #{district}|#{proposal.title}|#{proposal.errors.messages.to_s}"
     end
   end
@@ -77,7 +77,7 @@ class ProposalXLSImporter
       if @data[:district_name] == "Barcelona" or @data[:district_name] == "Tota la Ciutat (PAM)"
         @data[:scope] = "city"
       else
-        district = Proposal::DISTRICTS.detect { |district| district[0] == @data[:district_name] }
+        district = District.all.find { |d| d.name == @data[:district_name] }
         @data[:scope] = "district"
         @data[:district_id] = district[1]
       end


### PR DESCRIPTION
# Why?

As districts gain more entity in the system, we should promote them to be a model. This will allow us determining districts via postal codes and such.
