### PR TITLE
Add Danger Link component

### DIFF
--- a/app/frontend/application/danger_link.component.js
+++ b/app/frontend/application/danger_link.component.js
@@ -1,0 +1,19 @@
+import { Component } from 'react';
+
+export default class DangerLink extends Component {
+  render() {
+    return (
+      <a
+        {...this.props}
+        onClick={() => this.onClick()}>
+        {this.props.children}
+      </a>
+    );
+  }
+
+  onClick() {
+    if (confirm(I18n.t('admin.actions.confirm'))) {
+      this.props.onClick();
+    }
+  }
+}

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -10,6 +10,7 @@ import {
 
 import Loading                         from '../application/loading.component';
 import SocialShareButtons              from '../application/social_share_buttons.component';
+import DangerLink                      from '../application/danger_link.component';
 
 import FollowButton                    from '../follows/follow_button.component';
 
@@ -52,7 +53,7 @@ class ProposalShow extends Component {
   }
 
   renderProposal() {
-    const { proposal, hideProposal, hideProposalAuthor } = this.props;
+    const { proposal } = this.props;
 
     if (proposal.id) {
       const { 
@@ -182,24 +183,28 @@ class ProposalShow extends Component {
   }
 
   renderHideButton(id, hasPermission) {
+    const { hideProposal } = this.props;
+
     if (hasPermission) {
       return (
-        <a onClick={() => hideProposal(id)}>
+        <DangerLink onClick={() => hideProposal(id)}>
           { I18n.t('admin.actions.hide') }
-        </a>
+        </DangerLink>
       );
     }
     return null;
   }
 
   renderHideAuthorButton(id, hasPermission) {
+    const { hideProposalAuthor } = this.props;
+
     if (hasPermission) {
       return (
         <span>
           <span>&nbsp;|&nbsp;</span>
-          <a onClick={() => hideProposalAuthor(id)}>
+          <DangerLink onClick={() => hideProposalAuthor(id)}>
             { I18n.t('admin.actions.hide_author') }
-          </a>
+          </DangerLink>
         </span>
       );
     }


### PR DESCRIPTION
# What and why

I added a component called `DangerLink` to wrap a normal link click action with a confirmation.
# QA

Try the "Hide" and "Hide author" moderator links. They need a confirmation in order to execute the action.
# GIF Tax

![](https://media.giphy.com/media/26FPqut4lzK3AECEo/giphy.gif)
