### PR TITLE
Add document number to organizations

### DIFF
--- a/app/controllers/organizations/registrations_controller.rb
+++ b/app/controllers/organizations/registrations_controller.rb
@@ -29,7 +29,10 @@ class Organizations::RegistrationsController < Devise::RegistrationsController
   private
 
     def sign_up_params
-      params.require(:user).permit(:email, :password, :phone_number, :password_confirmation, :captcha, :captcha_key, :terms_of_service, organization_attributes: [:name, :responsible_name])
+      params.require(:user).permit(:email, :password, :phone_number,
+                                   :password_confirmation, :captcha,
+                                   :captcha_key, :terms_of_service,
+                                   organization_attributes: [:name, :responsible_name, :document_number])
     end
 
 end

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -23,6 +23,7 @@
     <% hidden += 1 and next if organization.user.nil? || organization.user.hidden? %>
     <tr id="<%= dom_id(organization) %>">
     <td><%= organization.name %></td>
+    <td><%= organization.document_number %></td>
     <td><%= organization.email %></td>
     <td><%= organization.phone_number %></td>
     <td><%= organization.responsible_name %></td>

--- a/app/views/organizations/registrations/new.html.erb
+++ b/app/views/organizations/registrations/new.html.erb
@@ -8,6 +8,7 @@
 
       <%= f.fields_for :organization do |fo| %>
         <%= fo.text_field :name, autofocus: true, maxlength: Organization.name_max_length, placeholder: t("devise_views.organizations.registrations.new.organization_name_label") %>
+        <%= fo.text_field :document_number, placeholder: t("devise_views.organizations.registrations.new.organization_document_number_label") %>
         <%= fo.label :responsible_name %>
         <p class="note"><%= t("devise_views.organizations.registrations.new.responsible_name_note") %></p>
         <%= fo.text_field :responsible_name, placeholder: t("devise_views.organizations.registrations.new.responsible_name_label"), maxlength: Organization.responsible_name_max_length, label: false %>

--- a/config/locales/activerecord.ca.yml
+++ b/config/locales/activerecord.ca.yml
@@ -12,6 +12,7 @@ ca:
         title: Títol
       organization:
         name: Nom d'organització
+        document_number: NIF
         responsible_name: Persona responsable del col·lectiu
       proposal:
         author: Autor/a

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -70,3 +70,4 @@ en:
       organization:
         name: Name of organisation
         responsible_name: Person responsible for the group
+        document_number: NIF

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -70,3 +70,4 @@ es:
       organization:
         name: Nombre de organización
         responsible_name: Persona responsable del colectivo
+        document_number: NIF

--- a/config/locales/devise_views.ca.yml
+++ b/config/locales/devise_views.ca.yml
@@ -41,6 +41,7 @@ ca:
       registrations:
         new:
           email_label: Adreça electrònica
+          organization_document_number_label: NIF
           organization_name_label: Nom de l'organització
           password_confirmation_label: Confirma la contrasenya
           password_label: Contrasenya

--- a/config/locales/devise_views.en.yml
+++ b/config/locales/devise_views.en.yml
@@ -41,6 +41,7 @@ en:
       registrations:
         new:
           email_label: Email
+          organization_document_number_label: NIF
           organization_name_label: Name of organisation
           password_confirmation_label: Confirm password
           password_label: Password

--- a/config/locales/devise_views.es.yml
+++ b/config/locales/devise_views.es.yml
@@ -41,6 +41,7 @@ es:
       registrations:
         new:
           email_label: Correo electrónico
+          organization_document_number_label: NIF
           organization_name_label: Nombre de la organización
           password_confirmation_label: Confirmar contraseña
           password_label: Contraseña

--- a/db/migrate/20160215113838_add_document_number_to_organizations.rb
+++ b/db/migrate/20160215113838_add_document_number_to_organizations.rb
@@ -1,0 +1,7 @@
+class AddDocumentNumberToOrganizations < ActiveRecord::Migration
+  def change
+    change_table :organizations do |t| 
+      t.string :document_number
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160211071429) do
+ActiveRecord::Schema.define(version: 20160215113838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -267,6 +267,7 @@ ActiveRecord::Schema.define(version: 20160211071429) do
     t.datetime "verified_at"
     t.datetime "rejected_at"
     t.string   "responsible_name", limit: 60
+    t.string   "document_number"
   end
 
   add_index "organizations", ["user_id"], name: "index_organizations_on_user_id", using: :btree


### PR DESCRIPTION
# What & Why?

This adds a document number field to organizations so we can better assess wether they're real or not.
