### PR TITLE
Add reviewed status to proposal filters

### DIFF
--- a/app/frontend/filters/filters.reducers.js
+++ b/app/frontend/filters/filters.reducers.js
@@ -87,7 +87,7 @@ function getInitialFiltersState() {
 
       values = values.split(",");
 
-      if (name !== "scope" && name !== "other" && name !== "source") {
+      if (name !== "scope" && name !== "other" && name !== "source" && name !== 'reviewer_status') {
         values = values.map((x) => parseInt(x, 10));
       }
 

--- a/app/frontend/filters/reviewer_filter.component.js
+++ b/app/frontend/filters/reviewer_filter.component.js
@@ -1,0 +1,36 @@
+import { Component }          from 'react';
+import { bindActionCreators } from 'redux';
+import { connect }            from 'react-redux';
+
+import FilterOptionGroup      from './filter_option_group.component';
+import FilterOption           from './filter_option.component';
+
+import { setFilterGroup }     from './filters.actions';
+
+class ReviewerFilter extends Component {
+  render() {
+    if (this.props.session.is_reviewer) {
+      return (
+        <FilterOptionGroup 
+          isExclusive={true}
+          filterGroupName="reviewer_status" 
+          filterGroupValue={this.props.filters.filter["reviewer_status"]}
+          onChangeFilterGroup={(name, value) => this.props.setFilterGroup(name, value) }>
+          <FilterOption filterName="reviewed" />
+          <FilterOption filterName="not_reviewed" />
+        </FilterOptionGroup>
+      );
+    }
+    return null;
+  }
+}
+
+function mapStateToProps({ filters, session }) {
+  return { filters, session };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ setFilterGroup }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ReviewerFilter);

--- a/app/frontend/proposals/proposals_filters.component.js
+++ b/app/frontend/proposals/proposals_filters.component.js
@@ -9,6 +9,7 @@ import ScopeFilterOptionGroup           from '../filters/scope_filter_option_gro
 import CategoryFilterOptionGroup        from '../filters/category_filter_option_group.component';
 import SubcategoryFilterOptionGroup     from '../filters/subcategory_filter_option_group.component';
 import TagCloudFilter                   from '../filters/tag_cloud_filter.component';
+import ReviewerFilter                   from '../filters/reviewer_filter.component';
 
 import FilterOptionGroup                from '../filters/filter_option_group.component';
 import FilterOption                     from '../filters/filter_option.component';
@@ -18,6 +19,7 @@ class ProposalsFilters extends Component {
     return (
       <form className="proposal-filters">
         <SearchFilter searchText={this.props.filters.text} />
+        <ReviewerFilter />
         <ScopeFilterOptionGroup />
         <CategoryFilterOptionGroup />
         <SubcategoryFilterOptionGroup />

--- a/app/services/resource_filter.rb
+++ b/app/services/resource_filter.rb
@@ -1,5 +1,5 @@
 class ResourceFilter
-  IGNORE_FILTER_PARAMS = ["source", "other", "date"]
+  IGNORE_FILTER_PARAMS = ["source", "other", "date", "reviewer_status"]
   attr_reader :search_filter, :tag_filter, :params
 
   def initialize(params={}, options = {})
@@ -93,6 +93,14 @@ class ResourceFilter
 
     if @params["source"] && @params["source"].include?("citizenship")
       collection = collection.where(official: false)
+    end
+
+    if @params["reviewer_status"]
+      if params["reviewer_status"].include? "reviewed"
+        collection = collection.reviewed
+      else
+        collection = collection.not_reviewed
+      end
     end
 
     collection

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -21,15 +21,18 @@ ca:
       district: Un districte
       from_meetings: Cites presencials
       meetings: Debatudes a cites presencials
+      not_reviewed: No revisades
       official: Ajuntament
       organization: Organitzacions
       past: Passades
+      reviewed: Revisades
       upcoming: Properes
     filter_option_group:
       category_id: Eix
       date: Data
       district: Districte
       other: Altres
+      reviewer_status: Estat de la revisió
       scope: "Àmbit"
       source: Origen
       subcategory_id: Línia estratègica

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -21,15 +21,18 @@ en:
       district: A district
       from_meetings: Meetings
       meetings: Meetings
+      not_reviewed: Not reviewed
       official: Town Hall
       organization: Organizations
       past: Past
+      reviewed: Reviewed
       upcoming: Upcoming
     filter_option_group:
       category_id: Axis
       date: Date
       district: District
       other: Other
+      reviewer_status: Revision status
       scope: Scope
       source: Source
       subcategory_id: Strategic Line

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -21,15 +21,18 @@ es:
       district: Un distrito
       from_meetings: Citas presenciales
       meetings: Debatidas en citas presenciales
+      not_reviewed: No revisadas
       official: Ayuntamiento
       organization: Organizaciones
       past: Pasadas
+      reviewed: Revisadas
       upcoming: Próximas
     filter_option_group:
       category_id: Eje
       date: Fecha
       district: Distrito
       other: Otros
+      reviewer_status: Estado de la revisión
       scope: "Ámbito"
       source: Origen
       subcategory_id: Línea estratégica


### PR DESCRIPTION
# What and why

Reviewers should be able to filter `reviewed` and `not reviewed` proposals. I added new filters visible to the role `reviewer' on the proposals page.

![reviewer_status](https://cloud.githubusercontent.com/assets/106021/14283405/9305159a-fb43-11e5-85d0-48b106471a49.png)
# QA

Just checkout the project and check if the filter is active and working
# GIF Tax

![](https://media.giphy.com/media/eij3Aplt9hquI/giphy.gif)
