### PR TITLE
Close proposals: users cannot create or edit proposals, comments and votes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ultrayoshi/ruby-node-phantomjs:2.1.1
+FROM codegram/ruby-node-phantomjs
 MAINTAINER david.morcillo@codegram.com
 
 # Create working directory

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -15,3 +15,4 @@
 @import "components/infinite_pagination";
 @import "components/social_share_buttons";
 @import "components/proposal_answer_box";
+@import "components/author_avatar";

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -16,3 +16,4 @@
 @import "components/social_share_buttons";
 @import "components/proposal_answer_box";
 @import "components/author_avatar";
+@import "components/proposal_show";

--- a/app/assets/stylesheets/components/_author_avatar.scss
+++ b/app/assets/stylesheets/components/_author_avatar.scss
@@ -1,0 +1,12 @@
+.author-avatar {
+  width: 32px;
+  height: 32px;
+  background: rgb(22, 160, 133);
+  color: #fff;
+  border-radius: 32px;
+  display: inline-block;
+  vertical-align: middle;
+  text-align: center;
+  line-height: 32px;
+  font-size: 1.7em;
+}

--- a/app/assets/stylesheets/components/_proposal_show.scss
+++ b/app/assets/stylesheets/components/_proposal_show.scss
@@ -1,0 +1,3 @@
+.proposal-show.component {
+  position: relative;
+}

--- a/app/controllers/api/author_controller.rb
+++ b/app/controllers/api/author_controller.rb
@@ -1,0 +1,11 @@
+class Api::AuthorController < Api::ApplicationController
+  before_action :authenticate_user!
+  load_and_authorize_resource :proposal
+  load_and_authorize_resource :author, :through => :proposal, :singleton => true
+
+  def hide
+    @author.block
+    Activity.log(current_user, :block, @author)
+    render json: @author
+  end
+end

--- a/app/controllers/api/meetings_controller.rb
+++ b/app/controllers/api/meetings_controller.rb
@@ -2,24 +2,27 @@ class Api::MeetingsController < Api::ApplicationController
   load_and_authorize_resource
 
   def index
-    meetings = Meeting.all
-    filter = ResourceFilter.new(params, filter_date: true)
+    if params[:proposal_id]
+      proposal = Proposal.find(params[:proposal_id])
+      @meetings = proposal.meetings
 
-    @meetings = filter.filter_collection(meetings.includes(:category, :subcategory))
-    tag_cloud = filter.tag_cloud(@meetings)
+      render json: @meetings
+    else
+      meetings = Meeting.all
+      filter = ResourceFilter.new(params, filter_date: true)
 
-    @meetings = @meetings.page(params[:page]).per(15)
+      @meetings = filter.filter_collection(meetings.includes(:category, :subcategory))
+      tag_cloud = filter.tag_cloud(@meetings)
 
-    respond_to do |format|
-      format.json { 
-        render json: @meetings, meta: {
-          tag_cloud: tag_cloud,
-          current_page: @meetings.current_page,
-          next_page: @meetings.next_page,
-          prev_page: @meetings.prev_page,
-          total_pages: @meetings.total_pages,
-          total_count: @meetings.total_count
-        }
+      @meetings = @meetings.page(params[:page]).per(15)
+
+      render json: @meetings, meta: {
+        tag_cloud: tag_cloud,
+        current_page: @meetings.current_page,
+        next_page: @meetings.next_page,
+        prev_page: @meetings.prev_page,
+        total_pages: @meetings.total_pages,
+        total_count: @meetings.total_count
       }
     end
   end

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -4,7 +4,7 @@ class Api::ProposalsController < Api::ApplicationController
   before_action :authenticate_user!, only: [:update, :flag, :unflag]
 
   load_resource
-  authorize_resource except: [:references]
+  authorize_resource except: [:update, :references]
 
   has_orders %w{random hot_score confidence_score created_at}, only: :index
 
@@ -38,6 +38,7 @@ class Api::ProposalsController < Api::ApplicationController
   end
 
   def update
+    authorize! :review, @proposal
     @proposal.assign_attributes(strong_params)
     @proposal.save
     render json: @proposal

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -1,7 +1,7 @@
 class Api::ProposalsController < Api::ApplicationController
   include HasOrders
 
-  before_action :authenticate_user!, only: [:update]
+  before_action :authenticate_user!, only: [:update, :flag, :unflag]
 
   load_resource
   authorize_resource except: [:references]
@@ -52,6 +52,16 @@ class Api::ProposalsController < Api::ApplicationController
   def hide
     @proposal.hide
     Activity.log(current_user, :hide, @proposal)
+    render json: @proposal
+  end
+
+  def flag
+    Flag.flag(current_user, @proposal)
+    render json: @proposal
+  end
+
+  def unflag
+    Flag.unflag(current_user, @proposal)
     render json: @proposal
   end
 

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -49,6 +49,12 @@ class Api::ProposalsController < Api::ApplicationController
     render json: @references
   end
 
+  def hide
+    @proposal.hide
+    Activity.log(current_user, :hide, @proposal)
+    render json: @proposal
+  end
+
   private
 
   def strong_params

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -2,7 +2,9 @@ class Api::ProposalsController < Api::ApplicationController
   include HasOrders
 
   before_action :authenticate_user!, only: [:update]
-  load_and_authorize_resource
+
+  load_resource
+  authorize_resource except: [:references]
 
   has_orders %w{random hot_score confidence_score created_at}, only: :index
 
@@ -39,6 +41,12 @@ class Api::ProposalsController < Api::ApplicationController
     @proposal.assign_attributes(strong_params)
     @proposal.save
     render json: @proposal
+  end
+
+  def references
+    @references = Reference.references_for(@proposal)
+    authorize! :read, @proposal
+    render json: @references
   end
 
   private

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -4,8 +4,12 @@ class Api::VotesController < Api::ApplicationController
 
   def create
     authorize! :vote, @proposal
-    @proposal.register_vote(current_user, 'yes')
-    @vote = Vote.where(voter: current_user, votable: @proposal).first
-    render json: @vote
+    unless @proposal.closed
+      @proposal.register_vote(current_user, 'yes')
+      @vote = Vote.where(voter: current_user, votable: @proposal).first
+      render json: @vote
+    else
+      render json: { error: I18n.t('unauthorized.default') }, status: :forbidden
+    end
   end
 end

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -4,12 +4,8 @@ class Api::VotesController < Api::ApplicationController
 
   def create
     authorize! :vote, @proposal
-    unless @proposal.closed
-      @proposal.register_vote(current_user, 'yes')
-      @vote = Vote.where(voter: current_user, votable: @proposal).first
-      render json: @vote
-    else
-      render json: { error: I18n.t('unauthorized.default') }, status: :forbidden
-    end
+    @proposal.register_vote(current_user, 'yes')
+    @vote = Vote.where(voter: current_user, votable: @proposal).first
+    render json: @vote
   end
 end

--- a/app/frontend/application/author_avatar.component.js
+++ b/app/frontend/application/author_avatar.component.js
@@ -1,0 +1,9 @@
+export default ({
+  author
+}) => {
+  const firstLetter = author.name[0].toUpperCase();
+  
+  return (
+    <span className="author-avatar">{firstLetter}</span>
+  );
+}

--- a/app/frontend/entry.js
+++ b/app/frontend/entry.js
@@ -39,4 +39,4 @@ window.ProposalsCarousel          = ProposalsCarousel;
 window.Votes                      = Votes; // Depcrecated
 
 require('quill/dist/quill.snow');
-
+require('expose?autoLink!autolink-js');

--- a/app/frontend/filters/filter_server_link.component.js
+++ b/app/frontend/filters/filter_server_link.component.js
@@ -1,0 +1,15 @@
+import { Component }          from 'react';
+
+export default class FilterServerLink extends Component {
+  render() {
+    let namespace = this.props.namespace || 'proposals';
+
+    return (
+      <a
+        href={`/${namespace}?filter=${this.props.name}=${this.props.value}`}>
+        <i className={this.props.cssClass} />
+        {this.props.label}
+      </a>
+    );
+  }
+}

--- a/app/frontend/meetings/meeting.component.js
+++ b/app/frontend/meetings/meeting.component.js
@@ -1,7 +1,8 @@
-import { Component } from 'react';
+import { Component }    from 'react';
 
-import MeetingTime   from './meeting_time.component';
-import FilterLink    from '../filters/filter_link.component';
+import MeetingTime      from './meeting_time.component';
+import FilterLink       from '../filters/filter_link.component';
+import FilterServerLink from '../filters/filter_server_link.component';
 
 export default class Meeting extends Component {
   constructor(props) {
@@ -39,17 +40,26 @@ export default class Meeting extends Component {
   }
 
   renderMeetingCategory() {
-    let { meeting } = this.props;
+    let { meeting, useServerLinks } = this.props;
     let { category, subcategory } = meeting;
 
     if(!meeting.category){ return <div />; }
     var categoryClassNames = `category-icon category-icon-${ meeting.category.id }`;
 
-    return (
-      <div className="item-meta">
-        <FilterLink name="category_id" value={category.id} label={` ${category.name}`} cssClass={`category-icon category-icon-${category.id}`} />
-        <FilterLink name="subcategory_id" value={subcategory.id} label={subcategory.name} />
-      </div>
-    );
+    if (useServerLinks) {
+      return (
+        <div className="item-meta">
+          <FilterServerLink namespace="meetings" name="category_id" value={category.id} label={` ${category.name}`} cssClass={`category-icon category-icon-${category.id}`} />
+          <FilterServerLink namespace="meetings" name="subcategory_id" value={subcategory.id} label={subcategory.name} />
+        </div>
+      );
+    } else {
+      return (
+        <div className="item-meta">
+          <FilterLink name="category_id" value={category.id} label={` ${category.name}`} cssClass={`category-icon category-icon-${category.id}`} />
+          <FilterLink name="subcategory_id" value={subcategory.id} label={subcategory.name} />
+        </div>
+      );
+    }
   }
 };

--- a/app/frontend/proposals/new_proposal_button.component.js
+++ b/app/frontend/proposals/new_proposal_button.component.js
@@ -1,5 +1,21 @@
-export default function () {
-  return (
-    <a href="/proposals/new" className="new-proposal button radius expand">{I18n.t("proposals.index.start_proposal")}</a>
-  );
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+class NewProposalButton extends Component {
+  render() {
+    const { session } = this.props;
+
+    if (session.can_create_new_proposals) {
+      return (
+        <a href="/proposals/new" className="new-proposal button radius expand">{I18n.t("proposals.index.start_proposal")}</a>
+      );
+    }
+    return null;
+  }
 }
+
+function mapStateToProps({ session }) {
+  return { session };
+}
+
+export default connect(mapStateToProps)(NewProposalButton);

--- a/app/frontend/proposals/proposal.component.js
+++ b/app/frontend/proposals/proposal.component.js
@@ -1,5 +1,6 @@
 import FilterLink      from '../filters/filter_link.component';
 import ProposalVoteBox from './proposal_vote_box.component';
+import ProposalBadge   from './proposal_badge.component';
 
 export default function ({
   id,
@@ -26,7 +27,7 @@ export default function ({
       <div className="row">
         <div className="small-12 medium-9 column">
           <div className="proposal-content">
-            <span className={`proposal-badge ${source}-badge`}></span>
+            <ProposalBadge source={source} />
             <span className="label-proposal">{ I18n.t('proposals.proposal.proposal') }</span>
             <h3><a href={url}>{ title }</a></h3>
             <p className="proposal-info">

--- a/app/frontend/proposals/proposal.component.js
+++ b/app/frontend/proposals/proposal.component.js
@@ -15,6 +15,7 @@ export default function ({
   total_votes,
   total_comments,
   voted,
+  closed,
   votable,
   official,
   from_meeting,
@@ -47,6 +48,7 @@ export default function ({
         </div>
         <aside id={`proposal_${id}_votes`} className="small-12 medium-3 column">
           <ProposalVoteBox 
+            hideButton={ closed }
             proposalId={ id } 
             proposalTitle={ title } 
             proposalUrl={ url } 

--- a/app/frontend/proposals/proposal.component.js
+++ b/app/frontend/proposals/proposal.component.js
@@ -1,8 +1,9 @@
-import FilterLink      from '../filters/filter_link.component';
 import ProposalVoteBox from './proposal_vote_box.component';
 import ProposalBadge   from './proposal_badge.component';
+import ProposalInfo    from './proposal_info.component';
+import ProposalMeta    from './proposal_meta.component';
 
-export default function ({
+export default ({
   id,
   title,
   url,
@@ -21,109 +22,43 @@ export default function ({
   official,
   from_meeting,
   author
-}) {
-  return (
-    <div id={`proposal_${id}`} className="proposal clear">
-      <div className="row">
-        <div className="small-12 medium-9 column">
-          <div className="proposal-content">
-            <ProposalBadge source={source} />
-            <span className="label-proposal">{ I18n.t('proposals.proposal.proposal') }</span>
-            <h3><a href={url}>{ title }</a></h3>
-            <p className="proposal-info">
-              <span>{ created_at }</span>
-              {renderAuthorInfo(official, from_meeting, author)}
-            </p>
-            <div className="proposal-description">
-              <p>{ summary }</p>
-              <div className="truncate"></div>
-            </div>
-            <div className="bottom-bar">
-              <div className="item-meta">
-                {renderMetaScope(scope_, district)}
-                <FilterLink name="category_id" value={category.id} label={` ${category.name}`} cssClass={`category-icon category-icon-${category.id}`} />
-                <FilterLink name="subcategory_id" value={subcategory.id} label={subcategory.name} />
-              </div>
-            </div>
+}) => (
+  <div id={`proposal_${id}`} className="proposal clear">
+    <div className="row">
+      <div className="small-12 medium-9 column">
+        <div className="proposal-content">
+          <ProposalBadge source={source} />
+          <span className="label-proposal">{ I18n.t('proposals.proposal.proposal') }</span>
+          <h3><a href={url}>{ title }</a></h3>
+          <ProposalInfo 
+            created_at={ created_at }
+            official={ official }
+            from_meeting={ from_meeting }
+            author={ author }/>
+          <div className="proposal-description">
+            <p>{ summary }</p>
+            <div className="truncate"></div>
+          </div>
+          <div className="bottom-bar">
+            <ProposalMeta 
+              scope={ scope_ }
+              district={ district }
+              category={ category }
+              subcategory={ subcategory } />
           </div>
         </div>
-        <aside id={`proposal_${id}_votes`} className="small-12 medium-3 column">
-          <ProposalVoteBox 
-            hideButton={ closed }
-            proposalId={ id } 
-            proposalTitle={ title } 
-            proposalUrl={ url } 
-            voted={ voted } 
-            votable={ votable } 
-            totalVotes={ total_votes } 
-            totalComments={ total_comments } />
-        </aside>
       </div>
+      <aside id={`proposal_${id}_votes`} className="small-12 medium-3 column">
+        <ProposalVoteBox 
+          hideButton={ closed }
+          proposalId={ id } 
+          proposalTitle={ title } 
+          proposalUrl={ url } 
+          voted={ voted } 
+          votable={ votable } 
+          totalVotes={ total_votes } 
+          totalComments={ total_comments } />
+      </aside>
     </div>
-  );
-}
-
-function renderMetaScope(scope, district) {
-  if (scope === "city") {
-    return (
-      <FilterLink name="scope" value="city" cssClass="bcn-icon-localitzacio bcn-icon" label={I18n.t("components.filter_option.city")} />
-    );
-  }
-  return (
-    <FilterLink name="district" value={district.id} cssClass="bcn-icon-localitzacio bcn-icon" label={district.name} />
-  );
-}
-
-function renderAuthorInfo(official, from_meeting, author) {
-  let result = [];
-
-  if(!(official || from_meeting)) {
-    if (author.hidden || author.erased) {
-      result.push(
-        <span key="deleted">
-          <span className="bullet">&nbsp;&bull;&nbsp;</span>
-          <span className="author">
-          { I18n.t("proposals.show.author_deleted") }
-          </span>
-        </span>
-      );
-    } else {
-      if (official) {
-        result.push(
-          <span key="official">
-            <span className="bullet">&nbsp;&bull;&nbsp;</span>
-            <span className="author">
-              <a href="">{author.name}</a>
-            </span>
-            <span className="bullet">&nbsp;&bull;&nbsp;</span>
-            <span className={`label round level-${author.official_level}`}>
-              {I18n.t(`officials.level_${author.official_level}`)}
-            </span>
-          </span>
-        );
-      } else {
-        result.push(
-          <span key="name">
-            <span className="bullet">&nbsp;&bull;&nbsp;</span>
-            <span className="author">
-              <a href={`/users/${author.id}`}>{author.name}</a>
-            </span>
-          </span>
-        );
-      }
-
-      if (author.verified_organization) {
-        result.push(
-          <span key="organization">
-            <span className="bullet">&nbsp;&bull;&nbsp;</span>
-            <span className="label round is-association">
-              {I18n.t("shared.collective")}
-            </span>
-          </span>
-        );
-      }
-    }
-  }
-
-  return result;
-}
+  </div>
+);

--- a/app/frontend/proposals/proposal_app.component.js
+++ b/app/frontend/proposals/proposal_app.component.js
@@ -10,6 +10,7 @@ import ReduxPromise      from 'redux-promise';
 import { proposal }      from './proposals.reducers';
 import categories        from '../categories/categories.reducers';
 import districts         from '../districts/districts.reducers';
+import filters           from '../filters/filters.reducers';
 
 import ProposalShow      from './proposal_show.component';
 
@@ -31,7 +32,8 @@ function createReducers(sessionState) {
     session,
     proposal,
     categories,
-    districts
+    districts,
+    filters
   });
 }
 

--- a/app/frontend/proposals/proposal_author.component.js
+++ b/app/frontend/proposals/proposal_author.component.js
@@ -1,0 +1,81 @@
+import { Component } from 'react';
+
+export default class ProposalAuthor extends Component {
+  render() {
+    return this.renderAuthor();
+  }
+
+  renderAuthor() {
+    const { official, fromMeeting, author } = this.props;
+
+    if(author && !(official || fromMeeting)) {
+      return this.renderHiddenOrAuthor();
+    }
+
+    return null;
+  }
+
+  renderHiddenOrAuthor() {
+    const { author } = this.props;
+
+    if (author.hidden || author.erased) {
+      return (
+        <span key="deleted">
+          <span className="author">
+          { I18n.t("proposals.show.author_deleted") }
+          </span>
+        </span>
+      );
+    } else {
+      return (
+        <span>
+          {this.renderOfficialOrAuthor()}
+          {this.renderVerifiedOrganization()}
+        </span>
+      );
+    }
+  }
+
+  renderOfficialOrAuthor() {
+    const { official, author } = this.props;
+
+    if (official) {
+      return (
+        <span key="official">
+          <span className="author">
+            <a href="">{author.name}</a>
+          </span>
+          <span className="bullet">&nbsp;&bull;&nbsp;</span>
+          <span className={`label round level-${author.official_level}`}>
+            {I18n.t(`officials.level_${author.official_level}`)}
+          </span>
+        </span>
+      );
+    } else {
+      return (
+        <span key="name">
+          <span className="author">
+            <a href={`/users/${author.id}`}>{author.name}</a>
+          </span>
+        </span>
+      );
+    }
+  }
+
+  renderVerifiedOrganization() {
+    const { author } = this.props;
+
+    if (author.verified_organization) {
+      return (
+        <span key="organization">
+          <span className="bullet">&nbsp;&bull;&nbsp;</span>
+          <span className="label round is-association">
+            {I18n.t("shared.collective")}
+          </span>
+        </span>
+      );
+    }
+
+    return null;
+  }
+}

--- a/app/frontend/proposals/proposal_badge.component.js
+++ b/app/frontend/proposals/proposal_badge.component.js
@@ -1,0 +1,5 @@
+export default ({
+  source
+}) => (
+  <span className={`proposal-badge ${source}-badge`}></span>
+);

--- a/app/frontend/proposals/proposal_info.component.js
+++ b/app/frontend/proposals/proposal_info.component.js
@@ -1,0 +1,67 @@
+export default function ({
+  created_at,
+  official,
+  from_meeting,
+  author
+}) {
+  return (
+    <p className="proposal-info">
+      <span>{ created_at }</span>
+      {renderAuthorInfo(official, from_meeting, author)}
+    </p>
+  );
+}
+
+function renderAuthorInfo(official, from_meeting, author) {
+  let result = [];
+
+  if(author && !(official || from_meeting)) {
+    if (author.hidden || author.erased) {
+      result.push(
+        <span key="deleted">
+          <span className="bullet">&nbsp;&bull;&nbsp;</span>
+          <span className="author">
+          { I18n.t("proposals.show.author_deleted") }
+          </span>
+        </span>
+      );
+    } else {
+      if (official) {
+        result.push(
+          <span key="official">
+            <span className="bullet">&nbsp;&bull;&nbsp;</span>
+            <span className="author">
+              <a href="">{author.name}</a>
+            </span>
+            <span className="bullet">&nbsp;&bull;&nbsp;</span>
+            <span className={`label round level-${author.official_level}`}>
+              {I18n.t(`officials.level_${author.official_level}`)}
+            </span>
+          </span>
+        );
+      } else {
+        result.push(
+          <span key="name">
+            <span className="bullet">&nbsp;&bull;&nbsp;</span>
+            <span className="author">
+              <a href={`/users/${author.id}`}>{author.name}</a>
+            </span>
+          </span>
+        );
+      }
+
+      if (author.verified_organization) {
+        result.push(
+          <span key="organization">
+            <span className="bullet">&nbsp;&bull;&nbsp;</span>
+            <span className="label round is-association">
+              {I18n.t("shared.collective")}
+            </span>
+          </span>
+        );
+      }
+    }
+  }
+
+  return result;
+}

--- a/app/frontend/proposals/proposal_info.component.js
+++ b/app/frontend/proposals/proposal_info.component.js
@@ -1,3 +1,5 @@
+import ProposalAuthor from './proposal_author.component';
+
 export default function ({
   created_at,
   official,
@@ -7,61 +9,11 @@ export default function ({
   return (
     <p className="proposal-info">
       <span>{ created_at }</span>
-      {renderAuthorInfo(official, from_meeting, author)}
+      <span className="bullet">&nbsp;&bull;&nbsp;</span>
+      <ProposalAuthor 
+        official={ official }
+        fromMeeting={ from_meeting }
+        author={ author } />
     </p>
   );
-}
-
-function renderAuthorInfo(official, from_meeting, author) {
-  let result = [];
-
-  if(author && !(official || from_meeting)) {
-    if (author.hidden || author.erased) {
-      result.push(
-        <span key="deleted">
-          <span className="bullet">&nbsp;&bull;&nbsp;</span>
-          <span className="author">
-          { I18n.t("proposals.show.author_deleted") }
-          </span>
-        </span>
-      );
-    } else {
-      if (official) {
-        result.push(
-          <span key="official">
-            <span className="bullet">&nbsp;&bull;&nbsp;</span>
-            <span className="author">
-              <a href="">{author.name}</a>
-            </span>
-            <span className="bullet">&nbsp;&bull;&nbsp;</span>
-            <span className={`label round level-${author.official_level}`}>
-              {I18n.t(`officials.level_${author.official_level}`)}
-            </span>
-          </span>
-        );
-      } else {
-        result.push(
-          <span key="name">
-            <span className="bullet">&nbsp;&bull;&nbsp;</span>
-            <span className="author">
-              <a href={`/users/${author.id}`}>{author.name}</a>
-            </span>
-          </span>
-        );
-      }
-
-      if (author.verified_organization) {
-        result.push(
-          <span key="organization">
-            <span className="bullet">&nbsp;&bull;&nbsp;</span>
-            <span className="label round is-association">
-              {I18n.t("shared.collective")}
-            </span>
-          </span>
-        );
-      }
-    }
-  }
-
-  return result;
 }

--- a/app/frontend/proposals/proposal_info_extended.component.js
+++ b/app/frontend/proposals/proposal_info_extended.component.js
@@ -1,28 +1,93 @@
-import ProposalAuthor from './proposal_author.component';
-import AuthorAvatar   from '../application/author_avatar.component';
+import { Component }                    from 'react';
+import { connect }                      from 'react-redux';
+import { bindActionCreators }           from 'redux';
 
-export default function ({
-  created_at,
-  official,
-  fromMeeting,
-  author,
-  totalComments
-}) {
-  return (
-    <p className="proposal-info extended">
-      <AuthorAvatar author={ author } />
-      <span className="bullet">&nbsp;&bull;&nbsp;</span>
-      <ProposalAuthor 
-        official={ official }
-        fromMeeting={ fromMeeting }
-        author={ author } />
-      <span className="bullet">&nbsp;&bull;&nbsp;</span>
-      <span>{ created_at }</span>
-      <span className="bullet">&nbsp;&bull;&nbsp;</span>
-      <i className="icon-comments"></i>&nbsp;
-      <a href="#comments">{ I18n.t('proposals.show.comments', { count: totalComments }) }</a>
-      <span className="bullet">&nbsp;&bull;&nbsp;</span>
-      <span className="js-flag-actions"></span>
-    </p>
-  );
+import { flagProposal, unFlagProposal } from './proposals.actions';
+
+import ProposalAuthor                   from './proposal_author.component';
+import AuthorAvatar                     from '../application/author_avatar.component';
+
+class ProposalInfoExtended extends Component {
+  render() {
+    const {
+      created_at,
+      official,
+      fromMeeting,
+      author,
+      totalComments
+    } = this.props;
+
+    return (
+      <p className="proposal-info extended">
+        <AuthorAvatar author={ author } />
+        <span className="bullet">&nbsp;&bull;&nbsp;</span>
+        <ProposalAuthor 
+          official={ official }
+          fromMeeting={ fromMeeting }
+          author={ author } />
+        <span className="bullet">&nbsp;&bull;&nbsp;</span>
+        <span>{ created_at }</span>
+        <span className="bullet">&nbsp;&bull;&nbsp;</span>
+        <i className="icon-comments"></i>&nbsp;
+        <a href="#comments">{ I18n.t('proposals.show.comments', { count: totalComments }) }</a>
+        <span className="bullet">&nbsp;&bull;&nbsp;</span>
+        {this.renderFlagActions()}
+      </p>
+    );
+  }
+
+  renderFlagActions() {
+    const { session, id, flagged, author } = this.props;
+
+    if (session.signed_in && session.user.id !== author.id) {
+      return (
+        <span className="js-flag-actions">
+          <span className="flag-content">
+            {this.renderFlagAction(id, flagged)}
+            {this.renderUnFlagAction(id, flagged)}
+          </span>
+        </span>
+      );
+    }
+
+    return null;
+  }
+
+  renderFlagAction(id, flagged) {
+    if (!flagged) {
+      return (
+        <a 
+          onClick={ () => this.props.flagProposal(id) }
+          title={ I18n.t('shared.flag') }>
+          &nbsp;<i className="icon-flag flag-disable"></i>&nbsp;&nbsp;
+        </a>
+      );
+    }
+
+    return null;
+  }
+
+  renderUnFlagAction(id, flagged) {
+    if (flagged) {
+      return (
+        <a 
+          onClick={ () => this.props.unFlagProposal(id) }
+          title={ I18n.t('shared.unflag') }>
+          &nbsp;<i className="icon-flag flag-active"></i>&nbsp;&nbsp;
+        </a>
+      );
+    }
+
+    return null;
+  }
 }
+
+function mapStateToProps({ session }) {
+  return { session };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ flagProposal, unFlagProposal }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProposalInfoExtended);

--- a/app/frontend/proposals/proposal_info_extended.component.js
+++ b/app/frontend/proposals/proposal_info_extended.component.js
@@ -57,6 +57,7 @@ class ProposalInfoExtended extends Component {
     if (!flagged) {
       return (
         <a 
+          id={`flag-proposal-${id}`}
           onClick={ () => this.props.flagProposal(id) }
           title={ I18n.t('shared.flag') }>
           &nbsp;<i className="icon-flag flag-disable"></i>&nbsp;&nbsp;
@@ -71,6 +72,7 @@ class ProposalInfoExtended extends Component {
     if (flagged) {
       return (
         <a 
+          id={`unflag-proposal-${id}`}
           onClick={ () => this.props.unFlagProposal(id) }
           title={ I18n.t('shared.unflag') }>
           &nbsp;<i className="icon-flag flag-active"></i>&nbsp;&nbsp;

--- a/app/frontend/proposals/proposal_info_extended.component.js
+++ b/app/frontend/proposals/proposal_info_extended.component.js
@@ -1,0 +1,28 @@
+import ProposalAuthor from './proposal_author.component';
+import AuthorAvatar   from '../application/author_avatar.component';
+
+export default function ({
+  created_at,
+  official,
+  fromMeeting,
+  author,
+  totalComments
+}) {
+  return (
+    <p className="proposal-info extended">
+      <AuthorAvatar author={ author } />
+      <span className="bullet">&nbsp;&bull;&nbsp;</span>
+      <ProposalAuthor 
+        official={ official }
+        fromMeeting={ fromMeeting }
+        author={ author } />
+      <span className="bullet">&nbsp;&bull;&nbsp;</span>
+      <span>{ created_at }</span>
+      <span className="bullet">&nbsp;&bull;&nbsp;</span>
+      <i className="icon-comments"></i>&nbsp;
+      <a href="#comments">{ I18n.t('proposals.show.comments', { count: totalComments }) }</a>
+      <span className="bullet">&nbsp;&bull;&nbsp;</span>
+      <span className="js-flag-actions"></span>
+    </p>
+  );
+}

--- a/app/frontend/proposals/proposal_meetings.component.js
+++ b/app/frontend/proposals/proposal_meetings.component.js
@@ -24,7 +24,7 @@ class ProposalMeetings extends Component {
   }
 
   renderMeetings() {
-    const { proposal } = this.props;
+    const { proposal, useServerLinks } = this.props;
     const meetings = proposal.meetings || [];
 
     if (meetings.length > 0) {
@@ -37,7 +37,7 @@ class ProposalMeetings extends Component {
                 { 
                   meetings.map((meeting) => 
                     <li key={ meeting.id }>
-                      <Meeting meeting={ meeting } />
+                      <Meeting meeting={ meeting } useServerLinks={ useServerLinks } />
                     </li>
                   )
                 }

--- a/app/frontend/proposals/proposal_meetings.component.js
+++ b/app/frontend/proposals/proposal_meetings.component.js
@@ -1,0 +1,51 @@
+import { Component }            from 'react';
+import { bindActionCreators }   from 'redux';
+import { connect }              from 'react-redux';
+
+import Meeting                  from '../meetings/meeting.component';
+
+import { fetchRelatedMeetings } from './proposals.actions';
+
+class ProposalMeetings extends Component {
+  componentDidMount() {
+    const { proposal } = this.props;
+
+    this.props.fetchRelatedMeetings(proposal.id);
+  }
+
+  render() {
+    const { proposal } = this.props;
+    const meetings = proposal.meetings || [];
+
+    return (
+      <div className="row">
+        <div className="small-12 medium-12 column">
+          <h2>{ I18n.t("proposals.show.meetings_title") }</h2>
+          <div className="meetings-directory">
+            <div className="meetings-list">
+              <ul className="meetings-list-items">
+                { 
+                  meetings.map((meeting) => 
+                    <li key={ meeting.id }>
+                      <Meeting meeting={ meeting } />
+                    </li>
+                  )
+                }
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps({ proposal }) {
+  return { proposal };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ fetchRelatedMeetings }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProposalMeetings);

--- a/app/frontend/proposals/proposal_meetings.component.js
+++ b/app/frontend/proposals/proposal_meetings.component.js
@@ -14,12 +14,22 @@ class ProposalMeetings extends Component {
   }
 
   render() {
-    const { proposal } = this.props;
-    const meetings = proposal.meetings || [];
-
     return (
       <div className="row">
         <div className="small-12 medium-12 column">
+          {this.renderMeetings()}
+        </div>
+      </div>
+    );
+  }
+
+  renderMeetings() {
+    const { proposal } = this.props;
+    const meetings = proposal.meetings || [];
+
+    if (meetings.length > 0) {
+      return (
+        <div>
           <h2>{ I18n.t("proposals.show.meetings_title") }</h2>
           <div className="meetings-directory">
             <div className="meetings-list">
@@ -35,8 +45,9 @@ class ProposalMeetings extends Component {
             </div>
           </div>
         </div>
-      </div>
-    );
+      );
+    }
+    return null;
   }
 }
 

--- a/app/frontend/proposals/proposal_meta.component.js
+++ b/app/frontend/proposals/proposal_meta.component.js
@@ -1,25 +1,61 @@
-import FilterLink from '../filters/filter_link.component';
+import { Component }    from 'react';
 
-export default ({
-  scope,
-  district,
-  category,
-  subcategory
-}) => (
-  <div className="item-meta">
-    {renderMetaScope(scope, district)}
-    <FilterLink name="category_id" value={category.id} label={` ${category.name}`} cssClass={`category-icon category-icon-${category.id}`} />
-    <FilterLink name="subcategory_id" value={subcategory.id} label={subcategory.name} />
-  </div>
-);
+import FilterLink       from '../filters/filter_link.component';
+import FilterServerLink from '../filters/filter_server_link.component';
 
-function renderMetaScope(scope, district) {
-  if (scope === "city") {
+export default class ProposalMeta extends Component {
+  render() {
     return (
-      <FilterLink name="scope" value="city" cssClass="bcn-icon-localitzacio bcn-icon" label={I18n.t("components.filter_option.city")} />
+      <div className="item-meta">
+        {this.renderMetaScope()}
+        {this.renderMetaCategories()}
+      </div>
     );
   }
-  return (
-    <FilterLink name="district" value={district.id} cssClass="bcn-icon-localitzacio bcn-icon" label={district.name} />
-  );
+
+  renderMetaScope() {
+    const { scope, district, useServerLinks } = this.props;
+
+    if (scope === "city") {
+      if (useServerLinks) {
+        return (
+          <FilterServerLink name="scope" value="city" cssClass="bcn-icon-localitzacio bcn-icon" label={I18n.t("components.filter_option.city")} />
+        );
+      } else {
+        return (
+          <FilterLink name="scope" value="city" cssClass="bcn-icon-localitzacio bcn-icon" label={I18n.t("components.filter_option.city")} />
+        );
+      }
+    }
+
+    if (useServerLinks) {
+      return (
+        <FilterServerLink name="district" value={district.id} cssClass="bcn-icon-localitzacio bcn-icon" label={district.name} />
+      );
+    } else {
+      return (
+        <FilterLink name="district" value={district.id} cssClass="bcn-icon-localitzacio bcn-icon" label={district.name} />
+      );
+    }
+  }
+
+  renderMetaCategories() {
+    const { category, subcategory, useServerLinks } = this.props;
+    let links = [];
+
+    if (useServerLinks) {
+      links = [
+        <FilterServerLink key="category_id" name="category_id" value={category.id} label={` ${category.name}`} cssClass={`category-icon category-icon-${category.id}`} />,
+        <FilterServerLink key="subcategory_id" name="subcategory_id" value={subcategory.id} label={subcategory.name} />
+      ];
+    } else {
+      links = [
+        <FilterLink key="category_id" name="category_id" value={category.id} label={` ${category.name}`} cssClass={`category-icon category-icon-${category.id}`} />,
+        <FilterLink key="subcategory_id" name="subcategory_id" value={subcategory.id} label={subcategory.name} />
+      ];
+    }
+
+    return links;
+  }
 }
+

--- a/app/frontend/proposals/proposal_meta.component.js
+++ b/app/frontend/proposals/proposal_meta.component.js
@@ -1,0 +1,25 @@
+import FilterLink from '../filters/filter_link.component';
+
+export default ({
+  scope,
+  district,
+  category,
+  subcategory
+}) => (
+  <div className="item-meta">
+    {renderMetaScope(scope, district)}
+    <FilterLink name="category_id" value={category.id} label={` ${category.name}`} cssClass={`category-icon category-icon-${category.id}`} />
+    <FilterLink name="subcategory_id" value={subcategory.id} label={subcategory.name} />
+  </div>
+);
+
+function renderMetaScope(scope, district) {
+  if (scope === "city") {
+    return (
+      <FilterLink name="scope" value="city" cssClass="bcn-icon-localitzacio bcn-icon" label={I18n.t("components.filter_option.city")} />
+    );
+  }
+  return (
+    <FilterLink name="district" value={district.id} cssClass="bcn-icon-localitzacio bcn-icon" label={district.name} />
+  );
+}

--- a/app/frontend/proposals/proposal_references.component.js
+++ b/app/frontend/proposals/proposal_references.component.js
@@ -1,0 +1,44 @@
+import { Component }            from 'react';
+import { bindActionCreators }   from 'redux';
+import { connect }              from 'react-redux';
+
+import { fetchReferences }      from './proposals.actions';
+
+class ProposalReferences extends Component {
+  componentDidMount() {
+    const { proposal } = this.props;
+
+    this.props.fetchReferences(proposal.id);
+  }
+
+  render() {
+    const { proposal } = this.props;
+    const references = proposal.references || [];
+
+    if (references.length > 0) {
+      return (
+        <div className="references">
+          <p>{ I18n.t('shared.references.description') }</p>
+          <ul className="references-list">
+            {
+              references.map(reference => 
+                <li key={reference.id}><a href={reference.url}>{reference.title}</a></li>
+              )
+            }
+          </ul>
+        </div>
+      );
+    }
+    return null;
+  }
+}
+
+function mapStateToProps({ proposal }) {
+  return { proposal };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ fetchReferences }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProposalReferences);

--- a/app/frontend/proposals/proposal_reviewer.component.js
+++ b/app/frontend/proposals/proposal_reviewer.component.js
@@ -1,0 +1,54 @@
+import { Component }          from 'react';
+import { connect }            from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import ScopePicker            from './scope_picker.component';
+import CategoryPicker         from '../categories/new_category_picker.component';
+import ProposalAnswerBox      from './proposal_answer_box.component';
+
+import { fetchDistricts }     from '../districts/districts.actions';
+import { fetchCategories }    from '../categories/categories.actions';
+import { updateAnswer }       from './proposals.actions';
+
+class ProposalReviewer extends Component {
+  componentDidMount() {
+    this.props.fetchDistricts();
+    this.props.fetchCategories();
+  }
+
+  render() {
+    const { session, proposal, updateAnswer } = this.props;
+    const { id, answer } = proposal;
+
+    if (session.is_reviewer) {
+      return (
+        <div>
+          <h2>{I18n.t('proposals.edit.editing')}</h2>
+          <ScopePicker />
+          <CategoryPicker />
+          <ProposalAnswerBox 
+            answerMessage={answer && answer.message}
+            answerStatus={answer && answer.status}
+            onButtonClick={(answerParams) => updateAnswer(proposal.id, answer, answerParams)} 
+          />
+        </div>
+      );
+    }
+
+    return null;
+  }
+}
+
+function mapStateToProps({ session, proposal }) {
+  return { session, proposal };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ 
+    fetchDistricts,
+    fetchCategories, 
+    updateAnswer
+  }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProposalReviewer);

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -113,6 +113,9 @@ class ProposalShow extends Component {
                 author={ author }
                 totalComments={ total_comments } />
 
+              <span className="bullet">&nbsp;&bull;&nbsp;</span>
+              {this.renderFlagActions(id)}
+
               <div className="proposal-description">{ summary }</div>
 
               {this.renderExternalUrl(external_url)}
@@ -219,6 +222,55 @@ class ProposalShow extends Component {
     }
 
     return null;
+  }
+
+  renderFlagActions(id) {
+    return (
+      <span className="js-flag-actions">
+        <span className="flag-content">
+          <a 
+            id={`flag-expand-proposal-${id}`}
+            data-dropdown={`flag-drop-proposal-${id}`} 
+            aria-controls={`flag-drop-proposal-${id}`}
+            aria-expanded="false"
+            title={ I18n.t('shared.flag') }>
+            &nbsp;<i className="icon-flag flag-disable"></i>&nbsp;&nbsp;
+          </a>
+          <ul 
+            id={`flag-drop-proposal-${id}`} 
+            className="f-dropdown"
+            data-dropdown-content
+            aria-hidden="true"
+            tabindex="-1">
+            <li>
+              <a id={`flag-proposal-${id}`}>
+                { I18n.t('shared.flag') }
+              </a>
+            </li>
+          </ul>
+          <a 
+            id={`unflag-expand-proposal-${id}`} 
+            data-dropdown={`unflag-drop-proposal-${id}`}
+            aria-controls={`unflag-drop-proposal-${id}`}
+            aria-expanded="false"
+            title={ I18n.t('shared.unflag') }>
+            &nbsp;<i className="icon-flag flag-active"></i>&nbsp;&nbsp;
+          </a>
+          <ul 
+            id={`unflag-drop-proposal-${id}`}
+            className="f-dropdown"
+            data-dropdown-content
+            aria-hidden="true"
+            tabindex="-1">
+            <li>
+              <a id={`unflag-proposal-${id}`}>
+                { I18n.t('shared.unflag') }
+              </a>
+            </li>
+          </ul>
+        </span>
+      </span>
+    )
   }
 
   renderReviewBox() {

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -124,7 +124,8 @@ class ProposalShow extends Component {
                 scope={ scope_ }
                 district={ district }
                 category={ category }
-                subcategory={ subcategory } />
+                subcategory={ subcategory } 
+                useServerLinks={ true }/>
 
               <ProposalReferences />
 
@@ -156,7 +157,7 @@ class ProposalShow extends Component {
             </aside>
           </div>
 
-          <ProposalMeetings />
+          <ProposalMeetings useServerLinks={ true } />
         </div>
       );
     }

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -60,20 +60,22 @@ class ProposalShow extends Component {
     );
   }
 
-  renderAnswerBox() {
+  renderReviewBox() {
     const { session, proposalId, proposal } = this.props;
     const { answer } = proposal;
 
     if (session.is_reviewer) {
       return (
-        <h2>{I18n.t('proposals.edit.editing')}</h2>
-        <ScopePicker />
-        <CategoryPicker />
-        <ProposalAnswerBox 
-          answerMessage={answer && answer.message}
-          answerStatus={answer && answer.status}
-          onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
-        />
+        <div>
+          <h2>{I18n.t('proposals.edit.editing')}</h2>
+          <ScopePicker />
+          <CategoryPicker />
+          <ProposalAnswerBox 
+            answerMessage={answer && answer.message}
+            answerStatus={answer && answer.status}
+            onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
+          />
+        </div>
       );
     }
 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -24,8 +24,9 @@ class ProposalShow extends Component {
   componentDidMount() {
     const { session } = this.props;
 
+    this.props.fetchProposal(this.props.proposalId);
+
     if (session.is_reviewer) {
-      this.props.fetchProposal(this.props.proposalId);
       this.props.fetchCategories();
       this.props.fetchDistricts();
     }

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -85,7 +85,8 @@ class ProposalShow extends Component {
         external_url,
         hidden,
         can_hide,
-        can_hide_author
+        can_hide_author,
+        flagged
       } = proposal;
 
       return (
@@ -107,14 +108,13 @@ class ProposalShow extends Component {
               {this.renderConflictiveWarning(conflictive)}
 
               <ProposalInfoExtended
+                id={ id }
                 created_at={ created_at }
                 official={ official }
                 from_meeting={ from_meeting }
                 author={ author }
-                totalComments={ total_comments } />
-
-              <span className="bullet">&nbsp;&bull;&nbsp;</span>
-              {this.renderFlagActions(id)}
+                totalComments={ total_comments } 
+                flagged={ flagged } />
 
               <div className="proposal-description">{ summary }</div>
 
@@ -222,55 +222,6 @@ class ProposalShow extends Component {
     }
 
     return null;
-  }
-
-  renderFlagActions(id) {
-    return (
-      <span className="js-flag-actions">
-        <span className="flag-content">
-          <a 
-            id={`flag-expand-proposal-${id}`}
-            data-dropdown={`flag-drop-proposal-${id}`} 
-            aria-controls={`flag-drop-proposal-${id}`}
-            aria-expanded="false"
-            title={ I18n.t('shared.flag') }>
-            &nbsp;<i className="icon-flag flag-disable"></i>&nbsp;&nbsp;
-          </a>
-          <ul 
-            id={`flag-drop-proposal-${id}`} 
-            className="f-dropdown"
-            data-dropdown-content
-            aria-hidden="true"
-            tabindex="-1">
-            <li>
-              <a id={`flag-proposal-${id}`}>
-                { I18n.t('shared.flag') }
-              </a>
-            </li>
-          </ul>
-          <a 
-            id={`unflag-expand-proposal-${id}`} 
-            data-dropdown={`unflag-drop-proposal-${id}`}
-            aria-controls={`unflag-drop-proposal-${id}`}
-            aria-expanded="false"
-            title={ I18n.t('shared.unflag') }>
-            &nbsp;<i className="icon-flag flag-active"></i>&nbsp;&nbsp;
-          </a>
-          <ul 
-            id={`unflag-drop-proposal-${id}`}
-            className="f-dropdown"
-            data-dropdown-content
-            aria-hidden="true"
-            tabindex="-1">
-            <li>
-              <a id={`unflag-proposal-${id}`}>
-                { I18n.t('shared.unflag') }
-              </a>
-            </li>
-          </ul>
-        </span>
-      </span>
-    )
   }
 
   renderReviewBox() {

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -13,7 +13,7 @@ import CategoryPicker                  from '../categories/new_category_picker.c
 
 import ProposalAnswerBox               from './proposal_answer_box.component';
 import ProposalBadge                   from './proposal_badge.component';
-import ProposalInfo                    from './proposal_info.component';
+import ProposalInfoExtended            from './proposal_info_extended.component';
 import ProposalMeta                    from './proposal_meta.component';
 import ProposalVoteBox                 from './proposal_vote_box.component';
 import ProposalReferences              from './proposal_references.component';
@@ -91,11 +91,12 @@ class ProposalShow extends Component {
                 <a href={url}>{title}<ProposalBadge source={source} /></a>
               </h2>
 
-              <ProposalInfo 
+              <ProposalInfoExtended
                 created_at={ created_at }
                 official={ official }
                 from_meeting={ from_meeting }
-                author={ author }/>
+                author={ author }
+                totalComments={ total_comments } />
 
               <div className="proposal-description">{ summary }</div>
 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -4,26 +4,20 @@ import { bindActionCreators }          from 'redux';
 
 import { 
   fetchProposal, 
-  updateAnswer,
   hideProposal,
   hideProposalAuthor
 } from './proposals.actions';
-import { fetchCategories }             from '../categories/categories.actions';
-import { fetchDistricts }              from '../districts/districts.actions';
 
 import Loading                         from '../application/loading.component';
 import SocialShareButtons              from '../application/social_share_buttons.component';
 
-import CategoryPicker                  from '../categories/new_category_picker.component';
-
-import ProposalAnswerBox               from './proposal_answer_box.component';
+import ProposalReviewer                from './proposal_reviewer.component';
 import ProposalBadge                   from './proposal_badge.component';
 import ProposalInfoExtended            from './proposal_info_extended.component';
 import ProposalMeta                    from './proposal_meta.component';
 import ProposalVoteBox                 from './proposal_vote_box.component';
 import ProposalReferences              from './proposal_references.component';
 import ProposalMeetings                from './proposal_meetings.component';
-import ScopePicker                     from './scope_picker.component';
 
 class ProposalShow extends Component {
   constructor(props) {
@@ -38,8 +32,6 @@ class ProposalShow extends Component {
     const { session } = this.props;
 
     this.props.fetchProposal(this.props.proposalId);
-    this.props.fetchCategories();
-    this.props.fetchDistricts();
   }
 
   componentWillReceiveProps(newProps) {
@@ -116,7 +108,9 @@ class ProposalShow extends Component {
                 totalComments={ total_comments } 
                 flagged={ flagged } />
 
-              <div className="proposal-description">{ summary }</div>
+              <div 
+                className="proposal-description"
+                dangerouslySetInnerHTML={{ __html: summary.autoLink() }} />
 
               {this.renderExternalUrl(external_url)}
 
@@ -134,7 +128,7 @@ class ProposalShow extends Component {
                 {this.renderHideAuthorButton(id, can_hide_author)}
               </div>
 
-              {this.renderReviewBox()}
+              <ProposalReviewer />
             </div>
 
             <aside className="small-12 medium-3 column">
@@ -224,28 +218,6 @@ class ProposalShow extends Component {
 
     return null;
   }
-
-  renderReviewBox() {
-    const { session, proposal } = this.props;
-    const { id, answer } = proposal;
-
-    if (session.is_reviewer) {
-      return (
-        <div>
-          <h2>{I18n.t('proposals.edit.editing')}</h2>
-          <ScopePicker />
-          <CategoryPicker />
-          <ProposalAnswerBox 
-            answerMessage={answer && answer.message}
-            answerStatus={answer && answer.status}
-            onButtonClick={(answerParams) => this.props.updateAnswer(proposal.id, answer, answerParams)} 
-          />
-        </div>
-      );
-    }
-
-    return null;
-  }
 }
 
 function mapStateToProps({ session, proposal }) {
@@ -255,9 +227,6 @@ function mapStateToProps({ session, proposal }) {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ 
     fetchProposal, 
-    updateAnswer, 
-    fetchCategories, 
-    fetchDistricts,
     hideProposal,
     hideProposalAuthor
   }, dispatch);

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -6,11 +6,17 @@ import { fetchProposal, updateAnswer } from './proposals.actions';
 import { fetchCategories }             from '../categories/categories.actions';
 import { fetchDistricts }              from '../districts/districts.actions';
 
-import ProposalAnswerBox               from './proposal_answer_box.component';
-import CategoryPicker                  from '../categories/new_category_picker.component';
-import ScopePicker                     from './scope_picker.component';
 import Loading                         from '../application/loading.component';
+import SocialShareButtons              from '../application/social_share_buttons.component';
+
+import CategoryPicker                  from '../categories/new_category_picker.component';
+
+import ProposalAnswerBox               from './proposal_answer_box.component';
 import ProposalBadge                   from './proposal_badge.component';
+import ProposalInfo                    from './proposal_info.component';
+import ProposalMeta                    from './proposal_meta.component';
+import ProposalVoteBox                 from './proposal_vote_box.component';
+import ScopePicker                     from './scope_picker.component';
 
 class ProposalShow extends Component {
   constructor(props) {
@@ -25,11 +31,8 @@ class ProposalShow extends Component {
     const { session } = this.props;
 
     this.props.fetchProposal(this.props.proposalId);
-
-    if (session.is_reviewer) {
-      this.props.fetchCategories();
-      this.props.fetchDistricts();
-    }
+    this.props.fetchCategories();
+    this.props.fetchDistricts();
   }
 
   componentWillReceiveProps() {
@@ -37,33 +40,96 @@ class ProposalShow extends Component {
   }
 
   render() {
-    const { proposalId, proposal } = this.props;
-    const { url, title, source } = proposal;
-
     return (
-      <div id={`proposal_${proposalId}`}>
+      <div>
         <Loading show={this.state.loading} />
-        <div className="small-12 medium-9 column">
-          <i className="icon-angle-left left"></i>&nbsp;
-          <a className="left back">{I18n.t('proposals.show.back_link')}</a>
-
-          <h2>
-            <a href={url}>
-              {title}
-              <ProposalBadge source={source} />
-            </a>
-          </h2>
-
-        </div>
-
-        {this.renderReviewBox()}
+        {this.renderProposal()}
       </div>
     );
   }
 
+  renderProposal() {
+    const { proposal } = this.props;
+
+    if (proposal.id) {
+      const { 
+        id,
+        url, 
+        title, 
+        source, 
+        created_at, 
+        official, 
+        from_meeting, 
+        author,
+        summary,
+        closed,
+        voted,
+        votable,
+        total_votes,
+        total_comments,
+        scope_,
+        district,
+        category,
+        subcategory
+      } = proposal;
+
+      return (
+        <div className="row" id={`proposal_${proposal.id}`}>
+          <div className="small-12 medium-9 column">
+            <i className="icon-angle-left left"></i>&nbsp;
+
+            <a className="left back" href="/proposals">
+              {I18n.t('proposals.show.back_link')}
+            </a>
+
+            <h2>
+              <a href={url}>{title}<ProposalBadge source={source} /></a>
+            </h2>
+
+            <ProposalInfo 
+              created_at={ created_at }
+              official={ official }
+              from_meeting={ from_meeting }
+              author={ author }/>
+
+            <div className="proposal-description">{ summary }</div>
+
+            <ProposalMeta 
+              scope={ scope_ }
+              district={ district }
+              category={ category }
+              subcategory={ subcategory } />
+
+            {this.renderReviewBox()}
+          </div>
+
+          <aside className="small-12 medium-3 column">
+            <div className="sidebar-divider"></div>
+            <h3>{ I18n.t("votes.supports") }</h3>
+            <ProposalVoteBox 
+              hideButton={ closed }
+              proposalId={ proposal.id } 
+              proposalTitle={ title } 
+              proposalUrl={ url } 
+              voted={ voted } 
+              votable={ votable } 
+              totalVotes={ total_votes } 
+              totalComments={ total_comments } />
+            <div className="sidebar-divider"></div>
+            <h3>{ I18n.t("proposals.show.share") }</h3>
+            <SocialShareButtons 
+              title={ title }
+              url={ url }/>
+          </aside>
+        </div>
+      );
+    }
+    return null;
+  }
+
   renderReviewBox() {
-    const { session, proposalId, proposal } = this.props;
-    const { answer } = proposal;
+    const { session, proposal } = this.props;
+    const { id, answer } = proposal;
 
     if (session.is_reviewer) {
       return (
@@ -74,26 +140,11 @@ class ProposalShow extends Component {
           <ProposalAnswerBox 
             answerMessage={answer && answer.message}
             answerStatus={answer && answer.status}
-            onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
+            onButtonClick={(answerParams) => this.props.updateAnswer(proposal.id, answer, answerParams)} 
           />
         </div>
       );
     }
-
-    return null;
-  }
-
-  renderAnswerBox() {
-    const { proposalId, proposal } = this.props;
-    const { answer } = proposal;
-
-    return (
-      <ProposalAnswerBox 
-        answerMessage={answer && answer.message}
-        answerStatus={answer && answer.status}
-        onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
-      />
-    );
 
     return null;
   }

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -16,6 +16,7 @@ import ProposalBadge                   from './proposal_badge.component';
 import ProposalInfo                    from './proposal_info.component';
 import ProposalMeta                    from './proposal_meta.component';
 import ProposalVoteBox                 from './proposal_vote_box.component';
+import ProposalReferences              from './proposal_references.component';
 import ProposalMeetings                from './proposal_meetings.component';
 import ScopePicker                     from './scope_picker.component';
 
@@ -103,6 +104,8 @@ class ProposalShow extends Component {
                 district={ district }
                 category={ category }
                 subcategory={ subcategory } />
+
+              <ProposalReferences />
 
               {this.renderReviewBox()}
             </div>

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -10,6 +10,7 @@ import ProposalAnswerBox               from './proposal_answer_box.component';
 import CategoryPicker                  from '../categories/new_category_picker.component';
 import ScopePicker                     from './scope_picker.component';
 import Loading                         from '../application/loading.component';
+import ProposalBadge                   from './proposal_badge.component';
 
 class ProposalShow extends Component {
   constructor(props) {
@@ -35,17 +36,44 @@ class ProposalShow extends Component {
   }
 
   render() {
-    const { session } = this.props;
+    const { proposalId, proposal } = this.props;
+    const { url, title, source } = proposal;
+
+    return (
+      <div id={`proposal_${proposalId}`}>
+        <Loading show={this.state.loading} />
+        <div className="small-12 medium-9 column">
+          <i className="icon-angle-left left"></i>&nbsp;
+          <a className="left back">{I18n.t('proposals.show.back_link')}</a>
+
+          <h2>
+            <a href={url}>
+              {title}
+              <ProposalBadge source={source} />
+            </a>
+          </h2>
+
+        </div>
+
+        {this.renderReviewBox()}
+      </div>
+    );
+  }
+
+  renderAnswerBox() {
+    const { session, proposalId, proposal } = this.props;
+    const { answer } = proposal;
 
     if (session.is_reviewer) {
       return (
-        <div>
-          <Loading show={this.state.loading} />
-          <h2>{I18n.t('proposals.edit.editing')}</h2>
-          <ScopePicker />
-          <CategoryPicker />
-          {this.renderAnswerBox()}
-        </div>
+        <h2>{I18n.t('proposals.edit.editing')}</h2>
+        <ScopePicker />
+        <CategoryPicker />
+        <ProposalAnswerBox 
+          answerMessage={answer && answer.message}
+          answerStatus={answer && answer.status}
+          onButtonClick={(answerParams) => this.props.updateAnswer(proposalId, answer, answerParams)} 
+        />
       );
     }
 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -50,7 +50,7 @@ class ProposalShow extends Component {
 
   render() {
     return (
-      <div>
+      <div className="proposal-show component">
         <Loading show={this.state.loading} />
         {this.renderProposal()}
       </div>

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -97,6 +97,10 @@ class ProposalShow extends Component {
                 <a href={url}>{title}<ProposalBadge source={source} /></a>
               </h2>
 
+              <div className="alert-box info radius margin-top">
+                <strong>{ I18n.t("proposals.proposal.closing") }</strong>
+              </div>
+
               {this.renderConflictiveWarning(conflictive)}
 
               <ProposalInfoExtended

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -74,7 +74,8 @@ class ProposalShow extends Component {
         scope_,
         district,
         category,
-        subcategory
+        subcategory,
+        editable
       } = proposal;
 
       return (
@@ -86,6 +87,8 @@ class ProposalShow extends Component {
               <a className="left back" href="/proposals">
                 {I18n.t('proposals.show.back_link')}
               </a>
+
+              {this.renderEditButton(editable, url)}
 
               <h2>
                 <a href={url}>{title}<ProposalBadge source={source} /></a>
@@ -134,6 +137,19 @@ class ProposalShow extends Component {
         </div>
       );
     }
+    return null;
+  }
+
+  renderEditButton(editable, url) {
+    if (editable) {
+      return (
+        <a href={`${url}/edit`} className="edit-proposal button success tiny radius right">
+          <i className="icon-edit"></i>
+          { I18n.t("proposals.show.edit_proposal_link") }
+        </a>
+      );
+    }
+
     return null;
   }
 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -23,6 +23,7 @@ import ScopePicker                     from './scope_picker.component';
 class ProposalShow extends Component {
   constructor(props) {
     super(props);
+    console.log(autoLink);
 
     this.state = {
       loading: true
@@ -75,7 +76,9 @@ class ProposalShow extends Component {
         district,
         category,
         subcategory,
-        editable
+        editable,
+        conflictive,
+        external_url
       } = proposal;
 
       return (
@@ -94,6 +97,8 @@ class ProposalShow extends Component {
                 <a href={url}>{title}<ProposalBadge source={source} /></a>
               </h2>
 
+              {this.renderConflictiveWarning(conflictive)}
+
               <ProposalInfoExtended
                 created_at={ created_at }
                 official={ official }
@@ -102,6 +107,8 @@ class ProposalShow extends Component {
                 totalComments={ total_comments } />
 
               <div className="proposal-description">{ summary }</div>
+
+              <div className="document-link" dangerouslySetInnerHTML={{ __html: external_url.autoLink() }}></div>
 
               <ProposalMeta 
                 scope={ scope_ }
@@ -150,6 +157,18 @@ class ProposalShow extends Component {
       );
     }
 
+    return null;
+  }
+
+  renderConflictiveWarning(isConflictive) {
+    if (isConflictive) {
+      return (
+        <div className="alert-box alert radius margin-top">
+          <strong>{ I18n.t("proposals.show.flag") }</strong>
+        </div>
+      );
+    }
+    
     return null;
   }
 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -16,6 +16,7 @@ import ProposalBadge                   from './proposal_badge.component';
 import ProposalInfo                    from './proposal_info.component';
 import ProposalMeta                    from './proposal_meta.component';
 import ProposalVoteBox                 from './proposal_vote_box.component';
+import ProposalMeetings                from './proposal_meetings.component';
 import ScopePicker                     from './scope_picker.component';
 
 class ProposalShow extends Component {
@@ -35,8 +36,10 @@ class ProposalShow extends Component {
     this.props.fetchDistricts();
   }
 
-  componentWillReceiveProps() {
-    this.setState({ loading: false });
+  componentWillReceiveProps(newProps) {
+    if (newProps.proposal.id) {
+      this.setState({ loading: false });
+    }
   }
 
   render() {
@@ -74,53 +77,56 @@ class ProposalShow extends Component {
       } = proposal;
 
       return (
-        <div className="row" id={`proposal_${proposal.id}`}>
-          <div className="small-12 medium-9 column">
-            <i className="icon-angle-left left"></i>&nbsp;
+        <div>
+          <div className="row" id={`proposal_${proposal.id}`}>
+            <div className="small-12 medium-9 column">
+              <i className="icon-angle-left left"></i>&nbsp;
 
-            <a className="left back" href="/proposals">
-              {I18n.t('proposals.show.back_link')}
-            </a>
+              <a className="left back" href="/proposals">
+                {I18n.t('proposals.show.back_link')}
+              </a>
 
-            <h2>
-              <a href={url}>{title}<ProposalBadge source={source} /></a>
-            </h2>
+              <h2>
+                <a href={url}>{title}<ProposalBadge source={source} /></a>
+              </h2>
 
-            <ProposalInfo 
-              created_at={ created_at }
-              official={ official }
-              from_meeting={ from_meeting }
-              author={ author }/>
+              <ProposalInfo 
+                created_at={ created_at }
+                official={ official }
+                from_meeting={ from_meeting }
+                author={ author }/>
 
-            <div className="proposal-description">{ summary }</div>
+              <div className="proposal-description">{ summary }</div>
 
-            <ProposalMeta 
-              scope={ scope_ }
-              district={ district }
-              category={ category }
-              subcategory={ subcategory } />
+              <ProposalMeta 
+                scope={ scope_ }
+                district={ district }
+                category={ category }
+                subcategory={ subcategory } />
 
-            {this.renderReviewBox()}
+              {this.renderReviewBox()}
+            </div>
+
+            <aside className="small-12 medium-3 column">
+              <div className="sidebar-divider"></div>
+              <h3>{ I18n.t("votes.supports") }</h3>
+              <ProposalVoteBox 
+                hideButton={ closed }
+                proposalId={ proposal.id } 
+                proposalTitle={ title } 
+                proposalUrl={ url } 
+                voted={ voted } 
+                votable={ votable } 
+                totalVotes={ total_votes } 
+                totalComments={ total_comments } />
+              <div className="sidebar-divider"></div>
+              <h3>{ I18n.t("proposals.show.share") }</h3>
+              <SocialShareButtons 
+                title={ title }
+                url={ url }/>
+            </aside>
           </div>
-
-          <aside className="small-12 medium-3 column">
-            <div className="sidebar-divider"></div>
-            <h3>{ I18n.t("votes.supports") }</h3>
-            <ProposalVoteBox 
-              hideButton={ closed }
-              proposalId={ proposal.id } 
-              proposalTitle={ title } 
-              proposalUrl={ url } 
-              voted={ voted } 
-              votable={ votable } 
-              totalVotes={ total_votes } 
-              totalComments={ total_comments } />
-            <div className="sidebar-divider"></div>
-            <h3>{ I18n.t("proposals.show.share") }</h3>
-            <SocialShareButtons 
-              title={ title }
-              url={ url }/>
-          </aside>
+          <ProposalMeetings />
         </div>
       );
     }

--- a/app/frontend/proposals/proposal_vote_box.component.js
+++ b/app/frontend/proposals/proposal_vote_box.component.js
@@ -27,7 +27,7 @@ class ProposalVoteBox extends Component {
             </span>
             <div className="proposal-comments">
               <i className="icon-comments"></i>&nbsp;
-              <a>{I18n.t("proposals.proposal.comments", { count: this.props.totalComments })}</a>
+              <a href={`${this.props.proposalUrl}#comments`}>{I18n.t("proposals.proposal.comments", { count: this.props.totalComments })}</a>
             </div>
           </div>
           <div className="in-favor">

--- a/app/frontend/proposals/proposal_vote_box.component.js
+++ b/app/frontend/proposals/proposal_vote_box.component.js
@@ -31,7 +31,7 @@ class ProposalVoteBox extends Component {
             </div>
           </div>
           <div className="in-favor">
-            {this.renderVoteButton()}
+            {this.renderVoteButton(this.props.proposalTitle, this.props.proposalUrl)}
           </div>
           {this.renderShareButtons(this.props.proposalTitle, this.props.proposalUrl)}
           {this.renderCantVoteOverlay()}
@@ -40,7 +40,7 @@ class ProposalVoteBox extends Component {
     )
   }
 
-  renderVoteButton() {
+  renderVoteButton(title, url) {
     if(this.props.voted) { 
       return (
         <div className="supported">
@@ -49,7 +49,7 @@ class ProposalVoteBox extends Component {
       )
     } else {
       if (this.props.hideButton) {
-        return null;
+        return <SocialShareButtons title={title} url={url} />
       } else {
         return (
           <button 

--- a/app/frontend/proposals/proposal_vote_box.component.js
+++ b/app/frontend/proposals/proposal_vote_box.component.js
@@ -48,15 +48,19 @@ class ProposalVoteBox extends Component {
         </div>
       )
     } else {
-      return (
-        <button 
-          className="button button-support tiny radius expand" 
-          title={I18n.t('proposals.proposal.support_title')}
-          onClick={() => { this.props.voteProposal(this.props.proposalId) }}
-          onMouseEnter={() => { this.setState({ showCantVoteOverlay: true }) }}>
-          {I18n.t("proposals.proposal.support")}
-        </button>
-      )
+      if (this.props.hideButton) {
+        return null;
+      } else {
+        return (
+          <button 
+            className="button button-support tiny radius expand" 
+            title={I18n.t('proposals.proposal.support_title')}
+            onClick={() => { this.props.voteProposal(this.props.proposalId) }}
+            onMouseEnter={() => { this.setState({ showCantVoteOverlay: true }) }}>
+            {I18n.t("proposals.proposal.support")}
+          </button>
+        )
+      }
     }
   }
 

--- a/app/frontend/proposals/proposals.actions.js
+++ b/app/frontend/proposals/proposals.actions.js
@@ -1,13 +1,14 @@
 import axios from 'axios';
 
-export const API_BASE_URL          = '/api';
-export const FETCH_PROPOSALS       = 'FETCH_PROPOSALS';
-export const FETCH_PROPOSAL        = 'FETCH_PROPOSAL';
-export const UPDATE_PROPOSAL       = 'UPDATE_PROPOSAL';
-export const APPEND_PROPOSALS_PAGE = 'APPEND_PROPOSALS_PAGE';
-export const VOTE_PROPOSAL         = 'VOTE_PROPOSAL';
-export const SET_ORDER             = 'SET_ORDER';
-export const UPDATE_ANSWER         = 'UPDATE_ANSWER';
+export const API_BASE_URL           = '/api';
+export const FETCH_PROPOSALS        = 'FETCH_PROPOSALS';
+export const FETCH_PROPOSAL         = 'FETCH_PROPOSAL';
+export const UPDATE_PROPOSAL        = 'UPDATE_PROPOSAL';
+export const APPEND_PROPOSALS_PAGE  = 'APPEND_PROPOSALS_PAGE';
+export const VOTE_PROPOSAL          = 'VOTE_PROPOSAL';
+export const SET_ORDER              = 'SET_ORDER';
+export const UPDATE_ANSWER          = 'UPDATE_ANSWER';
+export const FETCH_RELATED_MEETINGS = 'FETCH_RELATED_MEETINGS';
 
 export function fetchProposals(options) {
   return {
@@ -65,6 +66,15 @@ export function updateAnswer(proposalId, answer, answerParams) {
 
   return {
     type: UPDATE_ANSWER,
+    payload: request
+  };
+}
+
+export function fetchRelatedMeetings(proposalId) {
+  const request = axios.get(`${API_BASE_URL}/proposals/${proposalId}/meetings.json`);
+
+  return {
+    type: FETCH_RELATED_MEETINGS,
     payload: request
   };
 }

--- a/app/frontend/proposals/proposals.actions.js
+++ b/app/frontend/proposals/proposals.actions.js
@@ -10,6 +10,8 @@ export const SET_ORDER              = 'SET_ORDER';
 export const UPDATE_ANSWER          = 'UPDATE_ANSWER';
 export const FETCH_RELATED_MEETINGS = 'FETCH_RELATED_MEETINGS';
 export const FETCH_REFERENCES       = 'FETCH_REFERENCES';
+export const HIDE_PROPOSAL          = 'HIDE_PROPOSAL';
+export const HIDE_PROPOSAL_AUTHOR   = 'HIDE_PROPOSAL_AUTHOR';
 
 export function fetchProposals(options) {
   return {
@@ -85,6 +87,24 @@ export function fetchReferences(proposalId) {
 
   return {
     type: FETCH_REFERENCES,
+    payload: request
+  };
+}
+
+export function hideProposal(proposalId) {
+  const request = axios.patch(`${API_BASE_URL}/proposals/${proposalId}/hide.json`);
+
+  return {
+    type: HIDE_PROPOSAL,
+    payload: request
+  };
+}
+
+export function hideProposalAuthor(proposalId) {
+  const request = axios.patch(`${API_BASE_URL}/proposals/${proposalId}/author/hide.json`);
+
+  return {
+    type: HIDE_PROPOSAL_AUTHOR,
     payload: request
   };
 }

--- a/app/frontend/proposals/proposals.actions.js
+++ b/app/frontend/proposals/proposals.actions.js
@@ -9,6 +9,7 @@ export const VOTE_PROPOSAL          = 'VOTE_PROPOSAL';
 export const SET_ORDER              = 'SET_ORDER';
 export const UPDATE_ANSWER          = 'UPDATE_ANSWER';
 export const FETCH_RELATED_MEETINGS = 'FETCH_RELATED_MEETINGS';
+export const FETCH_REFERENCES       = 'FETCH_REFERENCES';
 
 export function fetchProposals(options) {
   return {
@@ -75,6 +76,15 @@ export function fetchRelatedMeetings(proposalId) {
 
   return {
     type: FETCH_RELATED_MEETINGS,
+    payload: request
+  };
+}
+
+export function fetchReferences(proposalId) {
+  const request = axios.get(`${API_BASE_URL}/proposals/${proposalId}/references.json`);
+
+  return {
+    type: FETCH_REFERENCES,
     payload: request
   };
 }

--- a/app/frontend/proposals/proposals.actions.js
+++ b/app/frontend/proposals/proposals.actions.js
@@ -12,6 +12,8 @@ export const FETCH_RELATED_MEETINGS = 'FETCH_RELATED_MEETINGS';
 export const FETCH_REFERENCES       = 'FETCH_REFERENCES';
 export const HIDE_PROPOSAL          = 'HIDE_PROPOSAL';
 export const HIDE_PROPOSAL_AUTHOR   = 'HIDE_PROPOSAL_AUTHOR';
+export const FLAG_PROPOSAL          = 'FLAG_PROPOSAL';
+export const UNFLAG_PROPOSAL        = 'UNFLAG_PROPOSAL';
 
 export function fetchProposals(options) {
   return {
@@ -105,6 +107,24 @@ export function hideProposalAuthor(proposalId) {
 
   return {
     type: HIDE_PROPOSAL_AUTHOR,
+    payload: request
+  };
+}
+
+export function flagProposal(proposalId) {
+  const request = axios.patch(`${API_BASE_URL}/proposals/${proposalId}/flag.json`);
+
+  return {
+    type: FLAG_PROPOSAL,
+    payload: request
+  };
+}
+
+export function unFlagProposal(proposalId) {
+  const request = axios.patch(`${API_BASE_URL}/proposals/${proposalId}/unflag.json`);
+
+  return {
+    type: UNFLAG_PROPOSAL,
     payload: request
   };
 }

--- a/app/frontend/proposals/proposals.reducers.js
+++ b/app/frontend/proposals/proposals.reducers.js
@@ -8,7 +8,9 @@ import {
   FETCH_RELATED_MEETINGS,
   FETCH_REFERENCES,
   HIDE_PROPOSAL,
-  HIDE_PROPOSAL_AUTHOR
+  HIDE_PROPOSAL_AUTHOR,
+  FLAG_PROPOSAL,
+  UNFLAG_PROPOSAL
 } from './proposals.actions';
 
 export const proposals = function (state = [], action) {
@@ -31,7 +33,15 @@ export const proposal = function (state = {}, action) {
     case FETCH_PROPOSAL:
     case UPDATE_PROPOSAL:
     case HIDE_PROPOSAL:
-      return action.payload.data.proposal;
+    case FLAG_PROPOSAL:
+    case UNFLAG_PROPOSAL:
+      let proposal = action.payload.data.proposal;
+
+      return {
+        ...proposal,
+        meetings: state.meetings,
+        references: state.references
+      }
     case HIDE_PROPOSAL_AUTHOR:
       let author = action.payload.data.user;
 

--- a/app/frontend/proposals/proposals.reducers.js
+++ b/app/frontend/proposals/proposals.reducers.js
@@ -4,7 +4,8 @@ import {
   UPDATE_PROPOSAL,
   APPEND_PROPOSALS_PAGE, 
   VOTE_PROPOSAL,
-  UPDATE_ANSWER
+  UPDATE_ANSWER,
+  FETCH_RELATED_MEETINGS
 } from './proposals.actions';
 
 export const proposals = function (state = [], action) {
@@ -27,6 +28,13 @@ export const proposal = function (state = {}, action) {
     case FETCH_PROPOSAL:
     case UPDATE_PROPOSAL:
       return action.payload.data.proposal;
+    case FETCH_RELATED_MEETINGS:
+      let meetings = action.payload.data.meetings;
+
+      return {
+        ...state,
+        meetings
+      };
     case UPDATE_ANSWER:
       let answer = action.payload.data.proposal_answer;
 

--- a/app/frontend/proposals/proposals.reducers.js
+++ b/app/frontend/proposals/proposals.reducers.js
@@ -5,7 +5,8 @@ import {
   APPEND_PROPOSALS_PAGE, 
   VOTE_PROPOSAL,
   UPDATE_ANSWER,
-  FETCH_RELATED_MEETINGS
+  FETCH_RELATED_MEETINGS,
+  FETCH_REFERENCES
 } from './proposals.actions';
 
 export const proposals = function (state = [], action) {
@@ -34,6 +35,13 @@ export const proposal = function (state = {}, action) {
       return {
         ...state,
         meetings
+      };
+    case FETCH_REFERENCES:
+      let references = action.payload.data.proposals;
+
+      return {
+        ...state,
+        references
       };
     case UPDATE_ANSWER:
       let answer = action.payload.data.proposal_answer;

--- a/app/frontend/proposals/proposals.reducers.js
+++ b/app/frontend/proposals/proposals.reducers.js
@@ -6,7 +6,9 @@ import {
   VOTE_PROPOSAL,
   UPDATE_ANSWER,
   FETCH_RELATED_MEETINGS,
-  FETCH_REFERENCES
+  FETCH_REFERENCES,
+  HIDE_PROPOSAL,
+  HIDE_PROPOSAL_AUTHOR
 } from './proposals.actions';
 
 export const proposals = function (state = [], action) {
@@ -28,7 +30,15 @@ export const proposal = function (state = {}, action) {
   switch (action.type) {
     case FETCH_PROPOSAL:
     case UPDATE_PROPOSAL:
+    case HIDE_PROPOSAL:
       return action.payload.data.proposal;
+    case HIDE_PROPOSAL_AUTHOR:
+      let author = action.payload.data.user;
+
+      return {
+        ...state,
+        author
+      }
     case FETCH_RELATED_MEETINGS:
       let meetings = action.payload.data.meetings;
 

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -8,7 +8,7 @@ module ComponentsHelper
         },
         is_organization: current_user && current_user.organization?,
         is_reviewer: current_user && current_user.reviewer?,
-        can_create_new_proposals: !Proposal.closed?
+        can_create_new_proposals: can?(:create, Proposal)
       }
     })
     react_component("#{name}App", props)

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -4,7 +4,8 @@ module ComponentsHelper
       session: {
         signed_in: user_signed_in?,
         is_organization: current_user && current_user.organization?,
-        is_reviewer: current_user && current_user.reviewer?
+        is_reviewer: current_user && current_user.reviewer?,
+        can_create_new_proposals: !Proposal.closed?
       }
     })
     react_component("#{name}App", props)

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -3,6 +3,9 @@ module ComponentsHelper
     props.merge!({
       session: {
         signed_in: user_signed_in?,
+        user: {
+          id: current_user && current_user.id
+        },
         is_organization: current_user && current_user.organization?,
         is_reviewer: current_user && current_user.reviewer?,
         can_create_new_proposals: !Proposal.closed?

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -22,7 +22,8 @@ module Abilities
       can :create, Comment
       can :create, Debate if user.official_level? &&
                              user.official_level > 0
-      can :create, Proposal
+
+      can :create, Proposal unless Proposal.closed?
 
       can :write_long, Comment if user.official?
 

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -14,7 +14,7 @@ module Abilities
 
       can :read, Proposal
       can :update, Proposal do |proposal|
-        proposal.editable_by?(user)
+        proposal.editable_by?(user) && !proposal.closed?
       end
 
       can :read, SpendingProposal
@@ -41,7 +41,7 @@ module Abilities
       end
 
       if user.level_two_or_three_verified?
-        can :vote, Proposal
+        can :vote, Proposal, closed: false
         can :vote_featured, Proposal
         can :create, SpendingProposal
       end

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -42,7 +42,9 @@ module Abilities
       end
 
       if user.level_two_or_three_verified?
-        can :vote, Proposal, closed: false
+        can :vote, Proposal do |proposal|
+          !proposal.closed?
+        end
         can :vote_featured, Proposal
         can :create, SpendingProposal
       end

--- a/app/models/abilities/dynamizer.rb
+++ b/app/models/abilities/dynamizer.rb
@@ -8,6 +8,7 @@ module Abilities
 
       can :manage, Meeting
       can :create, Meeting
+      can :create, Proposal
     end
   end
 end

--- a/app/models/abilities/reviewer.rb
+++ b/app/models/abilities/reviewer.rb
@@ -8,7 +8,7 @@ module Abilities
       can :access_panel, :revision
 
       can :moderate, Proposal
-      can :update, Proposal
+      can :review, Proposal
 
       can [:read, :create, :update], [ProposalAnswer]
     end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -167,7 +167,7 @@ class Proposal < ActiveRecord::Base
   alias :closed? :closed
 
   def self.closed?
-    Time.now > Setting[:proposal_closing_time]
+    Setting[:proposal_closing_time] && (Time.now > Setting[:proposal_closing_time])
   end
 
   protected

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -161,6 +161,12 @@ class Proposal < ActiveRecord::Base
     where.not(id: reviewed) 
   end
 
+  def closed
+    Time.now > Time.now - 1.hour
+    #TODO: correct time
+    #Time.now > Setting[:proposal_closing_time]
+  end
+
   protected
 
     def set_responsible_name

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -162,11 +162,13 @@ class Proposal < ActiveRecord::Base
   end
 
   def closed
-    Time.now > Time.now - 1.hour
-    #TODO: correct time
-    #Time.now > Setting[:proposal_closing_time]
+    Proposal.closed?
   end
   alias :closed? :closed
+
+  def self.closed?
+    Time.now > Setting[:proposal_closing_time]
+  end
 
   protected
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -166,6 +166,7 @@ class Proposal < ActiveRecord::Base
     #TODO: correct time
     #Time.now > Setting[:proposal_closing_time]
   end
+  alias :closed? :closed
 
   protected
 

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -1,5 +1,6 @@
 class ProposalSerializer < ActiveModel::Serializer
-  attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source, :total_votes, :total_comments, :voted, :votable, :official, :from_meeting
+  attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source, 
+    :total_votes, :total_comments, :voted, :votable, :closed, :official, :from_meeting
 
   has_one :category
   has_one :subcategory
@@ -31,6 +32,12 @@ class ProposalSerializer < ActiveModel::Serializer
 
   def url
     scope && scope.proposal_url(object)
+  end
+
+  def closed
+    Time.now > Time.now - 1.hour
+    #TODO: correct time
+    #Time.now > Setting[:proposal_closing_time]
   end
 
   def created_at

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -1,7 +1,8 @@
 class ProposalSerializer < ActiveModel::Serializer
   attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source, 
     :total_votes, :total_comments, :voted, :votable, :closed, :official, :from_meeting,
-    :editable, :conflictive?, :external_url, :hidden?, :can_hide, :can_hide_author
+    :editable, :conflictive?, :external_url, :hidden?, :can_hide, :can_hide_author,
+    :flagged
 
   has_one :category
   has_one :subcategory
@@ -41,6 +42,10 @@ class ProposalSerializer < ActiveModel::Serializer
 
   def can_hide_author
     scope && scope.can?(:hide , object.author)
+  end
+
+  def flagged
+    scope && Flag.flagged?(scope.current_user, object)
   end
 
   def url

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -34,12 +34,6 @@ class ProposalSerializer < ActiveModel::Serializer
     scope && scope.proposal_url(object)
   end
 
-  def closed
-    Time.now > Time.now - 1.hour
-    #TODO: correct time
-    #Time.now > Setting[:proposal_closing_time]
-  end
-
   def created_at
     I18n.l object.created_at.to_date
   end

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -1,7 +1,7 @@
 class ProposalSerializer < ActiveModel::Serializer
   attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source, 
     :total_votes, :total_comments, :voted, :votable, :closed, :official, :from_meeting,
-    :editable
+    :editable, :conflictive?, :external_url
 
   has_one :category
   has_one :subcategory

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -1,7 +1,7 @@
 class ProposalSerializer < ActiveModel::Serializer
   attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source, 
     :total_votes, :total_comments, :voted, :votable, :closed, :official, :from_meeting,
-    :editable, :conflictive?, :external_url
+    :editable, :conflictive?, :external_url, :hidden?, :can_hide, :can_hide_author
 
   has_one :category
   has_one :subcategory
@@ -33,6 +33,14 @@ class ProposalSerializer < ActiveModel::Serializer
 
   def editable
     scope && scope.can?(:update , object)
+  end
+
+  def can_hide
+    scope && scope.can?(:hide , object)
+  end
+
+  def can_hide_author
+    scope && scope.can?(:hide , object.author)
   end
 
   def url

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -1,6 +1,7 @@
 class ProposalSerializer < ActiveModel::Serializer
   attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source, 
-    :total_votes, :total_comments, :voted, :votable, :closed, :official, :from_meeting
+    :total_votes, :total_comments, :voted, :votable, :closed, :official, :from_meeting,
+    :editable
 
   has_one :category
   has_one :subcategory
@@ -28,6 +29,10 @@ class ProposalSerializer < ActiveModel::Serializer
 
   def votable
     scope && scope.current_user && scope.current_user.level_two_or_three_verified?
+  end
+
+  def editable
+    scope && scope.can?(:update , object)
   end
 
   def url

--- a/app/views/proposals/_comments.html.erb
+++ b/app/views/proposals/_comments.html.erb
@@ -10,16 +10,18 @@
 
         <%= render 'shared/wide_order_selector', i18n_namespace: "comments" %>
 
-        <% if user_signed_in? %>
-          <%= render 'comments/form', {commentable: @proposal, parent_id: nil, toggeable: false} %>
-        <% else %>
-        <br>
+        <% unless @proposal.closed? %>
+          <% if user_signed_in? %>
+            <%= render 'comments/form', {commentable: @proposal, parent_id: nil, toggeable: false} %>
+          <% else %>
+            <br>
 
-        <div class="alert-box radius info">
-          <%= t("proposals.show.login_to_comment",
-              signin: link_to(t("votes.signin"), new_user_session_path),
-              signup: link_to(t("votes.signup"), new_user_registration_path)).html_safe %>
-          </div>
+            <div class="alert-box radius info">
+              <%= t("proposals.show.login_to_comment",
+                signin: link_to(t("votes.signin"), new_user_session_path),
+                signup: link_to(t("votes.signup"), new_user_registration_path)).html_safe %>
+            </div>
+          <% end %>
         <% end %>
 
         <% @comment_tree.root_comments.each do |comment| %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -10,8 +10,6 @@
 
 <section class="proposal-show" data-timestamp="<%= @proposal.created_at.to_i %>">
   <%= react_app 'Proposal', proposalId: @proposal.id %>
-
-  <%= render partial: 'closing_alert' %>
 </section>
 
 <%= render "proposals/comments" %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -11,26 +11,7 @@
 <section class="proposal-show" data-timestamp="<%= @proposal.created_at.to_i %>">
   <%= react_app 'Proposal', proposalId: @proposal.id %>
 
-
   <%= render partial: 'closing_alert' %>
+</section>
 
-  <% if @proposal.meetings.any? %>
-    <div class="row">
-      <div class="small-12 medium-9 column">
-        <h2><%= t("proposals.show.meetings_title") %></h2>
-        <ul class="small-block-grid-2 medium-block-grid-3 large-block-grid-4">
-          <% @proposal.meeting_proposals.each do |meeting_proposal| %>
-              <li class="meeting">
-                <div class="date"><%= l meeting_proposal.meeting.held_at %></div>
-                <div class="title"><%= link_to meeting_proposal.meeting.title, meeting_proposal.meeting %></div>
-                <% if meeting_proposal.meeting.closed? && meeting_proposal.consensus %>
-                  <div class="support"><%= t("meetings.close.form.proposals.consensus") %></div>
-                <% end %>
-              </li>
-          <% end %>
-        </ul>
-      </ul>
-    </div>
-  </section>
-<% end %>
 <%= render "proposals/comments" %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -9,92 +9,13 @@
 
 
 <section class="proposal-show" data-timestamp="<%= @proposal.created_at.to_i %>">
-  <div id="<%= dom_id(@proposal) %>" class="row">
-    <div class="small-12 medium-9 column">
-      <i class="icon-angle-left left"></i>&nbsp;
-      <%= link_to t("proposals.show.back_link"), :back, class: 'left back' %>
-
-      <% if current_user && @proposal.editable_by?(current_user) %>
-        <%= link_to edit_proposal_path(@proposal), class: 'edit-proposal button success tiny radius right' do %>
-          <i class="icon-edit"></i>
-          <%= t("proposals.show.edit_proposal_link") %>
-        <% end %>
-      <% end %>
-
-      <h2>
-        <%= link_to proposal_path(@proposal) do %>
-          <%= @proposal.title %>
-          <%= proposal_badge(@proposal) %>
-        <% end %>
-      </h2>
-
-      <%= render partial: 'closing_alert' %>
-
-      <% if @proposal.conflictive? %>
-        <div class="alert-box alert radius margin-top">
-          <strong><%= t("proposals.show.flag") %></strong>
-        </div>
-      <% end %>
-
-      <div class="proposal-info">
-        <% unless @proposal.official? or @proposal.from_meeting? %>
-          <%= render '/shared/author_info', resource: @proposal %>
-          <span class="bullet">&nbsp;&bull;&nbsp;</span>
-        <% end %>
-
-        <%= l @proposal.created_at.to_date %>
-        <span class="bullet">&nbsp;&bull;&nbsp;</span>
-        <i class="icon-comments"></i>&nbsp;
-        <%= link_to t("proposals.show.comments", count: @proposal.comments_count), "#comments" %>
-        <span class="bullet">&nbsp;&bull;&nbsp;</span>
-        <span class="js-flag-actions">
-          <%= render 'proposals/flag_actions', proposal: @proposal %>
-        </span>
-      </div>
-
-      <div class="proposal-description">
-        <%= text_with_links @proposal.summary %>
-      </div>
-
-      <% if @proposal.external_url.present? %>
-        <div class="document-link">
-          <%= text_with_links @proposal.external_url %>
-        </div>
-      <% end %>
-
-      <% if feature?(:proposal_video_url) && @proposal.video_url.present? %>
-        <div class="video-link">
-          <%= text_with_links @proposal.video_url %>
-        </div>
-      <% end %>
-
-      <%= render "proposals/meta", proposal: @proposal %>
-      <% if feature?(:proposal_tags) %>
-        <%= render 'shared/tags', taggable: @proposal %>
-      <% end %>
-
-      <%= render partial: 'shared/references', locals: { subject: @proposal } %>
-
-      <div class="js-moderator-proposal-actions margin">
-        <%= render 'proposals/actions', proposal: @proposal %>
-      </div>
-    </div>
-
-    <aside class="small-12 medium-3 column">
-      <div class="sidebar-divider"></div>
-      <h3><%= t("votes.supports") %></h3>
-      <%= vote_component_for @proposal %>
-      <div class="sidebar-divider"></div>
-      <h3><%= t("proposals.show.share") %></h3>
-      <%= react_component 'SocialShareButtons', title: @proposal.title, url: proposal_url(@proposal) %>
-    </aside>
-  </div>
-
   <div class="row">
     <div class="small-12 medium-9 column">
       <%= react_app 'Proposal', proposalId: @proposal.id %>
     </div>
   </div>
+
+  <%= render partial: 'closing_alert' %>
 
   <% if @proposal.meetings.any? %>
     <div class="row">

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -9,11 +9,7 @@
 
 
 <section class="proposal-show" data-timestamp="<%= @proposal.created_at.to_i %>">
-  <div class="row">
-    <div class="small-12 medium-9 column">
-      <%= react_app 'Proposal', proposalId: @proposal.id %>
-    </div>
-  </div>
+  <%= react_app 'Proposal', proposalId: @proposal.id %>
 
 
   <%= render partial: 'closing_alert' %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -15,6 +15,7 @@
     </div>
   </div>
 
+
   <%= render partial: 'closing_alert' %>
 
   <% if @proposal.meetings.any? %>

--- a/app/views/proposals/show.html.erb.bak
+++ b/app/views/proposals/show.html.erb.bak
@@ -1,0 +1,116 @@
+<% provide :title do %><%= @proposal.title %><% end %>
+<% provide :social_media_meta_tags do %>
+<%= render "shared/social_media_meta_tags",
+            social_url: proposal_url(@proposal),
+            social_title: @proposal.title,
+            social_media_image: asset_url('social-media-icon.png'),
+            social_description: text_with_links(@proposal.summary) %>
+<% end %>
+
+
+<section class="proposal-show" data-timestamp="<%= @proposal.created_at.to_i %>">
+  <div id="<%= dom_id(@proposal) %>" class="row">
+    <div class="small-12 medium-9 column">
+      <i class="icon-angle-left left"></i>&nbsp;
+      <%= link_to t("proposals.show.back_link"), :back, class: 'left back' %>
+
+      <% if current_user && @proposal.editable_by?(current_user) %>
+        <%= link_to edit_proposal_path(@proposal), class: 'edit-proposal button success tiny radius right' do %>
+          <i class="icon-edit"></i>
+          <%= t("proposals.show.edit_proposal_link") %>
+        <% end %>
+      <% end %>
+
+      <h2>
+        <%= link_to proposal_path(@proposal) do %>
+          <%= @proposal.title %>
+          <%= proposal_badge(@proposal) %>
+        <% end %>
+      </h2>
+
+      <% if @proposal.conflictive? %>
+        <div class="alert-box alert radius margin-top">
+          <strong><%= t("proposals.show.flag") %></strong>
+        </div>
+      <% end %>
+
+      <div class="proposal-info">
+        <% unless @proposal.official? or @proposal.from_meeting? %>
+          <%= render '/shared/author_info', resource: @proposal %>
+          <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <% end %>
+
+        <%= l @proposal.created_at.to_date %>
+        <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <i class="icon-comments"></i>&nbsp;
+        <%= link_to t("proposals.show.comments", count: @proposal.comments_count), "#comments" %>
+        <span class="bullet">&nbsp;&bull;&nbsp;</span>
+        <span class="js-flag-actions">
+          <%= render 'proposals/flag_actions', proposal: @proposal %>
+        </span>
+      </div>
+
+      <div class="proposal-description">
+        <%= text_with_links @proposal.summary %>
+      </div>
+
+      <% if @proposal.external_url.present? %>
+        <div class="document-link">
+          <%= text_with_links @proposal.external_url %>
+        </div>
+      <% end %>
+
+      <% if feature?(:proposal_video_url) && @proposal.video_url.present? %>
+        <div class="video-link">
+          <%= text_with_links @proposal.video_url %>
+        </div>
+      <% end %>
+
+      <%= render "proposals/meta", proposal: @proposal %>
+      <% if feature?(:proposal_tags) %>
+        <%= render 'shared/tags', taggable: @proposal %>
+      <% end %>
+
+      <%= render partial: 'shared/references', locals: { subject: @proposal } %>
+
+      <div class="js-moderator-proposal-actions margin">
+        <%= render 'proposals/actions', proposal: @proposal %>
+      </div>
+    </div>
+
+    <aside class="small-12 medium-3 column">
+      <div class="sidebar-divider"></div>
+      <h3><%= t("votes.supports") %></h3>
+      <%= vote_component_for @proposal %>
+      <div class="sidebar-divider"></div>
+      <h3><%= t("proposals.show.share") %></h3>
+      <%= react_component 'SocialShareButtons', title: @proposal.title, url: proposal_url(@proposal) %>
+    </aside>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-9 column">
+      <%= react_app 'Proposal', proposalId: @proposal.id %>
+    </div>
+  </div>
+
+  <% if @proposal.meetings.any? %>
+    <div class="row">
+      <div class="small-12 medium-9 column">
+        <h2><%= t("proposals.show.meetings_title") %></h2>
+        <ul class="small-block-grid-2 medium-block-grid-3 large-block-grid-4">
+          <% @proposal.meeting_proposals.each do |meeting_proposal| %>
+              <li class="meeting">
+                <div class="date"><%= l meeting_proposal.meeting.held_at %></div>
+                <div class="title"><%= link_to meeting_proposal.meeting.title, meeting_proposal.meeting %></div>
+                <% if meeting_proposal.meeting.closed? && meeting_proposal.consensus %>
+                  <div class="support"><%= t("meetings.close.form.proposals.consensus") %></div>
+                <% end %>
+              </li>
+          <% end %>
+        </ul>
+      </ul>
+    </div>
+  </section>
+<% end %>
+<%= render "proposals/comments" %>

--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ database:
 
 test:
   override:
-    - docker-compose run -e CI=true -e CI_PULL_REQUEST=$CI_PULL_REQUEST -e CI_PULL_REQUESTS=$CI_PULL_REQUESTS -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN -e COVERALLS_PARALLEL=true app bundle exec rspec:
+    - docker-compose run -e CI=true -e CI_PULL_REQUEST=$CI_PULL_REQUEST -e CI_PULL_REQUESTS=$CI_PULL_REQUESTS -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN -e COVERALLS_PARALLEL=true -e NODE_ENV=test app bundle exec rspec:
         parallel: true
         files:
           - spec/**/*_spec.rb

--- a/config/application.yml
+++ b/config/application.yml
@@ -39,7 +39,7 @@ defaults: &defaults
   github_handle: "AjuntamentdeBarcelona/decidim.barcelona"
   facebook_app_id: "929041747208547"
 
-  proposal_closing_time: <%= Time.zone.parse('2016-04-09 00:00:00 +0200') %>
+  proposal_closing_time: <%= ENV['PROPOSAL_CLOSING_DATE'] ? Time.zone.parse(ENV['PROPOSAL_CLOSING_DATE']) : nil %>
 
   blog_url: 
     ca: "http://eldigital.barcelona.cat/pambcn"

--- a/config/application.yml
+++ b/config/application.yml
@@ -39,6 +39,8 @@ defaults: &defaults
   github_handle: "AjuntamentdeBarcelona/decidim.barcelona"
   facebook_app_id: "929041747208547"
 
+  proposal_closing_time: <%= Time.zone.parse('2016-04-09 00:00:00 +0200') %>
+
   blog_url: 
     ca: "http://eldigital.barcelona.cat/pambcn"
     es: "http://eldigital.barcelona.cat/es/pambcn_es"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -469,6 +469,10 @@ ca:
     new:
       form:
         submit_button: Crear línia estratègica
+  unauthorized:
+    default: No tens permís per a accedir en aquesta pàgina.
+    manage:
+      all: No tens permís per a '%{action}' en aquest %{subject}.
   users:
     show:
       deleted: Eliminat

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,10 +268,16 @@ Rails.application.routes.draw do
     resources :proposals, only: [:show, :index, :update] do
       member do
         get :references
+        patch :hide
       end
       resources :votes, only: [:create]
       resource :answers, only: [:create, :update], controller: :proposal_answers
       resources :meetings, only: [:index]
+      resource :author, only: [], controller: 'author' do
+        member do
+          patch :hide
+        end
+      end
     end
     resources :meetings, only: [:index]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,8 @@ Rails.application.routes.draw do
       member do
         get :references
         patch :hide
+        patch :flag
+        patch :unflag
       end
       resources :votes, only: [:create]
       resource :answers, only: [:create, :update], controller: :proposal_answers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,6 +266,9 @@ Rails.application.routes.draw do
     resources :districts, only: [:index]
     resources :categories, only: [:index]
     resources :proposals, only: [:show, :index, :update] do
+      member do
+        get :references
+      end
       resources :votes, only: [:create]
       resource :answers, only: [:create, :update], controller: :proposal_answers
       resources :meetings, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,6 +268,7 @@ Rails.application.routes.draw do
     resources :proposals, only: [:show, :index, :update] do
       resources :votes, only: [:create]
       resource :answers, only: [:create, :update], controller: :proposal_answers
+      resources :meetings, only: [:index]
     end
     resources :meetings, only: [:index]
   end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "decidim.barcelona",
   "dependencies": {
+    "autolink-js": "^1.0.1",
     "axios": "^0.9.1",
     "babel-core": "^6.7.2",
     "babel-loader": "^6.2.4",

--- a/spec/features/admin/activity_spec.rb
+++ b/spec/features/admin/activity_spec.rb
@@ -13,9 +13,8 @@ feature 'Admin activity' do
 
       visit proposal_path(proposal)
 
-      within("#proposal_#{proposal.id}") do
-        click_link 'Hide'
-      end
+      expect(page).to have_selector("#proposal_#{proposal.id}")
+      find("#proposal_#{proposal.id} a", text: 'Hide').click
 
       visit admin_activity_path
 
@@ -195,14 +194,13 @@ feature 'Admin activity' do
   end
 
   context "User" do
-    scenario "Shows moderation activity on users" do
+    scenario "Shows moderation activity on users", :js do
       proposal = create(:proposal)
 
       visit proposal_path(proposal)
 
-      within("#proposal_#{proposal.id}") do
-        click_link 'Block author'
-      end
+      expect(page).to have_selector("#proposal_#{proposal.id}")
+      find("#proposal_#{proposal.id} a", text: 'Block author').click
 
       visit admin_activity_path
 

--- a/spec/features/admin/comments_spec.rb
+++ b/spec/features/admin/comments_spec.rb
@@ -7,7 +7,7 @@ feature 'Admin comments' do
     login_as(admin)
   end
 
-  scenario "Do not show comments from blocked users" do
+  scenario "Do not show comments from blocked users", :js do
     comment = create(:comment, :hidden, body: "SPAM from SPAMMER")
     proposal = create(:proposal, author: comment.author)
     create(:comment, commentable: proposal, user: comment.author, body: "Good Proposal!")
@@ -17,9 +17,9 @@ feature 'Admin comments' do
     expect(page).not_to have_content("Good Proposal!")
 
     visit proposal_path(proposal)
-    within("#proposal_#{proposal.id}") do
-      click_link 'Block author'
-    end
+
+    expect(page).to have_selector("#proposal_#{proposal.id}")
+    find("#proposal_#{proposal.id} a", text: 'Block author').click
 
     visit admin_comments_path
     expect(page).to_not have_content("SPAM from SPAMMER")

--- a/spec/features/moderation/proposals_spec.rb
+++ b/spec/features/moderation/proposals_spec.rb
@@ -11,11 +11,8 @@ feature 'Moderate proposals' do
     login_as(moderator)
     visit proposal_path(proposal)
 
-    within("#proposal_#{proposal.id}") do
-      click_link 'Hide'
-    end
-
-    expect(page).to have_css("#proposal_#{proposal.id}.faded")
+    expect(page).to have_selector("#proposal_#{proposal.id}")
+    find("#proposal_#{proposal.id} a", text: "Hide").click
 
     login_as(citizen)
     visit proposals_path
@@ -23,7 +20,7 @@ feature 'Moderate proposals' do
     expect(page).to have_css('.proposal', count: 0)
   end
 
-  scenario 'Can not hide own proposal' do
+  scenario 'Can not hide own proposal', :js do
     moderator = create(:moderator)
     proposal = create(:proposal, author: moderator)
 

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -254,6 +254,8 @@ feature 'Votes' do
       scenario 'Create in listed proposal in index', :js do
         visit proposals_path
 
+        expect(page).to have_selector("#proposal_#{@proposal.id}")
+
         within("#proposal_#{@proposal.id}") do
           find('.in-favor button').click
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,10 @@ RSpec.configure do |config|
     end
   end
 
+  config.after(:each, :js) do |example|
+    sleep 1
+  end
+
   if ENV["CI"]
     config.include RSpec::Repeat
     config.around :each, type: :feature do |example|
@@ -89,6 +93,4 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-
-
 end


### PR DESCRIPTION
# What and why

Well... I'm sorry but this PR is bigger than I expected. Let me explain the changes step by step:
- I created a new app component: `ProposalApp`. It replaces almost the `proposals#show` server view except the comments. I reused a lot of components created before as well as some API end points.
- I added more API endpoints:
  - `GET /proposals/:id/references`: Get proposal references (similar proposals)
  - `PATCH /proposals/:id/hide`: Hide proposal so it's not shown on the list.
  - `PATCH /proposals/:id/flag`: Mark proposal as conflictive.
  - `PATCH /proposals/:id/unflag`: Undo the flag action.
  - `PATCH /proposals/:id/author/hide`: Block author and hide his proposals.
  - `GET /proposals/:id/meetings`: Get related meetings for this proposal.
- Last but not least I added a configuration option to close proposals:
  - Users cannot create new proposals
  - Users cannot edit existing proposals
  - Users cannot vote or comment proposals
# QA

After installing all dependencies with `npm install` if you want to test the closing feature you need to add an environment variable `PROPOSAL_CLOSING_DATE` to activate it.
# GIF Tax

![](https://media.giphy.com/media/pNyOD9hyrEck8/giphy.gif)
