### PR TITLE
Add Proposal Answers

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -14,3 +14,4 @@
 @import "components/debate_info_box";
 @import "components/infinite_pagination";
 @import "components/social_share_buttons";
+@import "components/proposal_answer_box";

--- a/app/assets/stylesheets/components/_proposal_answer_box.scss
+++ b/app/assets/stylesheets/components/_proposal_answer_box.scss
@@ -1,0 +1,9 @@
+.proposal-answer-box{
+  button.accept{
+    background-color: green;
+  }
+
+  .selected{
+    text-decoration: underline;
+  }
+}

--- a/app/assets/stylesheets/components/_proposal_answer_box.scss
+++ b/app/assets/stylesheets/components/_proposal_answer_box.scss
@@ -2,6 +2,8 @@
   button{
     border: 1px solid transparent;
     background-color: $highlight;
+    margin-right: rem-calc(10);
+    margin-top: rem-calc(10);
   }
 
   button.accept{

--- a/app/assets/stylesheets/components/_proposal_answer_box.scss
+++ b/app/assets/stylesheets/components/_proposal_answer_box.scss
@@ -1,9 +1,28 @@
 .proposal-answer-box{
+  button{
+    border: 1px solid transparent;
+    background-color: $highlight;
+  }
+
   button.accept{
+    color: green;
+    border-color: green;
+  }
+
+  button.reject{
+    color: $delete;
+    border-color: $delete;
+  }
+
+  button.selected{
+    color: $text-inverse;
+  }
+
+  button.accept.selected{
     background-color: green;
   }
 
-  .selected{
-    text-decoration: underline;
+  button.reject.selected{
+    background-color: $delete;
   }
 }

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,6 +1,7 @@
 class Api::ApplicationController < ActionController::Base
   serialization_scope :view_context
   check_authorization
+  respond_to :json
 
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,10 @@
+class Api::ApplicationController < ActionController::Base
+  serialization_scope :view_context
+  check_authorization
+
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.json { render json: {error: exception.message}, status: :forbidden }
+    end
+  end
+end

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,5 +1,5 @@
-class Api::CategoriesController < ApplicationController
-  skip_authorization_check
+class Api::CategoriesController < Api::ApplicationController
+  load_and_authorize_resource
 
   def index
     @categories = Category.all

--- a/app/controllers/api/districts_controller.rb
+++ b/app/controllers/api/districts_controller.rb
@@ -1,5 +1,5 @@
-class Api::DistrictsController < ApplicationController
-  skip_authorization_check
+class Api::DistrictsController < Api::ApplicationController
+  load_and_authorize_resource
 
   def index
     @districts = District.all.map { |district| [district.name, district.id] }

--- a/app/controllers/api/meetings_controller.rb
+++ b/app/controllers/api/meetings_controller.rb
@@ -1,6 +1,5 @@
-class Api::MeetingsController < ApplicationController
-  skip_authorization_check
-  serialization_scope :view_context
+class Api::MeetingsController < Api::ApplicationController
+  load_and_authorize_resource
 
   def index
     meetings = Meeting.all

--- a/app/controllers/api/proposal_answers_controller.rb
+++ b/app/controllers/api/proposal_answers_controller.rb
@@ -3,12 +3,15 @@ class Api::ProposalAnswersController < Api::ApplicationController
   #before_action :authenticate_user!
 
   def create
-    @answer = @proposal.create_answer(strong_params)
+    @answer = @proposal.build_answer(strong_params)
+    authorize! :create, @answer
+    @answer.save
     set_response
   end
 
   def update
     @answer = @proposal.answer
+    authorize! :update, @answer
     @answer.update_attributes(strong_params)
     set_response
   end

--- a/app/controllers/api/proposal_answers_controller.rb
+++ b/app/controllers/api/proposal_answers_controller.rb
@@ -3,7 +3,7 @@ class Api::ProposalAnswersController < Api::ApplicationController
   #before_action :authenticate_user!
 
   def create
-    @answer = @proposal.create_proposal_answer(strong_params)
+    @answer = @proposal.create_answer(strong_params)
     set_response
   end
 
@@ -17,7 +17,7 @@ class Api::ProposalAnswersController < Api::ApplicationController
 
   def strong_params
     permitted_params = [:message, :status]
-    params.require(:proposal_answer).permit(permitted_params)
+    params.require(:answer).permit(permitted_params)
   end
 
   def set_response

--- a/app/controllers/api/proposal_answers_controller.rb
+++ b/app/controllers/api/proposal_answers_controller.rb
@@ -1,0 +1,30 @@
+class Api::ProposalAnswersController < Api::ApplicationController
+  load_and_authorize_resource :proposal
+  #before_action :authenticate_user!
+
+  def create
+    @answer = @proposal.create_proposal_answer(strong_params)
+    set_response
+  end
+
+  def update
+    @answer = @proposal.answer
+    @answer.update_attributes(strong_params)
+    set_response
+  end
+
+  private
+
+  def strong_params
+    permitted_params = [:message, :status]
+    params.require(:proposal_answer).permit(permitted_params)
+  end
+
+  def set_response
+    if @answer.valid?
+      render json: @answer
+    else
+      render json: { errors: @answer.errors }, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -30,6 +30,10 @@ class Api::ProposalsController < Api::ApplicationController
     end
   end
 
+  def show
+    render json: @proposal
+  end
+
   private
 
   def set_seed

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -1,6 +1,7 @@
-class Api::ProposalsController < ApplicationController
-  skip_authorization_check
-  serialization_scope :view_context
+class Api::ProposalsController < Api::ApplicationController
+  include HasOrders
+
+  load_and_authorize_resource
 
   has_orders %w{random hot_score confidence_score created_at}, only: :index
 

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -1,20 +1,11 @@
-class Api::VotesController < ApplicationController
-  skip_authorization_check
-  serialization_scope :view_context
-  skip_before_action :verify_authenticity_token
+class Api::VotesController < Api::ApplicationController
   before_action :authenticate_user!
-  before_action :load_proposal
-  respond_to :json
+  load_and_authorize_resource :proposal
 
   def create
+    authorize! :vote, @proposal
     @proposal.register_vote(current_user, 'yes')
     @vote = Vote.where(voter: current_user, votable: @proposal).first
     render json: @vote
-  end
-
-  private
-
-  def load_proposal
-    @proposal = Proposal.find(params[:proposal_id])
   end
 end

--- a/app/controllers/concerns/moderate_actions.rb
+++ b/app/controllers/concerns/moderate_actions.rb
@@ -5,6 +5,7 @@ module ModerateActions
   def index
     @resources = @resources.send(@current_filter)
                        .send("sort_by_#{@current_order}")
+                       .includes(:author)
                        .page(params[:page])
                        .per(50)
     set_resources_instance

--- a/app/controllers/concerns/moderate_actions.rb
+++ b/app/controllers/concerns/moderate_actions.rb
@@ -5,7 +5,6 @@ module ModerateActions
   def index
     @resources = @resources.send(@current_filter)
                        .send("sort_by_#{@current_order}")
-                       .includes(:author)
                        .page(params[:page])
                        .per(50)
     set_resources_instance

--- a/app/controllers/revision/base_controller.rb
+++ b/app/controllers/revision/base_controller.rb
@@ -1,0 +1,15 @@
+class Revision::BaseController < ApplicationController
+  layout 'admin'
+
+  before_action :authenticate_user!
+  before_action :verify_reviewer
+
+  skip_authorization_check
+
+  private
+
+    def verify_reviewer
+      raise CanCan::AccessDenied unless can? :access_panel, :revision
+    end
+
+end

--- a/app/controllers/revision/dashboard_controller.rb
+++ b/app/controllers/revision/dashboard_controller.rb
@@ -1,0 +1,6 @@
+class Revision::DashboardController < Revision::BaseController
+
+  def index
+  end
+
+end

--- a/app/controllers/revision/proposals_controller.rb
+++ b/app/controllers/revision/proposals_controller.rb
@@ -1,0 +1,16 @@
+class Revision::ProposalsController < Revision::BaseController
+  include ModerateActions
+
+  has_filters %w{not_reviewed reviewed}, only: :index
+  has_orders %w{created_at_asc}, only: :index
+
+  before_action :load_resources, only: [:index]
+
+  load_and_authorize_resource
+
+  private
+
+  def resource_model
+    Proposal
+  end
+end

--- a/app/frontend/application/rich_editor.component.js
+++ b/app/frontend/application/rich_editor.component.js
@@ -31,8 +31,16 @@ export default class RichEditor extends Component {
 
   }
 
+  componentWillReceiveProps({ value }) {
+    this.setState({ value });
+  }
+
   onTextChange(value) {
     this.setState({ value });
+
+    if (this.props.onTextChange) {
+      this.props.onTextChange(value);
+    }
   }
 
   render() {

--- a/app/frontend/application/rich_editor.component.js
+++ b/app/frontend/application/rich_editor.component.js
@@ -38,7 +38,7 @@ export default class RichEditor extends Component {
   onTextChange(value) {
     this.setState({ value });
 
-    if (this.props.onTextChange) {
+    if (this.props.onTextChange && this.props.value !== value) {
       this.props.onTextChange(value);
     }
   }

--- a/app/frontend/entry.js
+++ b/app/frontend/entry.js
@@ -13,6 +13,7 @@ import MeetingsCarousel           from './meetings/meetings_carousel.component';
 import MeetingsMap                from './meetings/meetings_map.component';
 
 import ProposalsApp               from './proposals/proposals_app.component';
+import ProposalApp                from './proposals/proposal_app.component';
 import ProposalsCarousel          from './proposals/proposals_carousel.component';
 
 import Votes                      from './proposals/votes.component'; // Deprecated
@@ -32,6 +33,7 @@ window.MeetingsCarousel           = MeetingsCarousel;
 window.MeetingsMap                = MeetingsMap;
 
 window.ProposalsApp               = ProposalsApp;
+window.ProposalApp                = ProposalApp;
 window.ProposalsCarousel          = ProposalsCarousel;
 
 window.Votes                      = Votes; // Depcrecated

--- a/app/frontend/entry.test.js
+++ b/app/frontend/entry.test.js
@@ -1,7 +1,7 @@
 // ---------------------------------------
 // Test Environment Setup
 // ---------------------------------------
-import sinon from 'sinon'
+import sinon from 'sinon/pkg/sinon';
 import chai from 'chai'
 import sinonChai from 'sinon-chai'
 import chaiAsPromised from 'chai-as-promised'
@@ -19,5 +19,10 @@ global.should = chai.should()
 // ---------------------------------------
 // Require Tests
 // ---------------------------------------
-const testsContext = require.context('./application/', true, /\.test\.js$/);
-testsContext.keys().forEach(testsContext)
+let testsContext;
+
+testsContext = require.context('./application/', true, /\.test\.js$/);
+testsContext.keys().forEach(testsContext);
+
+testsContext = require.context('./proposals/', true, /\.test\.js$/);
+testsContext.keys().forEach(testsContext);

--- a/app/frontend/entry.test.js
+++ b/app/frontend/entry.test.js
@@ -2,10 +2,11 @@
 // Test Environment Setup
 // ---------------------------------------
 import sinon from 'sinon/pkg/sinon';
-import chai from 'chai'
-import sinonChai from 'sinon-chai'
-import chaiAsPromised from 'chai-as-promised'
-import chaiEnzyme from 'chai-enzyme'
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import chaiEnzyme from 'chai-enzyme';
+import I18n from 'i18n-js';
 
 chai.use(sinonChai)
 chai.use(chaiAsPromised)
@@ -15,6 +16,7 @@ global.chai = chai
 global.sinon = sinon
 global.expect = chai.expect
 global.should = chai.should()
+global.I18n = I18n;
 
 // ---------------------------------------
 // Require Tests

--- a/app/frontend/meetings/meetings_app.component.js
+++ b/app/frontend/meetings/meetings_app.component.js
@@ -7,6 +7,14 @@ import {
 import { Provider }        from 'react-redux';
 import ReduxPromise        from 'redux-promise';
 
+const middlewares = [ReduxPromise];
+
+if (process.env.NODE_ENV === 'development') {
+  const createLogger = require('redux-logger');
+  const logger = createLogger();
+  middlewares.push(logger);
+}
+
 import Meetings            from './meetings.component';
 
 import { 
@@ -19,7 +27,7 @@ import districts           from '../districts/districts.reducers';
 import categories          from '../categories/categories.reducers';
 import filters             from '../filters/filters.reducers';
 
-const createStoreWithMiddleware = applyMiddleware(ReduxPromise)(createStore);
+const createStoreWithMiddleware = applyMiddleware(...middlewares)(createStore);
 
 const pagination = function (state = {}, action) {
   switch (action.type) {

--- a/app/frontend/proposals/proposal_answer_box.component.js
+++ b/app/frontend/proposals/proposal_answer_box.component.js
@@ -20,8 +20,8 @@ export default class ProposalAnswerBox extends Component {
 
   render() {
     return (
-      <div>
-        <h2>Proposal Answer</h2>
+      <div className="proposal-answer-box">
+        <h2>{ I18n.t("components.proposal_answer_box.title") }</h2>
 
         <RichEditor 
           onTextChange={(answerMessage) => this.setState({ message: answerMessage, status: null })}
@@ -35,19 +35,18 @@ export default class ProposalAnswerBox extends Component {
 
   renderButton(action, status, currentStatus) {
     const { onButtonClick } = this.props;
+    var classes = [action];
 
     if (status === currentStatus) {
-      return (
-        <span className={action}>{action}</span>
-      );
-    } else {
-      return (
-        <button 
-          className={action} 
-          onClick={(event) => onButtonClick({ message: this.state.message, status })}>
-          {action}
-        </button>
-      );
+      classes.push("selected");
     }
+
+    return (
+      <button 
+        className={classes.join(" ")}
+        onClick={(event) => onButtonClick({ message: this.state.message, status })}>
+        {I18n.t(`components.proposal_answer_box.${action}`)}
+      </button>
+    );
   }
 }

--- a/app/frontend/proposals/proposal_answer_box.component.js
+++ b/app/frontend/proposals/proposal_answer_box.component.js
@@ -20,7 +20,7 @@ export default class ProposalAnswerBox extends Component {
 
   render() {
     return (
-      <form className="proposal-answer-box">
+      <div className="proposal-answer-box">
         <h2>{ I18n.t("components.proposal_answer_box.title") }</h2>
 
         <label>{ I18n.t("components.proposal_answer_box.message_label") }</label>
@@ -30,7 +30,7 @@ export default class ProposalAnswerBox extends Component {
 
         {this.renderButton("accept", "accepted", this.state.status)}
         {this.renderButton("reject", "rejected", this.state.status)}
-      </form>
+      </div>
     );
   }
 

--- a/app/frontend/proposals/proposal_answer_box.component.js
+++ b/app/frontend/proposals/proposal_answer_box.component.js
@@ -6,27 +6,29 @@ export default class ProposalAnswerBox extends Component {
     super(props);
 
     this.state = {
-      message: this.props.answerMessage
+      message: this.props.answerMessage,
+      status: this.props.answerStatus
     };
   }
 
-  componentWillReceiveProps({ answerMessage }) {
-    this.setState({ message: answerMessage });
+  componentWillReceiveProps({ answerMessage, answerStatus }) {
+    this.setState({ 
+      message: answerMessage,
+      status: answerStatus
+    });
   }
 
   render() {
-    const { answerStatus } = this.props;
-
     return (
       <div>
         <h2>Proposal Answer</h2>
 
         <RichEditor 
-          onTextChange={(answerMessage) => this.setState({ message: answerMessage })}
+          onTextChange={(answerMessage) => this.setState({ message: answerMessage, status: null })}
           value={this.state.message} />
 
-        {this.renderButton("accept", "accepted", answerStatus)}
-        {this.renderButton("reject", "rejected", answerStatus)}
+        {this.renderButton("accept", "accepted", this.state.status)}
+        {this.renderButton("reject", "rejected", this.state.status)}
       </div>
     );
   }

--- a/app/frontend/proposals/proposal_answer_box.component.js
+++ b/app/frontend/proposals/proposal_answer_box.component.js
@@ -20,16 +20,17 @@ export default class ProposalAnswerBox extends Component {
 
   render() {
     return (
-      <div className="proposal-answer-box">
+      <form className="proposal-answer-box">
         <h2>{ I18n.t("components.proposal_answer_box.title") }</h2>
 
+        <label>{ I18n.t("components.proposal_answer_box.message_label") }</label>
         <RichEditor 
           onTextChange={(answerMessage) => this.setState({ message: answerMessage, status: null })}
           value={this.state.message} />
 
         {this.renderButton("accept", "accepted", this.state.status)}
         {this.renderButton("reject", "rejected", this.state.status)}
-      </div>
+      </form>
     );
   }
 

--- a/app/frontend/proposals/proposal_answer_box.component.js
+++ b/app/frontend/proposals/proposal_answer_box.component.js
@@ -1,0 +1,51 @@
+import { Component } from 'react';
+import RichEditor    from '../application/rich_editor.component';
+
+export default class ProposalAnswerBox extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      message: this.props.answerMessage
+    };
+  }
+
+  componentWillReceiveProps({ answerMessage }) {
+    this.setState({ message: answerMessage });
+  }
+
+  render() {
+    const { answerStatus } = this.props;
+
+    return (
+      <div>
+        <h2>Proposal Answer</h2>
+
+        <RichEditor 
+          onTextChange={(answerMessage) => this.setState({ message: answerMessage })}
+          value={this.state.message} />
+
+        {this.renderButton("accept", "accepted", answerStatus)}
+        {this.renderButton("reject", "rejected", answerStatus)}
+      </div>
+    );
+  }
+
+  renderButton(action, status, currentStatus) {
+    const { onButtonClick } = this.props;
+
+    if (status === currentStatus) {
+      return (
+        <span className={action}>{action}</span>
+      );
+    } else {
+      return (
+        <button 
+          className={action} 
+          onClick={(event) => onButtonClick({ message: this.state.message, status })}>
+          {action}
+        </button>
+      );
+    }
+  }
+}

--- a/app/frontend/proposals/proposal_answer_box.component.test.js
+++ b/app/frontend/proposals/proposal_answer_box.component.test.js
@@ -1,0 +1,54 @@
+import React              from 'react';
+import { shallow, mount } from 'enzyme';
+
+import ProposalAnswerBox  from './proposal_answer_box.component';
+import RichEditor         from '../application/rich_editor.component';
+
+describe("Proposal answer box component", function () {
+  it("should render a rich editor for the message", function () {
+    const wrapper = shallow(
+      <ProposalAnswerBox 
+        answerMessage="Just a simple message" 
+        answerStatus="" />
+    );
+    expect(wrapper).to.have.descendants(RichEditor);
+  });
+
+  describe("clicking on the accept button", function () {
+    it("should call updateAnswer function with status accepted", function () {
+      const onButtonClick = sinon.spy();
+      const wrapper = mount(
+        <ProposalAnswerBox 
+          onButtonClick={onButtonClick}
+          answerMessage="I accept this proposal because it looks great" 
+          answerStatus="" />
+      );
+
+      wrapper.find('button.accept').simulate('click');
+
+      expect(onButtonClick).to.have.been.calledWith({ 
+        message: "<div>I accept this proposal because it looks great</div>",
+        status: "accepted"
+      });
+    });
+  });
+
+  describe("clicking on the reject button", function () {
+    it("should call updateAnswer function with status rejected", function () {
+      const onButtonClick = sinon.spy();
+      const wrapper = mount(
+        <ProposalAnswerBox 
+          onButtonClick={onButtonClick}
+          answerMessage="This is unacceptable!" 
+          answerStatus="" />
+      );
+
+      wrapper.find('button.reject').simulate('click');
+
+      expect(onButtonClick).to.have.been.calledWith({ 
+        message: "<div>This is unacceptable!</div>",
+        status: "rejected"
+      });
+    });
+  });
+});

--- a/app/frontend/proposals/proposal_app.component.js
+++ b/app/frontend/proposals/proposal_app.component.js
@@ -1,0 +1,43 @@
+import { Component }     from 'react';
+import {
+  createStore,
+  applyMiddleware,
+  combineReducers
+}                        from 'redux';
+import { Provider }      from 'react-redux';
+import ReduxPromise      from 'redux-promise';
+
+import { proposal }      from './proposals.reducers';
+
+import ProposalShow      from './proposal_show.component';
+
+const middlewares = [ReduxPromise];
+
+if (process.env.NODE_ENV === 'development') {
+  const createLogger = require('redux-logger');
+  const logger = createLogger();
+  middlewares.push(logger);
+}
+const createStoreWithMiddleware = applyMiddleware(...middlewares)(createStore);
+
+function createReducers(sessionState) {
+  let session = function (state = sessionState, action) {
+    return state;
+  };
+
+  return combineReducers({
+    session,
+    proposal
+  });
+}
+
+export default class ProposalApp extends Component {
+  render() {
+    return (
+      <Provider 
+        store={createStoreWithMiddleware(createReducers(this.props.session))}>
+        <ProposalShow proposalId={this.props.proposalId} />
+      </Provider>
+    );
+  }
+}

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -1,0 +1,35 @@
+import { Component }                   from 'react';
+import { connect }                     from 'react-redux';
+import { bindActionCreators }          from 'redux';
+
+import { fetchProposal, updateAnswer } from './proposals.actions';
+import ProposalAnswerBox               from './proposal_answer_box.component';
+
+class ProposalShow extends Component {
+  componentDidMount() {
+    this.props.fetchProposal(this.props.proposalId);
+  }
+
+  render() {
+    const proposalId = this.props.proposalId;
+    const answer = this.props.proposal.answer;
+
+    return (
+      <ProposalAnswerBox 
+        answerMessage={answer && answer.message}
+        answerStatus={answer && answer.status}
+        onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
+      />
+    );
+  }
+}
+
+function mapStateToProps({ proposal }) {
+  return { proposal };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ fetchProposal, updateAnswer }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProposalShow);

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -3,11 +3,25 @@ import { connect }                     from 'react-redux';
 import { bindActionCreators }          from 'redux';
 
 import { fetchProposal, updateAnswer } from './proposals.actions';
+
 import ProposalAnswerBox               from './proposal_answer_box.component';
+import Loading                         from '../application/loading.component';
 
 class ProposalShow extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: true
+    }
+  }
+
   componentDidMount() {
     this.props.fetchProposal(this.props.proposalId);
+  }
+
+  componentWillReceiveProps() {
+    this.setState({ loading: false });
   }
 
   render() {
@@ -20,11 +34,14 @@ class ProposalShow extends Component {
 
     if (session.is_reviewer) {
       return (
-        <ProposalAnswerBox 
-          answerMessage={answer && answer.message}
-          answerStatus={answer && answer.status}
-          onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
-        />
+        <div>
+          <Loading show={this.state.loading} />
+          <ProposalAnswerBox 
+            answerMessage={answer && answer.message}
+            answerStatus={answer && answer.status}
+            onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
+          />
+        </div>
       );
     }
 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -11,21 +11,29 @@ class ProposalShow extends Component {
   }
 
   render() {
-    const proposalId = this.props.proposalId;
-    const answer = this.props.proposal.answer;
+    return this.renderAnswerBox();
+  }
 
-    return (
-      <ProposalAnswerBox 
-        answerMessage={answer && answer.message}
-        answerStatus={answer && answer.status}
-        onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
-      />
-    );
+  renderAnswerBox() {
+    const { session, proposalId, proposal } = this.props;
+    const { answer } = proposal;
+
+    if (session.is_reviewer) {
+      return (
+        <ProposalAnswerBox 
+          answerMessage={answer && answer.message}
+          answerStatus={answer && answer.status}
+          onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
+        />
+      );
+    }
+
+    return null;
   }
 }
 
-function mapStateToProps({ proposal }) {
-  return { proposal };
+function mapStateToProps({ session, proposal }) {
+  return { session, proposal };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/app/frontend/proposals/proposals.actions.js
+++ b/app/frontend/proposals/proposals.actions.js
@@ -2,9 +2,11 @@ import axios from 'axios';
 
 export const API_BASE_URL          = '/api';
 export const FETCH_PROPOSALS       = 'FETCH_PROPOSALS';
+export const FETCH_PROPOSAL        = 'FETCH_PROPOSAL';
 export const APPEND_PROPOSALS_PAGE = 'APPEND_PROPOSALS_PAGE';
 export const VOTE_PROPOSAL         = 'VOTE_PROPOSAL';
 export const SET_ORDER             = 'SET_ORDER';
+export const UPDATE_ANSWER         = 'UPDATE_ANSWER';
 
 export function fetchProposals(options) {
   return {
@@ -13,11 +15,20 @@ export function fetchProposals(options) {
   };
 }
 
+export function fetchProposal(proposalId) {
+  const request = axios.get(`${API_BASE_URL}/proposals/${proposalId}.json`);
+
+  return {
+    type: FETCH_PROPOSAL,
+    payload: request
+  };
+}
+
 export function appendProposalsPage(options) {
   return {
     type: APPEND_PROPOSALS_PAGE,
     payload: buildProposalsRequest(options)
-  }
+  };
 }
 
 export function voteProposal(proposalId) {
@@ -26,14 +37,26 @@ export function voteProposal(proposalId) {
   return {
     type: VOTE_PROPOSAL,
     payload: request
-  }
+  };
 }
 
 export function setOrder(order) {
   return {
     type: SET_ORDER,
     order
-  }
+  };
+}
+
+export function updateAnswer(proposalId, answer, answerParams) {
+  const method  = answer ? 'patch' : 'post';
+  const request = axios[method](`${API_BASE_URL}/proposals/${proposalId}/answers.json`, {
+    answer: answerParams
+  });
+
+  return {
+    type: UPDATE_ANSWER,
+    payload: request
+  };
 }
 
 function buildProposalsRequest(options = {}) {

--- a/app/frontend/proposals/proposals.reducers.js
+++ b/app/frontend/proposals/proposals.reducers.js
@@ -1,10 +1,12 @@
 import { 
   FETCH_PROPOSALS, 
+  FETCH_PROPOSAL, 
   APPEND_PROPOSALS_PAGE, 
-  VOTE_PROPOSAL 
+  VOTE_PROPOSAL,
+  UPDATE_ANSWER
 } from './proposals.actions';
 
-export default function (state = [], action) {
+export const proposals = function (state = [], action) {
   switch (action.type) {
     case FETCH_PROPOSALS:
       return action.payload.data.proposals
@@ -19,8 +21,20 @@ export default function (state = [], action) {
   return state;
 }
 
-const proposal = function (state = {}, action) {
+export const proposal = function (state = {}, action) {
   switch (action.type) {
+    case FETCH_PROPOSAL:
+      return action.payload.data.proposal;
+    case UPDATE_ANSWER:
+      let answer = action.payload.data.proposal_answer;
+
+      if (state.id === answer.proposal_id) {
+        return {
+          ...state,
+          answer
+        };
+      }
+      return state;
     case VOTE_PROPOSAL:
       let vote = action.payload.data.vote;
 
@@ -30,9 +44,8 @@ const proposal = function (state = {}, action) {
           total_votes: state.total_votes + 1,
           voted: true
         };
-      } else {
-        return state;
       }
+      return state;
   }
   return state;
 }

--- a/app/frontend/proposals/proposals_app.component.js
+++ b/app/frontend/proposals/proposals_app.component.js
@@ -7,6 +7,14 @@ import {
 import { Provider }      from 'react-redux';
 import ReduxPromise      from 'redux-promise';
 
+const middlewares = [ReduxPromise];
+
+if (process.env.NODE_ENV === 'development') {
+  const createLogger = require('redux-logger');
+  const logger = createLogger();
+  middlewares.push(logger);
+}
+
 import Proposals         from './proposals.component';
 
 import {
@@ -14,12 +22,12 @@ import {
   APPEND_PROPOSALS_PAGE,
   SET_ORDER
 }                        from './proposals.actions';
-import proposals         from './proposals.reducers';
+import { proposals }     from './proposals.reducers';
 import districts         from '../districts/districts.reducers';
 import categories        from '../categories/categories.reducers';
 import filters           from '../filters/filters.reducers';
 
-const createStoreWithMiddleware = applyMiddleware(ReduxPromise)(createStore);
+const createStoreWithMiddleware = applyMiddleware(...middlewares)(createStore);
 
 const order = function (state = getInitialOrderState(), action) {
   switch (action.type) {

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -3,7 +3,8 @@ module ComponentsHelper
     props.merge!({
       session: {
         signed_in: user_signed_in?,
-        is_organization: current_user && current_user.organization?
+        is_organization: current_user && current_user.organization?,
+        is_reviewer: current_user && current_user.reviewer?
       }
     })
     react_component("#{name}App", props)

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -1,9 +1,12 @@
 module ComponentsHelper
-  def react_app(name) 
-    react_component("#{name}App", session: {
-      signed_in: user_signed_in?,
-      is_organization: current_user && current_user.organization?
+  def react_app(name, props = {}) 
+    props.merge!({
+      session: {
+        signed_in: user_signed_in?,
+        is_organization: current_user && current_user.organization?
+      }
     })
+    react_component("#{name}App", props)
   end
 
   def static_map(options={})

--- a/app/models/abilities/everyone.rb
+++ b/app/models/abilities/everyone.rb
@@ -11,6 +11,9 @@ module Abilities
       can :read, Legislation
       can :read, User
       can [:search, :read], Annotation
+      can :read, Category
+      can :read, Subcategory
+      can :read, District
     end
   end
 end

--- a/app/models/abilities/reviewer.rb
+++ b/app/models/abilities/reviewer.rb
@@ -5,6 +5,10 @@ module Abilities
     def initialize(user)
       self.merge Abilities::Everyone.new(user)
 
+      can :access_panel, :revision
+
+      can :moderate, Proposal
+
       can [:read, :create, :update], [ProposalAnswer]
     end
   end

--- a/app/models/abilities/reviewer.rb
+++ b/app/models/abilities/reviewer.rb
@@ -1,0 +1,11 @@
+module Abilities
+  class Reviewer
+    include CanCan::Ability
+
+    def initialize(user)
+      self.merge Abilities::Everyone.new(user)
+
+      can [:read, :create, :update], [ProposalAnswer]
+    end
+  end
+end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -21,6 +21,7 @@ class Proposal < ActiveRecord::Base
   has_many :meeting_proposals
   has_many :meetings, through: :meeting_proposals
   has_many :recommendations
+  has_one  :proposal_answer
 
   validates :title, presence: true
   validates :title, :summary, style: true, on: :create

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -44,6 +44,7 @@ class Proposal < ActiveRecord::Base
   scope :sort_by_hot_score ,       -> { reorder(hot_score: :desc) }
   scope :sort_by_confidence_score, -> { reorder(confidence_score: :desc) }
   scope :sort_by_created_at,       -> { reorder(created_at: :desc) }
+  scope :sort_by_created_at_asc,   -> { reorder(created_at: :asc) }
   scope :sort_by_most_commented,   -> { reorder(comments_count: :desc) }
   scope :sort_by_random,           -> { reorder("RANDOM()") }
   scope :sort_by_relevance ,       -> { all }
@@ -150,6 +151,14 @@ class Proposal < ActiveRecord::Base
 
   def district_object
     @district_object ||= District.find(district) if district
+  end
+
+  def self.reviewed
+    joins(:answer).where("proposal_answers.proposal_id = proposals.id")
+  end
+
+  def self.not_reviewed
+    where.not(id: reviewed) 
   end
 
   protected

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -21,7 +21,7 @@ class Proposal < ActiveRecord::Base
   has_many :meeting_proposals
   has_many :meetings, through: :meeting_proposals
   has_many :recommendations
-  has_one  :proposal_answer
+  has_one  :answer, class_name: ProposalAnswer
 
   validates :title, presence: true
   validates :title, :summary, style: true, on: :create

--- a/app/models/proposal_answer.rb
+++ b/app/models/proposal_answer.rb
@@ -2,5 +2,5 @@ class ProposalAnswer < ActiveRecord::Base
   belongs_to :proposal
 
   validates :proposal_id, presence: true
-  validates :status, inclusion: %w(accepted rejected pending)
+  validates :status, inclusion: %w(accepted rejected)
 end

--- a/app/models/proposal_answer.rb
+++ b/app/models/proposal_answer.rb
@@ -1,0 +1,6 @@
+class ProposalAnswer < ActiveRecord::Base
+  belongs_to :proposal
+
+  validates :proposal_id, presence: true
+  validates :status, inclusion: %w(accepted rejected pending)
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ActiveRecord::Base
-  ROLES = %w{administrator moderator dynamizer}
+  ROLES = %w{administrator moderator dynamizer reviewer}
 
   include Verification
   include PgSearch
@@ -44,6 +44,7 @@ class User < ActiveRecord::Base
 
   scope :administrators, -> { where.contains(roles: ['administrator']) }
   scope :moderators,     -> { where.contains(roles: ['moderator']) }
+  scope :reviewer,       -> { where.contains(roles: ['reviewer']) }
   scope :dynamizers,     -> { where.contains(roles: ['dynamizer']) }
   scope :organizations,  -> { joins(:organization) }
   scope :officials,      -> { where("official_level > 0") }
@@ -108,6 +109,10 @@ class User < ActiveRecord::Base
 
   def moderator?
     roles.include?('moderator')
+  end
+
+  def reviewer?
+    roles.include?('reviewer')
   end
 
   def organization?

--- a/app/serializers/proposal_answer_serializer.rb
+++ b/app/serializers/proposal_answer_serializer.rb
@@ -1,0 +1,3 @@
+class ProposalAnswerSerializer < ActiveModel::Serializer
+  attributes :proposal_id, :message, :status
+end

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -4,6 +4,7 @@ class ProposalSerializer < ActiveModel::Serializer
   has_one :category
   has_one :subcategory
   has_one :author
+  has_one :answer
 
   # Name collision with serialization `scope`
   def scope_

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -88,6 +88,12 @@
     </aside>
   </div>
 
+  <div class="row">
+    <div class="small-12 medium-9 column">
+      <%= react_app 'Proposal', proposalId: @proposal.id %>
+    </div>
+  </div>
+
   <% if @proposal.meetings.any? %>
     <div class="row">
       <div class="small-12 medium-9 column">

--- a/app/views/revision/_menu.html.erb
+++ b/app/views/revision/_menu.html.erb
@@ -1,0 +1,14 @@
+<nav class="admin-sidebar">
+  <ul id="revision_menu">
+    <li>
+      <%= link_to t("revision.dashboard.index.title"), revision_root_path %>
+    </li>
+
+    <li <%= "class=active" if controller_name == "proposals" %>>
+      <%= link_to revision_proposals_path do %>
+        <i class="icon-proposals"></i>
+        <%= t("revision.menu.proposals") %>
+      <% end %>
+    </li>
+  </ul>
+</nav>

--- a/app/views/revision/dashboard/index.html.erb
+++ b/app/views/revision/dashboard/index.html.erb
@@ -1,0 +1,2 @@
+<div class="dashboard">
+</div>

--- a/app/views/revision/proposals/index.html.erb
+++ b/app/views/revision/proposals/index.html.erb
@@ -1,0 +1,31 @@
+<h2><%= t("moderation.proposals.index.title") %></h2>
+
+<%= render 'shared/filter_subnav', i18n_namespace: "moderation.proposals.index" %>
+
+<div class="row">
+  <h3 class="small-8 large-8 columns"><%= page_entries_info @proposals %></h3>
+</div>
+
+<table class="clear">
+  <tr>
+    <th>
+      <%= t("moderation.proposals.index.headers.proposal") %>
+    </th>
+  </tr>
+  <% @proposals.each do |proposal| %>
+    <tr id="proposal_<%= proposal.id %>">
+      <td>
+        <%= link_to proposal.title, revision_proposal_path(proposal) %>
+        <br>
+        <span class="date"><%= l proposal.created_at.to_date %></span>
+        <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <%= proposal.flags_count %><i class="icon-flag flag-disable"></i>
+        <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <%= proposal.author.username %>
+        <br>
+      </td>
+    </tr>
+  <% end %>
+</table>
+
+<%= paginate @proposals %>

--- a/app/views/revision/proposals/show.html.erb
+++ b/app/views/revision/proposals/show.html.erb
@@ -1,0 +1,84 @@
+<% provide :title do %><%= @proposal.title %><% end %>
+<% provide :social_media_meta_tags do %>
+<%= render "shared/social_media_meta_tags",
+            social_url: proposal_url(@proposal),
+            social_title: @proposal.title,
+            social_media_image: asset_url('social-media-icon.png'),
+            social_description: text_with_links(@proposal.summary) %>
+<% end %>
+
+
+<section class="proposal-show" data-timestamp="<%= @proposal.created_at.to_i %>">
+  <div id="<%= dom_id(@proposal) %>" class="row">
+    <div class="small-12 medium-12 column">
+      <i class="icon-angle-left left"></i>&nbsp;
+      <%= link_to t("proposals.show.back_link"), :back, class: 'left back' %>
+
+      <% if current_user && @proposal.editable_by?(current_user) %>
+        <%= link_to edit_proposal_path(@proposal), class: 'edit-proposal button success tiny radius right' do %>
+          <i class="icon-edit"></i>
+          <%= t("proposals.show.edit_proposal_link") %>
+        <% end %>
+      <% end %>
+
+      <h2>
+        <%= link_to proposal_path(@proposal) do %>
+          <%= @proposal.title %>
+          <%= proposal_badge(@proposal) %>
+        <% end %>
+      </h2>
+
+      <% if @proposal.conflictive? %>
+        <div class="alert-box alert radius margin-top">
+          <strong><%= t("proposals.show.flag") %></strong>
+        </div>
+      <% end %>
+
+      <div class="proposal-info">
+        <% unless @proposal.official? or @proposal.from_meeting? %>
+          <%= render '/shared/author_info', resource: @proposal %>
+          <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <% end %>
+
+        <%= l @proposal.created_at.to_date %>
+        <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <span class="js-flag-actions">
+          <%= render 'proposals/flag_actions', proposal: @proposal %>
+        </span>
+      </div>
+
+      <div class="proposal-description">
+        <%= text_with_links @proposal.summary %>
+      </div>
+
+      <% if @proposal.external_url.present? %>
+        <div class="document-link">
+          <%= text_with_links @proposal.external_url %>
+        </div>
+      <% end %>
+
+      <% if feature?(:proposal_video_url) && @proposal.video_url.present? %>
+        <div class="video-link">
+          <%= text_with_links @proposal.video_url %>
+        </div>
+      <% end %>
+
+      <%= render "proposals/meta", proposal: @proposal %>
+      <% if feature?(:proposal_tags) %>
+        <%= render 'shared/tags', taggable: @proposal %>
+      <% end %>
+
+      <%= render partial: 'shared/references', locals: { subject: @proposal } %>
+
+      <div class="js-moderator-proposal-actions margin">
+        <%= render 'proposals/actions', proposal: @proposal %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-12 column">
+      <%= react_app 'Proposal', proposalId: @proposal.id %>
+    </div>
+  </div>
+</section>

--- a/app/views/shared/_admin_login_items.html.erb
+++ b/app/views/shared/_admin_login_items.html.erb
@@ -10,4 +10,10 @@
         <%= link_to t("layouts.header.moderation"), moderation_root_path %>
       </li>
     <% end %>
+
+    <% if can? :access_panel, :revision %>
+      <li>
+        <%= link_to t("layouts.header.revision"), revision_root_path %>
+      </li>
+    <% end %>
 <% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -24,6 +24,7 @@ data:
     - config/locales/%{locale}.yml
     - config/locales/admin.%{locale}.yml
     - config/locales/moderation.%{locale}.yml
+    - config/locales/revision.%{locale}.yml
     - config/locales/management.%{locale}.yml
     - config/locales/verification.%{locale}.yml
     - config/locales/mailers.%{locale}.yml

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -149,6 +149,7 @@ ignore_unused:
   - 'components.filter_option.{city,district,official,citizenship,meetings,organization,all,past,upcoming}'
   - 'components.filter_option_group.{category_id,district,scope,subcategory_id,other,source,date}'
   - 'recaptcha.*'
+  - 'components.proposal_answer_box.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -479,12 +479,12 @@ ca:
         debates:
           one: 1 Debat
           other: "%{count} Debats"
-        proposals:
-          one: 1 Proposta
-          other: "%{count} Propostes"
         meetings:
           one: 1 Cita presencial
           other: "%{count} Cites presencials"
+        proposals:
+          one: 1 Proposta
+          other: "%{count} Propostes"
       no_activity: Usuari sense activitat pública
       private_activity: Aquest usuari ha decidit mantenir en privat la seva llista d'activitats
   validators:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -198,6 +198,7 @@ ca:
         other: Tens %{count} notificacions noves
       no_notifications: No tens notificacions noves
       proposals: Propostes
+      revision: Revisar
       spending_proposals: Pressupostos ciutadans
   legislation:
     help:

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -1,6 +1,10 @@
 ---
 ca:
   components:
+    proposal_answer_box:
+      accept: Validar
+      reject: Rebutjar
+      title: Resposta de la proposta
     category_picker:
       category:
         label: Eix

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -1,10 +1,6 @@
 ---
 ca:
   components:
-    proposal_answer_box:
-      accept: Validar
-      reject: Rebutjar
-      title: Resposta de la proposta
     category_picker:
       category:
         label: Eix
@@ -49,6 +45,11 @@ ca:
       title: Títol
     meetings_filters:
       clean_filters: Netejar filtre
+    proposal_answer_box:
+      accept: Validar
+      message_label: Nota / motiu
+      reject: Rebutjar
+      title: Resposta de la proposta
     proposal_carousel:
       see_more: Veure més
       votes: "%{votes} suports"

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -45,6 +45,10 @@ en:
       title: Title
     meetings_filters:
       clean_filters: Clean filter
+    proposal_answer_box:
+      accept: Validate
+      reject: Reject
+      title: Proposal answer
     proposal_carousel:
       see_more: See more
       votes: "%{votes} supports"

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -47,6 +47,7 @@ en:
       clean_filters: Clean filter
     proposal_answer_box:
       accept: Validate
+      message_label: Note / reason
       reject: Reject
       title: Proposal answer
     proposal_carousel:

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -45,6 +45,10 @@ es:
       title: Título
     meetings_filters:
       clean_filters: Limpiar filtro
+    proposal_answer_box:
+      accept: Validar
+      reject: Rebutjar
+      title: Resposta de la proposta
     proposal_carousel:
       see_more: Ver más
       votes: "%{votes} soportes"

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -47,6 +47,7 @@ es:
       clean_filters: Limpiar filtro
     proposal_answer_box:
       accept: Validar
+      message_label: Nota / motivo
       reject: Rebutjar
       title: Resposta de la proposta
     proposal_carousel:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -483,12 +483,12 @@ en:
         debates:
           one: 1 Debate
           other: "%{count} Debates"
-        proposals:
-          one: 1 Proposal
-          other: "%{count} Proposals"
         meetings:
           one: 1 Presencial meeting
           other: "%{count} Presencial meetings"
+        proposals:
+          one: 1 Proposal
+          other: "%{count} Proposals"
       no_activity: User has no public activity
       private_activity: This user decided to keep the activity list private
   validators:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,7 @@ en:
         other: You have %{count} new notifications
       no_notifications: You don't have new notifications
       proposals: Proposals
+      revision: Review
       spending_proposals: Spending proposals
   legislation:
     help:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -483,12 +483,12 @@ es:
         debates:
           one: 1 Debate
           other: "%{count} Debates"
-        proposals:
-          one: 1 Propuesta
-          other: "%{count} Propuestas"
         meetings:
           one: 1 Cita presencial
           other: "%{count} Citas presenciales"
+        proposals:
+          one: 1 Propuesta
+          other: "%{count} Propuestas"
       no_activity: Usuario sin actividad pública
       private_activity: Este usuario ha decidido mantener en privado su lista de actividades
   validators:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -198,6 +198,7 @@ es:
         other: Tienes %{count} notificaciones nuevas
       no_notifications: No tienes notificaciones nuevas
       proposals: Propuestas
+      revision: Revisar
       spending_proposals: Presupuestos ciudadanos
   legislation:
     help:

--- a/config/locales/revision.ca.yml
+++ b/config/locales/revision.ca.yml
@@ -1,0 +1,9 @@
+---
+ca:
+  revision:
+    dashboard:
+      index:
+        title: Revisió
+    menu:
+      proposals: Propostes
+

--- a/config/locales/revision.en.yml
+++ b/config/locales/revision.en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  revision:
+    dashboard:
+      index:
+        title: Revision
+    menu:
+      proposals: Proposals
+

--- a/config/locales/revision.es.yml
+++ b/config/locales/revision.es.yml
@@ -1,0 +1,9 @@
+---
+es:
+  revision:
+    dashboard:
+      index:
+        title: Revisión
+    menu:
+      proposals: Propuestas
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,7 +259,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :districts, only: [:index]
     resources :categories, only: [:index]
-    resources :proposals, only: [:index] do
+    resources :proposals, only: [:show, :index] do
       resources :votes, only: [:create]
       resource :answers, only: [:create, :update], controller: :proposal_answers
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :revision do
+    root to: "proposals#index"
+
+    resources :proposals, only: [:index, :show]
+  end
+
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,6 +261,7 @@ Rails.application.routes.draw do
     resources :categories, only: [:index]
     resources :proposals, only: [:index] do
       resources :votes, only: [:create]
+      resource :answers, only: [:create, :update], controller: :proposal_answers
     end
     resources :meetings, only: [:index]
   end

--- a/db/migrate/20160404080535_create_proposal_answers.rb
+++ b/db/migrate/20160404080535_create_proposal_answers.rb
@@ -1,0 +1,11 @@
+class CreateProposalAnswers < ActiveRecord::Migration
+  def change
+    create_table :proposal_answers do |t|
+      t.integer :proposal_id, null: false
+      t.text :message
+      t.string :status, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160316100823) do
+ActiveRecord::Schema.define(version: 20160404080535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,12 +30,6 @@ ActiveRecord::Schema.define(version: 20160316100823) do
 
   add_index "activities", ["actionable_id", "actionable_type"], name: "index_activities_on_actionable_id_and_actionable_type", using: :btree
   add_index "activities", ["user_id"], name: "index_activities_on_user_id", using: :btree
-
-  create_table "administrators", force: :cascade do |t|
-    t.integer "user_id"
-  end
-
-  add_index "administrators", ["user_id"], name: "index_administrators_on_user_id", using: :btree
 
   create_table "ahoy_events", id: :uuid, default: nil, force: :cascade do |t|
     t.uuid     "visit_id"
@@ -261,12 +255,6 @@ ActiveRecord::Schema.define(version: 20160316100823) do
     t.boolean "consensus"
   end
 
-  create_table "moderators", force: :cascade do |t|
-    t.integer "user_id"
-  end
-
-  add_index "moderators", ["user_id"], name: "index_moderators_on_user_id", using: :btree
-
   create_table "notifications", force: :cascade do |t|
     t.integer "user_id"
     t.integer "notifiable_id"
@@ -286,6 +274,14 @@ ActiveRecord::Schema.define(version: 20160316100823) do
   end
 
   add_index "organizations", ["user_id"], name: "index_organizations_on_user_id", using: :btree
+
+  create_table "proposal_answers", force: :cascade do |t|
+    t.integer  "proposal_id", null: false
+    t.text     "message"
+    t.string   "status",      null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "proposals", force: :cascade do |t|
     t.string   "title",             limit: 250
@@ -351,13 +347,6 @@ ActiveRecord::Schema.define(version: 20160316100823) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
   end
-
-  create_table "settings", force: :cascade do |t|
-    t.string "key"
-    t.string "value"
-  end
-
-  add_index "settings", ["key"], name: "index_settings_on_key", using: :btree
 
   create_table "spending_proposals", force: :cascade do |t|
     t.string   "title"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-slick": "^0.11.1",
     "react-visibility-sensor": "^3.0.0",
     "redux": "^3.0.4",
+    "redux-logger": "^2.6.1",
     "redux-promise": "^0.5.3",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.14",
@@ -41,8 +42,10 @@
     "karma-chrome-launcher": "^0.2.2",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sinon-chai": "^1.2.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
+    "lolex": "^1.4.0",
     "phantomjs-prebuilt": "^2.1.7",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "exports-loader": "^0.6.3",
     "expose-loader": "^0.7.1",
     "extract-text-webpack-plugin": "^1.0.1",
+    "i18n-js": "^1.0.0",
     "imports-loader": "^0.6.5",
     "quill": "^0.20.1",
     "react": "^0.14.6",

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,10 +1,4 @@
-FactoryGirl.define do  factory :reference do
-    referral_type "MyString"
-referral_id 1
-referenced_type "MyString"
-referenced_id 1
-  end
-
+FactoryGirl.define do  
   sequence(:document_number) { |n| "#{n.to_s.rjust(8, '0')}X" }
 
   factory :user do
@@ -391,4 +385,18 @@ referenced_id 1
   factory :geozone do
     sequence(:name) { |n| "District #{n}" }
   end
+
+  factory :proposal_answer do
+    proposal
+    message "I'm totally agree with that"
+    status "accepted"
+  end
+
+  factory :reference do
+    referral_type "MyString"
+    referral_id 1
+    referenced_type "MyString"
+    referenced_id 1
+  end
+
 end

--- a/spec/models/proposal_answer_spec.rb
+++ b/spec/models/proposal_answer_spec.rb
@@ -12,12 +12,11 @@ describe ProposalAnswer do
     expect(proposal_answer).to_not be_valid
   end
 
-  it "should not be valid with a status different of 'accepted', 'rejected or 'pending'" do
+  it "should not be valid with a status different of 'accepted' or 'rejected'" do
     {
       nil => false,
       'accepted' => true,
       'rejected' => true,
-      'pending' => true,
       'completed' => false
     }.each do |status, is_valid|
       proposal_answer.status = status

--- a/spec/models/proposal_answer_spec.rb
+++ b/spec/models/proposal_answer_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe ProposalAnswer do
+  let(:proposal_answer) { build(:proposal_answer) }
+
+  it "should be valid" do
+    expect(proposal_answer).to be_valid
+  end
+
+  it "should not be valid without a proposal" do
+    proposal_answer.proposal = nil
+    expect(proposal_answer).to_not be_valid
+  end
+
+  it "should not be valid with a status different of 'accepted', 'rejected or 'pending'" do
+    {
+      nil => false,
+      'accepted' => true,
+      'rejected' => true,
+      'pending' => true,
+      'completed' => false
+    }.each do |status, is_valid|
+      proposal_answer.status = status
+      expect(proposal_answer.valid?).to be(is_valid), "proposal answer with status #{status}"
+    end
+  end
+end


### PR DESCRIPTION
# What and why

Added a new role `reviewer` in order to review proposals. These users should be able to mark proposals as 'Accepted' or 'Rejected'. They can also add a clarification note.

This feature has been developed as a new component `ProposalAnswerBox` which it is used both for the proposal page and for administration purposes.

Added new API Endpoints:
- `POST /proposals/:proposal_id/answers`: Create a proposal answer.
- `PATCH /proposals/:proposal_id/answers`: Update a proposal answer.
# QA

Checkout the project and run `npm install`. Then, as a `reviewer` you should be able to see the proposal answer box.
# GIF Tax

![](https://media.giphy.com/media/rcw4NNFE6JioM/giphy.gif)
# TODOs
- [x] Refactor API controllers
- [x] Create `ProposalAnswer` model
- [x] ~~Fix npm crazy stuff~~
- [x] Create API endpoints
- [x] Create `ProposalAnswerBox` component
- [x] Add new role (`reviewer`) and verify permissions
- [x] Styles magic
- [x] Loading
- [x] ~~Integration tests~~
- [x] Reenable buttons
- [x] i18n XD
- [x] Admin
