### PR TITLE
Show the meetings created in the user activity page

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -1421,5 +1421,10 @@ table {
       content: "h";
       top: 18px;
     }
+
+    &.activity-meetings td:before {
+      content: "g";
+      top: 18px;
+    }
   }
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  has_filters %w{proposals debates comments}, only: :show
+  has_filters %w{proposals meetings debates comments}, only: :show
 
   load_and_authorize_resource
 
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
     def set_activity_counts
       @activity_counts = HashWithIndifferentAccess.new(
                           proposals: Proposal.where(author_id: @user.id).count,
+                          meetings: Meeting.where(author_id: @user.id).count,
                           debates: Debate.where(author_id: @user.id).count,
                           comments: Comment.not_as_admin_or_moderator.where(user_id: @user.id).count)
     end
@@ -19,6 +20,7 @@ class UsersController < ApplicationController
       set_activity_counts
       case params[:filter]
       when "proposals" then load_proposals
+      when "meetings" then load_meetings
       when "debates"   then load_debates
       when "comments"  then load_comments
       else load_available_activity
@@ -29,6 +31,9 @@ class UsersController < ApplicationController
       if @activity_counts[:proposals] > 0
         load_proposals
         @current_filter = "proposals"
+      elsif  @activity_counts[:meetings] > 0
+        load_meetings
+        @current_filter = "meetings"
       elsif  @activity_counts[:debates] > 0
         load_debates
         @current_filter = "debates"
@@ -40,6 +45,10 @@ class UsersController < ApplicationController
 
     def load_proposals
       @proposals = Proposal.where(author_id: @user.id).order(created_at: :desc).page(params[:page])
+    end
+
+    def load_meetings
+      @meetings = Meeting.where(author_id: @user.id).order(created_at: :desc).page(params[:page])
     end
 
     def load_debates

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -1,5 +1,6 @@
 <%= form_for(@proposal, url: form_url) do |f| %>
   <%= render 'shared/errors', resource: @proposal %>
+  <%= @proposal.errors.inspect %>
 
   <div class="row">
     <div class="small-12 column">

--- a/app/views/users/_activity_page.html.erb
+++ b/app/views/users/_activity_page.html.erb
@@ -1,3 +1,4 @@
 <%= render "proposals" if @proposals.present? %>
+<%= render "meetings" if @meetings.present? %>
 <%= render "debates" if @debates.present? && feature?(:debates) %>
 <%= render "comments" if @comments.present? %>

--- a/app/views/users/_meetings.html.erb
+++ b/app/views/users/_meetings.html.erb
@@ -1,0 +1,13 @@
+<table class="clear activity-meetings">
+  <% @meetings.each do |meeting| %>
+    <tr id="meeting<%= meeting.id %>">
+      <td>
+        <%= link_to meeting.title, meeting %>
+        <br>
+        <%= meeting.description %>
+      </td>
+    </tr>
+  <% end %>
+</table>
+
+<%= paginate @meetings %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -476,6 +476,9 @@ ca:
         proposals:
           one: 1 Proposta
           other: "%{count} Propostes"
+        meetings:
+          one: 1 Cita presencial
+          other: "%{count} Cites presencials"
       no_activity: Usuari sense activitat pública
       private_activity: Aquest usuari ha decidit mantenir en privat la seva llista d'activitats
   validators:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -480,6 +480,9 @@ en:
         proposals:
           one: 1 Proposal
           other: "%{count} Proposals"
+        meetings:
+          one: 1 Presencial meeting
+          other: "%{count} Presencial meetings"
       no_activity: User has no public activity
       private_activity: This user decided to keep the activity list private
   validators:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -480,6 +480,9 @@ es:
         proposals:
           one: 1 Propuesta
           other: "%{count} Propuestas"
+        meetings:
+          one: 1 Cita presencial
+          other: "%{count} Citas presenciales"
       no_activity: Usuario sin actividad pública
       private_activity: Este usuario ha decidido mantener en privado su lista de actividades
   validators:


### PR DESCRIPTION
# What and why

I added meetings creation activity to the user activity page.
# QA

Navigate to the user activity page and meetings created should appear at the second tab.
# GIF Tax

![](https://media.giphy.com/media/yXBqba0Zx8S4/giphy.gif)
