### PR TITLE
Allow reviewers to comment closed proposals

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,7 @@ class CommentsController < ApplicationController
   respond_to :html, :js
 
   def create
-    if @comment.save
+    if can?(:comment, @commentable) && @comment.save
       CommentNotifier.new(comment: @comment).process
       CommentReferencesWorker.perform_async(@comment.id)
       add_notification @comment

--- a/app/models/abilities/common.rb
+++ b/app/models/abilities/common.rb
@@ -36,6 +36,12 @@ module Abilities
       can [:flag, :unflag], Proposal
       cannot [:flag, :unflag], Proposal, author_id: user.id
 
+      can :comment, Proposal do |proposal| 
+        !proposal.closed?
+      end
+
+      can :comment, Debate
+
       unless user.organization?
         can :vote, Debate
         can :vote, Comment

--- a/app/models/abilities/reviewer.rb
+++ b/app/models/abilities/reviewer.rb
@@ -9,6 +9,7 @@ module Abilities
 
       can :moderate, Proposal
       can :review, Proposal
+      can :comment, Proposal
 
       can [:read, :create, :update], [ProposalAnswer]
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -140,5 +140,4 @@ class Comment < ActiveRecord::Base
     def dereference
       Referrer.new(self, self.commentable).dereference!
     end
-
 end

--- a/app/views/proposals/_comments.html.erb
+++ b/app/views/proposals/_comments.html.erb
@@ -10,9 +10,11 @@
 
         <%= render 'shared/wide_order_selector', i18n_namespace: "comments" %>
 
-        <% unless @proposal.closed? %>
+        <% if !@proposal.closed? %>
           <% if user_signed_in? %>
-            <%= render 'comments/form', {commentable: @proposal, parent_id: nil, toggeable: false} %>
+            <% if can?(:comment, @proposal) %>
+              <%= render 'comments/form', {commentable: @proposal, parent_id: nil, toggeable: false} %>
+            <% end %>
           <% else %>
             <br>
 


### PR DESCRIPTION
This adds the necessary permissions for a reviewer to comment on a closed proposal.
