### PR TITLE
Link users on proposal list

### DIFF
--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -25,7 +25,9 @@
                 <% else %>
                   <span class="bullet">&nbsp;&bull;&nbsp;</span>
                   <span class="author">
-                    <%= proposal.author.name %>
+                    <%= link_to user_path(proposal.author) do %>
+                      <%= proposal.author.name %>
+                    <% end %>
                   </span>
                   <% if proposal.author.official? %>
                     <span class="bullet">&nbsp;&bull;&nbsp;</span>


### PR DESCRIPTION
# Why?

Playful exploration is one of the goals to achieve if we want equality of opportunities in proposals. Allowing users to check out other users' proposals and comments partly enables that.

This allows clicking on a user on the proposals list to see her profile.
# GIF TAX

![](https://media.giphy.com/media/VEakclh6bmV4A/giphy.gif)
