### PR TITLE
Add ScopePicker and CategoryPicker components

### DIFF
--- a/app/controllers/api/proposal_answers_controller.rb
+++ b/app/controllers/api/proposal_answers_controller.rb
@@ -1,6 +1,6 @@
 class Api::ProposalAnswersController < Api::ApplicationController
+  before_action :authenticate_user!
   load_and_authorize_resource :proposal
-  #before_action :authenticate_user!
 
   def create
     @answer = @proposal.build_answer(strong_params)

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -1,6 +1,7 @@
 class Api::ProposalsController < Api::ApplicationController
   include HasOrders
 
+  before_action :authenticate_user!, only: [:update]
   load_and_authorize_resource
 
   has_orders %w{random hot_score confidence_score created_at}, only: :index
@@ -34,7 +35,18 @@ class Api::ProposalsController < Api::ApplicationController
     render json: @proposal
   end
 
+  def update
+    @proposal.assign_attributes(strong_params)
+    @proposal.save
+    render json: @proposal
+  end
+
   private
+
+  def strong_params
+    permitted_params = [:scope, :district, :category_id, :subcategory_id]
+    params.require(:proposal).permit(permitted_params)
+  end
 
   def set_seed
     @random_seed = params[:random_seed] ? params[:random_seed].to_f : (rand * 2 - 1)

--- a/app/frontend/categories/new_category_picker.component.js
+++ b/app/frontend/categories/new_category_picker.component.js
@@ -1,0 +1,81 @@
+import { Component }     from 'react';
+
+//import SubcategoryPicker from './subcategory_picker.component';
+
+class CategoryPicker extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      //selectedCategoryId: props.selectedCategoryId,
+      //selectedSubcategoryId: props.selectedSubcategoryId,
+      //subcategories: props.subcategories.sort( () => Math.round(Math.random())-0.5 )
+    }
+  }
+
+  render () {
+    var category = this.props.categories.map(category => this.renderRow(category));
+
+    return (
+      <div>
+        <div className="category-picker">
+          <label>{I18n.t("components.category_picker.category.label")}</label>
+          <ul>{category}</ul>
+        </div>
+
+        {this.actionLinePicker()}
+
+        <input type="hidden"
+               name={this.props.categoryInputName}
+               value={this.state.selectedCategoryId} />
+
+        <input type="hidden"
+               name={this.props.subcategoryInputName}
+               value={this.state.selectedSubcategoryId} />
+      </div>
+    );
+  }
+
+  renderRow (category) {
+    var selected = this.state.selectedCategoryId === category.id;
+    var name = category.name;
+
+    var classNames = ['category-' + category.id];
+    if(selected){ classNames.push('selected'); }
+    var iconName = "icon category-icon-" + category.id;
+
+    return (
+      <li className={classNames.join(' ')}
+          key={category.id}
+          onClick={() => this.selectCategory(category)}>
+        <span className="category">
+          <span className={iconName}></span>
+          <span className="name">{name}</span>
+        </span>
+      </li>
+    );
+  }
+
+  actionLinePicker() {
+    if(this.state.selectedCategoryId){
+      return (
+        <SubcategoryPicker
+            categoryId={this.state.selectedCategoryId}
+            subcategories={this.state.subcategories}
+            selectedId={this.state.selectedSubcategoryId}
+            onSelect={ (actionLine) => this.setState({selectedSubcategoryId: actionLine.id}) }
+        />
+      );
+    }
+  }
+
+  selectCategory(category){
+    var state = {selectedCategoryId: category.id};
+
+    if(this.state.selectedCategoryId !== category.id){
+      state = {...state, selectedSubcategoryId: null };
+    }
+
+    this.setState(state);
+  }
+}

--- a/app/frontend/categories/new_category_picker.component.js
+++ b/app/frontend/categories/new_category_picker.component.js
@@ -1,20 +1,21 @@
-import { Component }     from 'react';
+import { Component }          from 'react';
+import { bindActionCreators } from 'redux';
+import { connect }            from 'react-redux';
 
-//import SubcategoryPicker from './subcategory_picker.component';
+import { updateProposal }     from '../proposals/proposals.actions';
+
+import SubcategoryPicker      from './new_subcategory_picker.component';
 
 class CategoryPicker extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      //selectedCategoryId: props.selectedCategoryId,
-      //selectedSubcategoryId: props.selectedSubcategoryId,
-      //subcategories: props.subcategories.sort( () => Math.round(Math.random())-0.5 )
-    }
-  }
-
   render () {
-    var category = this.props.categories.map(category => this.renderRow(category));
+    const { categories, proposal } = this.props;
+    const subcategories = (categories.length > 0 && proposal.category) ? categories
+      .filter(category => {
+        return proposal && category.id === proposal.category.id
+      })[0]
+      .subcategories : [];
+
+    var category = categories.map(category => this.renderRow(category));
 
     return (
       <div>
@@ -22,22 +23,17 @@ class CategoryPicker extends Component {
           <label>{I18n.t("components.category_picker.category.label")}</label>
           <ul>{category}</ul>
         </div>
-
-        {this.actionLinePicker()}
-
-        <input type="hidden"
-               name={this.props.categoryInputName}
-               value={this.state.selectedCategoryId} />
-
-        <input type="hidden"
-               name={this.props.subcategoryInputName}
-               value={this.state.selectedSubcategoryId} />
+        <SubcategoryPicker 
+          subcategories={subcategories} 
+          onSelect={subcategory => this.selectSubcategory(subcategory)} />
       </div>
     );
   }
 
   renderRow (category) {
-    var selected = this.state.selectedCategoryId === category.id;
+    const { proposal } = this.props;
+
+    var selected = proposal.category && proposal.category.id === category.id;
     var name = category.name;
 
     var classNames = ['category-' + category.id];
@@ -56,26 +52,37 @@ class CategoryPicker extends Component {
     );
   }
 
-  actionLinePicker() {
-    if(this.state.selectedCategoryId){
-      return (
-        <SubcategoryPicker
-            categoryId={this.state.selectedCategoryId}
-            subcategories={this.state.subcategories}
-            selectedId={this.state.selectedSubcategoryId}
-            onSelect={ (actionLine) => this.setState({selectedSubcategoryId: actionLine.id}) }
-        />
-      );
-    }
+  selectCategory(selectedCategory ){
+    const { categories, proposal } = this.props;
+
+    const subcategories = categories
+      .filter(category => {
+        return category.id === selectedCategory.id
+      })[0]
+      .subcategories;
+
+    this.props.updateProposal(proposal.id, {
+      category_id: selectedCategory.id,
+      subcategory_id: subcategories[0].id
+    });
   }
 
-  selectCategory(category){
-    var state = {selectedCategoryId: category.id};
+  selectSubcategory(subcategory){
+    const { proposal } = this.props;
 
-    if(this.state.selectedCategoryId !== category.id){
-      state = {...state, selectedSubcategoryId: null };
-    }
 
-    this.setState(state);
+    this.props.updateProposal(proposal.id, {
+      subcategory_id: subcategory.id
+    });
   }
 }
+
+function mapStateToProps({ categories, proposal }) {
+  return { categories, proposal };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ updateProposal }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CategoryPicker);

--- a/app/frontend/categories/new_subcategory_picker.component.js
+++ b/app/frontend/categories/new_subcategory_picker.component.js
@@ -1,0 +1,51 @@
+import { Component }          from 'react';
+import { bindActionCreators } from 'redux';
+import { connect }            from 'react-redux';
+
+class SubcategoryPicker extends Component {
+  subcategories () {
+    const { subcategories, proposal } = this.props;
+
+    return subcategories.map(subcategory => {
+      var selected = proposal.subcategory && subcategory.id === proposal.subcategory.id;
+
+      var classNames = ['subcategory-' + subcategory.id];
+      if(selected){ classNames.push('selected'); }
+
+      return (
+        <li className={classNames.join(' ')}
+            key={subcategory.id}
+            onClick={() => this.select(subcategory)}>
+          <span className="name">{subcategory.name} <a href={`/categories#subcategory_${subcategory.id}`} target="_blank"> <i className="fa fa-info-circle"></i></a></span>
+        </li>
+      );
+    });
+  }
+
+  render () {
+    return (
+      <div className="subcategory-picker">
+        <label>{I18n.t("components.category_picker.subcategory.label")}</label>
+        <ul>
+          {this.subcategories()}
+        </ul>
+      </div>
+    );
+  }
+
+  select (subcategory) {
+    if (this.props.onSelect) {
+      this.props.onSelect(subcategory)
+    }
+  }
+}
+
+function mapStateToProps({ proposal }) {
+  return { proposal };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SubcategoryPicker);

--- a/app/frontend/proposals/proposal_app.component.js
+++ b/app/frontend/proposals/proposal_app.component.js
@@ -8,6 +8,8 @@ import { Provider }      from 'react-redux';
 import ReduxPromise      from 'redux-promise';
 
 import { proposal }      from './proposals.reducers';
+import categories        from '../categories/categories.reducers';
+import districts         from '../districts/districts.reducers';
 
 import ProposalShow      from './proposal_show.component';
 
@@ -27,7 +29,9 @@ function createReducers(sessionState) {
 
   return combineReducers({
     session,
-    proposal
+    proposal,
+    categories,
+    districts
   });
 }
 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -3,9 +3,12 @@ import { connect }                     from 'react-redux';
 import { bindActionCreators }          from 'redux';
 
 import { fetchProposal, updateAnswer } from './proposals.actions';
+import { fetchCategories }             from '../categories/categories.actions';
+import { fetchDistricts }              from '../districts/districts.actions';
 
 import ProposalAnswerBox               from './proposal_answer_box.component';
 import CategoryPicker                  from '../categories/new_category_picker.component';
+import ScopePicker                     from './scope_picker.component';
 import Loading                         from '../application/loading.component';
 
 class ProposalShow extends Component {
@@ -19,6 +22,8 @@ class ProposalShow extends Component {
 
   componentDidMount() {
     this.props.fetchProposal(this.props.proposalId);
+    this.props.fetchCategories();
+    this.props.fetchDistricts();
   }
 
   componentWillReceiveProps() {
@@ -29,8 +34,10 @@ class ProposalShow extends Component {
     return (
       <div>
         <Loading show={this.state.loading} />
-        {this.renderAnswerBox()}
+        <h2>{I18n.t('proposals.edit.editing')}</h2>
+        <ScopePicker />
         <CategoryPicker />
+        {this.renderAnswerBox()}
       </div>
     );
   }
@@ -58,7 +65,7 @@ function mapStateToProps({ session, proposal }) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchProposal, updateAnswer }, dispatch);
+  return bindActionCreators({ fetchProposal, updateAnswer, fetchCategories, fetchDistricts }, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProposalShow);

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -21,9 +21,13 @@ class ProposalShow extends Component {
   }
 
   componentDidMount() {
-    this.props.fetchProposal(this.props.proposalId);
-    this.props.fetchCategories();
-    this.props.fetchDistricts();
+    const { session } = this.props;
+
+    if (session.is_reviewer) {
+      this.props.fetchProposal(this.props.proposalId);
+      this.props.fetchCategories();
+      this.props.fetchDistricts();
+    }
   }
 
   componentWillReceiveProps() {
@@ -31,30 +35,34 @@ class ProposalShow extends Component {
   }
 
   render() {
-    return (
-      <div>
-        <Loading show={this.state.loading} />
-        <h2>{I18n.t('proposals.edit.editing')}</h2>
-        <ScopePicker />
-        <CategoryPicker />
-        {this.renderAnswerBox()}
-      </div>
-    );
-  }
-
-  renderAnswerBox() {
-    const { session, proposalId, proposal } = this.props;
-    const { answer } = proposal;
+    const { session } = this.props;
 
     if (session.is_reviewer) {
       return (
-        <ProposalAnswerBox 
-          answerMessage={answer && answer.message}
-          answerStatus={answer && answer.status}
-          onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
-        />
+        <div>
+          <Loading show={this.state.loading} />
+          <h2>{I18n.t('proposals.edit.editing')}</h2>
+          <ScopePicker />
+          <CategoryPicker />
+          {this.renderAnswerBox()}
+        </div>
       );
     }
+
+    return null;
+  }
+
+  renderAnswerBox() {
+    const { proposalId, proposal } = this.props;
+    const { answer } = proposal;
+
+    return (
+      <ProposalAnswerBox 
+        answerMessage={answer && answer.message}
+        answerStatus={answer && answer.status}
+        onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
+      />
+    );
 
     return null;
   }

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -5,6 +5,7 @@ import { bindActionCreators }          from 'redux';
 import { fetchProposal, updateAnswer } from './proposals.actions';
 
 import ProposalAnswerBox               from './proposal_answer_box.component';
+import CategoryPicker                  from '../categories/new_category_picker.component';
 import Loading                         from '../application/loading.component';
 
 class ProposalShow extends Component {
@@ -25,7 +26,13 @@ class ProposalShow extends Component {
   }
 
   render() {
-    return this.renderAnswerBox();
+    return (
+      <div>
+        <Loading show={this.state.loading} />
+        {this.renderAnswerBox()}
+        <CategoryPicker />
+      </div>
+    );
   }
 
   renderAnswerBox() {
@@ -34,14 +41,11 @@ class ProposalShow extends Component {
 
     if (session.is_reviewer) {
       return (
-        <div>
-          <Loading show={this.state.loading} />
-          <ProposalAnswerBox 
-            answerMessage={answer && answer.message}
-            answerStatus={answer && answer.status}
-            onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
-          />
-        </div>
+        <ProposalAnswerBox 
+          answerMessage={answer && answer.message}
+          answerStatus={answer && answer.status}
+          onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
+        />
       );
     }
 

--- a/app/frontend/proposals/proposals.actions.js
+++ b/app/frontend/proposals/proposals.actions.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 export const API_BASE_URL          = '/api';
 export const FETCH_PROPOSALS       = 'FETCH_PROPOSALS';
 export const FETCH_PROPOSAL        = 'FETCH_PROPOSAL';
+export const UPDATE_PROPOSAL       = 'UPDATE_PROPOSAL';
 export const APPEND_PROPOSALS_PAGE = 'APPEND_PROPOSALS_PAGE';
 export const VOTE_PROPOSAL         = 'VOTE_PROPOSAL';
 export const SET_ORDER             = 'SET_ORDER';
@@ -20,6 +21,15 @@ export function fetchProposal(proposalId) {
 
   return {
     type: FETCH_PROPOSAL,
+    payload: request
+  };
+}
+
+export function updateProposal(proposalId, proposalParams) {
+  const request = axios.patch(`${API_BASE_URL}/proposals/${proposalId}.json`, { proposal: proposalParams });
+
+  return {
+    type: UPDATE_PROPOSAL,
     payload: request
   };
 }

--- a/app/frontend/proposals/proposals.reducers.js
+++ b/app/frontend/proposals/proposals.reducers.js
@@ -1,6 +1,7 @@
 import { 
   FETCH_PROPOSALS, 
   FETCH_PROPOSAL, 
+  UPDATE_PROPOSAL,
   APPEND_PROPOSALS_PAGE, 
   VOTE_PROPOSAL,
   UPDATE_ANSWER
@@ -24,6 +25,7 @@ export const proposals = function (state = [], action) {
 export const proposal = function (state = {}, action) {
   switch (action.type) {
     case FETCH_PROPOSAL:
+    case UPDATE_PROPOSAL:
       return action.payload.data.proposal;
     case UPDATE_ANSWER:
       let answer = action.payload.data.proposal_answer;

--- a/app/frontend/proposals/scope_picker.component.js
+++ b/app/frontend/proposals/scope_picker.component.js
@@ -1,0 +1,76 @@
+import { Component }          from 'react';
+import { bindActionCreators } from 'redux';
+import { connect }            from 'react-redux';
+
+import { updateProposal }     from './proposals.actions';
+
+class ScopePicker extends Component {
+  render() {
+    const { proposal, districts } = this.props;
+
+    return (
+      <div>
+        <div className="scope-radio small-12 column">
+          <label>Scope</label>
+          <p className="note">Scope note</p>
+          <div className="small-3 column">
+            <input 
+              id="proposal_scope_district"
+              type="radio" 
+              value="district" 
+              onChange={() => this.selectScope('district')}
+              checked={proposal.scope_ === 'district'}/>
+            <label htmlFor="proposal_scope_district">District</label>
+          </div>
+          <div className="small-3 end column">
+            <input 
+              id="proposal_scope_city"
+              type="radio" 
+              value="city" 
+              onChange={() => this.selectScope('city')}
+              checked={proposal.scope_ === 'city'}/>
+            <label htmlFor="proposal_scope_city">City</label>
+          </div>
+        </div>
+
+        <div className="small-12 column">
+          <select onChange={(event) => this.selectDistrict(event.target.value)}>
+            {
+              districts.map((district) => 
+                <option key={district[1]} value={district[1]} defaultValue={proposal.district.id === district[1]}>
+                  {district[0]}
+                </option>
+              )
+            }
+          </select>
+        </div>
+      </div>
+    );
+  }
+
+  selectScope(scope) {
+    const { proposal } = this.props;
+
+    this.props.updateProposal(proposal.id, {
+      scope
+    });
+  }
+
+  selectDistrict(district) {
+    const { proposal } = this.props;
+
+    this.props.updateProposal(proposal.id, {
+      district
+    });
+  }
+}
+
+function mapStateToProps({ proposal, districts }) {
+  return { proposal, districts };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ updateProposal }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ScopePicker);

--- a/app/frontend/proposals/scope_picker.component.js
+++ b/app/frontend/proposals/scope_picker.component.js
@@ -6,13 +6,13 @@ import { updateProposal }     from './proposals.actions';
 
 class ScopePicker extends Component {
   render() {
-    const { proposal, districts } = this.props;
+    const { proposal } = this.props;
 
     return (
       <div>
         <div className="scope-radio small-12 column">
-          <label>Scope</label>
-          <p className="note">Scope note</p>
+          <label>{I18n.t('proposals.form.proposal_scope')}</label>
+          <p className="note">{I18n.t('proposals.form.proposal_scope_note')}</p>
           <div className="small-3 column">
             <input 
               id="proposal_scope_district"
@@ -20,7 +20,7 @@ class ScopePicker extends Component {
               value="district" 
               onChange={() => this.selectScope('district')}
               checked={proposal.scope_ === 'district'}/>
-            <label htmlFor="proposal_scope_district">District</label>
+            <label htmlFor="proposal_scope_district">{I18n.t('proposals.form.proposal_scope_district')}</label>
           </div>
           <div className="small-3 end column">
             <input 
@@ -29,23 +29,34 @@ class ScopePicker extends Component {
               value="city" 
               onChange={() => this.selectScope('city')}
               checked={proposal.scope_ === 'city'}/>
-            <label htmlFor="proposal_scope_city">City</label>
+            <label htmlFor="proposal_scope_city">{I18n.t('proposals.form.proposal_scope_city')}</label>
           </div>
         </div>
 
+        {this.renderDistrictPicker()}
+      </div>
+    );
+  }
+
+  renderDistrictPicker() {
+    const { proposal, districts } = this.props;
+
+    if (proposal.scope_ === 'district') {
+      return (
         <div className="small-12 column">
-          <select onChange={(event) => this.selectDistrict(event.target.value)}>
+          <select onChange={(event) => this.selectDistrict(event.target.value)} value={proposal.district && String(proposal.district.id)}>
             {
               districts.map((district) => 
-                <option key={district[1]} value={district[1]} defaultValue={proposal.district.id === district[1]}>
+                <option key={district[1]} value={district[1]}>
                   {district[0]}
                 </option>
               )
             }
           </select>
         </div>
-      </div>
-    );
+      );
+    }
+    return null;
   }
 
   selectScope(scope) {

--- a/app/models/abilities/reviewer.rb
+++ b/app/models/abilities/reviewer.rb
@@ -8,6 +8,7 @@ module Abilities
       can :access_panel, :revision
 
       can :moderate, Proposal
+      can :update, Proposal
 
       can [:read, :create, :update], [ProposalAnswer]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,7 +265,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :districts, only: [:index]
     resources :categories, only: [:index]
-    resources :proposals, only: [:show, :index] do
+    resources :proposals, only: [:show, :index, :update] do
       resources :votes, only: [:create]
       resource :answers, only: [:create, :update], controller: :proposal_answers
     end


### PR DESCRIPTION
# What and why

A `reviewer` should be able to edit district, category and subcategory while creating answers for proposals. I added an excerpt of the proposals from based on components to inline editing those fields.
# QA

![form](https://cloud.githubusercontent.com/assets/106021/14308039/b327c4ea-fbd3-11e5-9812-e2a5a1a98c2c.png)
# GIF Tax

![](https://media.giphy.com/media/l2R0duZtUJWZjN2ko/giphy.gif)
