### PR TITLE
Enforce style validations when creating proposals

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -1,3 +1,5 @@
+require_dependency 'style_validator'
+
 class Proposal < ActiveRecord::Base
   extend FriendlyId
   include Flaggable
@@ -22,6 +24,7 @@ class Proposal < ActiveRecord::Base
   has_many :recommendations
 
   validates :title, presence: true
+  validates :title, style: true, on: :create
   validates :summary, presence: true, length: { maximum: 350 }
   validates :author, presence: true
   validates :responsible_name, presence: true

--- a/app/validators/style_validator.rb
+++ b/app/validators/style_validator.rb
@@ -1,0 +1,23 @@
+# coding: utf-8
+class StyleValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    validate_caps(record, attribute, value)
+    validate_marks(record, attribute, value)
+  end
+
+  private
+
+  def validate_caps(record, attribute, value)
+    if value.scan(/[A-Z]/).length > value.length / 2
+      record.errors[attribute] << (options[:message] || I18n.t('validators.style.caps'))
+    end
+  end
+
+  def validate_marks(record, attribute, value)
+    if value.scan(/[!?¡¿]{2,}/).length > 0
+      record.errors[attribute] << (options[:message] || I18n.t('validators.style.marks'))
+    end
+  end
+end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -466,6 +466,10 @@ ca:
           other: "%{count} Propostes"
       no_activity: Usuari sense activitat pública
       private_activity: Aquest usuari ha decidit mantenir en privat la seva llista d'activitats
+  validators:
+    style:
+      caps: "massa majúscules"
+      marks: "massa signes d'interrogació i/o exclamació"
   votes:
     agree: Estic d'acord
     anonymous: Massa vots anònims, per poder votar %{verify_account}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -470,6 +470,10 @@ en:
           other: "%{count} Proposals"
       no_activity: User has no public activity
       private_activity: This user decided to keep the activity list private
+  validators:
+    style:
+      caps: "too many capital letters"
+      marks: "too many exclamation and/or question marks"
   votes:
     agree: I agree
     anonymous: Too many anonymous votes to admit vote %{verify_account}.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -470,6 +470,10 @@ es:
           other: "%{count} Propuestas"
       no_activity: Usuario sin actividad pública
       private_activity: Este usuario ha decidido mantener en privado su lista de actividades
+  validators:
+    style:
+      caps: "demasiadas mayúsculas"
+      marks: "demasiados signos de interrocación y/o exclamación"
   votes:
     agree: Estoy de acuerdo
     anonymous: Demasiados votos anónimos, para poder votar %{verify_account}.

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -446,7 +446,7 @@ describe Proposal do
     context "case" do
 
       it "searches case insensite" do
-        proposal = create(:proposal, title: 'SHOUT')
+        proposal = create(:proposal, title: 'Shout')
 
         results = Proposal.search('shout')
         expect(results).to eq([proposal])

--- a/spec/validators/style_validator_spec.rb
+++ b/spec/validators/style_validator_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require_dependency 'style_validator'
+
+describe StyleValidator do
+  let(:subject) do
+    Class.new do
+      include ActiveModel::Model
+      attr_accessor :title
+
+      validates :title, style: true
+    end
+  end
+
+  describe "valid?" do
+    context "caps" do
+      it "returns true if title has a moderate amount of capital letters" do
+        expect(subject.new(title: "This has a moderate amount of CAPS.")).to be_valid
+      end
+
+      it "returns false if the title has an inadequate amount of caps" do
+        expect(subject.new(title: "OMG I AM SO RUDE, damn.")).to_not be_valid
+      end
+    end
+
+    context "symbols and exclamation marks" do
+      it "returns true if title doesn't have any exclamation marks" do
+        expect(subject.new(title: "I am reasonable!")).to be_valid
+      end
+
+      it "returns false if the title has too many exclamation marks" do
+        expect(subject.new(title: "Hey, are you here? Listen to me!!")).to_not be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why?

Some proposals are being created that abuse CAPS. This makes sure this doesn't happen, thus increasing the average proposal quality.
