### PR TITLE
Add activity filter

### DIFF
--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -13,7 +13,7 @@ class Api::ProposalsController < Api::ApplicationController
 
     proposals = @current_order == "recommended" ? Recommender.new(current_user).proposals : Proposal.all
 
-    @proposals = ResourceFilter.new(params)
+    @proposals = ResourceFilter.new(params, user: current_user)
       .filter_collection(proposals.includes(:category, :subcategory, :author => [:organization]))
       .send("sort_by_#{@current_order}")
       .page(params[:page])

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -21,7 +21,7 @@ class ProposalsController < ApplicationController
 
       if can?(:download_report, Proposal)
         format.xls do
-          @filter = ResourceFilter.new(params)
+          @filter = ResourceFilter.new(params, user: current_user)
           proposals = @current_order == "recommended" ? Recommender.new(current_user).proposals : Proposal.all
 
           proposals = @filter.filter_collection(proposals.includes(:category, :subcategory, :author => [:organization]))

--- a/app/frontend/filters/user_interaction_filter.component.js
+++ b/app/frontend/filters/user_interaction_filter.component.js
@@ -1,0 +1,37 @@
+import { Component }          from 'react';
+import { bindActionCreators } from 'redux';
+import { connect }            from 'react-redux';
+
+import FilterOptionGroup      from './filter_option_group.component';
+import FilterOption           from './filter_option.component';
+
+import { setFilterGroup }     from './filters.actions';
+
+class ReviewerFilter extends Component {
+  render() {
+    if (this.props.session.signed_in) {
+      return (
+        <FilterOptionGroup 
+          filterGroupName="interaction"
+          filterGroupValue={this.props.filters.filter["interaction"]}
+          onChangeFilterGroup={(name, value) => this.props.setFilterGroup(name, value) }>
+          <FilterOption filterName="created" />
+          <FilterOption filterName="voted" />
+          <FilterOption filterName="commented" />
+          <FilterOption filterName="followed" />
+        </FilterOptionGroup>
+      );
+    }
+    return null;
+  }
+}
+
+function mapStateToProps({ filters, session }) {
+  return { filters, session };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ setFilterGroup }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ReviewerFilter);

--- a/app/frontend/proposals/proposals_filters.component.js
+++ b/app/frontend/proposals/proposals_filters.component.js
@@ -10,6 +10,7 @@ import CategoryFilterOptionGroup        from '../filters/category_filter_option_
 import SubcategoryFilterOptionGroup     from '../filters/subcategory_filter_option_group.component';
 import TagCloudFilter                   from '../filters/tag_cloud_filter.component';
 import ReviewerFilter                   from '../filters/reviewer_filter.component';
+import UserInteractionFilter            from '../filters/user_interaction_filter.component';
 
 import FilterOptionGroup                from '../filters/filter_option_group.component';
 import FilterOption                     from '../filters/filter_option.component';
@@ -20,6 +21,7 @@ class ProposalsFilters extends Component {
       <form className="proposal-filters">
         <SearchFilter searchText={this.props.filters.text} />
         <ReviewerFilter />
+        <UserInteractionFilter />
         <ScopeFilterOptionGroup />
         <CategoryFilterOptionGroup />
         <SubcategoryFilterOptionGroup />

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -147,8 +147,8 @@ ignore_unused:
   - 'helpers.page_entries_info.*' # kaminari
   - 'views.pagination.*' # kaminari
   - 'officials.*'
-  - 'components.filter_option.{city,district,official,citizenship,meetings,organization,all,past,upcoming}'
-  - 'components.filter_option_group.{category_id,district,scope,subcategory_id,other,source,date}'
+  - 'components.filter_option.*'
+  - 'components.filter_option_group.*'
   - 'recaptcha.*'
   - 'components.proposal_answer_box.*'
 # - '{devise,kaminari,will_paginate}.*'

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -18,7 +18,10 @@ ca:
       all: Totes
       citizenship: Ciutadania
       city: Tota la ciutat
+      commented: Comentades
+      created: Creades
       district: Un districte
+      followed: Seguides
       from_meetings: Cites presencials
       meetings: Debatudes a cites presencials
       not_reviewed: No revisades
@@ -27,15 +30,20 @@ ca:
       past: Passades
       reviewed: Revisades
       upcoming: Properes
+      voted: Votades
     filter_option_group:
       category_id: Eix
       date: Data
       district: Districte
+      interaction: La teva activitat
       other: Altres
       reviewer_status: Estat de la revisió
       scope: "Àmbit"
       source: Origen
       subcategory_id: Línia estratègica
+    follow_button:
+      follow: Seguir
+      unfollow: Deixar de seguir
     infinite_pagination:
       loading_more: Carregant més resultats...
     meeting_proposals_autocomplete_input:
@@ -62,6 +70,3 @@ ca:
       count: Mostrant %{count} propostes
     search_filter:
       search_input_placeholder: Cercar
-    follow_button:
-      follow: Seguir
-      unfollow: Deixar de seguir

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -18,7 +18,10 @@ en:
       all: All
       citizenship: Citizenship
       city: Whole city
+      commented: Commented
+      created: Created
       district: A district
+      followed: Followed
       from_meetings: Meetings
       meetings: Meetings
       not_reviewed: Not reviewed
@@ -27,15 +30,20 @@ en:
       past: Past
       reviewed: Reviewed
       upcoming: Upcoming
+      voted: Voted
     filter_option_group:
       category_id: Axis
       date: Date
       district: District
+      interaction: Your activity
       other: Other
       reviewer_status: Revision status
       scope: Scope
       source: Source
       subcategory_id: Strategic Line
+    follow_button:
+      follow: Follow
+      unfollow: Unfollow
     infinite_pagination:
       loading_more: Loading more results...
     meeting_proposals_autocomplete_input:
@@ -62,6 +70,3 @@ en:
       count: Showing %{count} proposals
     search_filter:
       search_input_placeholder: Search
-    follow_button:
-      follow: Follow
-      unfollow: Unfollow

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -18,7 +18,10 @@ es:
       all: Todas
       citizenship: Ciudadania
       city: Toda la ciudad
+      commented: Comentadas
+      created: Creadas
       district: Un distrito
+      followed: Seguidas
       from_meetings: Citas presenciales
       meetings: Debatidas en citas presenciales
       not_reviewed: No revisadas
@@ -27,15 +30,20 @@ es:
       past: Pasadas
       reviewed: Revisadas
       upcoming: Próximas
+      voted: Votadas
     filter_option_group:
       category_id: Eje
       date: Fecha
       district: Distrito
+      interaction: Tu actividad
       other: Otros
       reviewer_status: Estado de la revisión
       scope: "Ámbito"
       source: Origen
       subcategory_id: Línea estratégica
+    follow_button:
+      follow: Seguir
+      unfollow: Dejar de seguir
     infinite_pagination:
       loading_more: Cargando más resultados...
     meeting_proposals_autocomplete_input:
@@ -62,6 +70,3 @@ es:
       count: Mostrando %{count} propuestas
     search_filter:
       search_input_placeholder: Buscar
-    follow_button:
-      follow: Seguir
-      unfollow: Dejar de seguir

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -399,4 +399,8 @@ FactoryGirl.define do
     referenced_id 1
   end
 
+  factory :follow do
+    following{ create(:proposal, :debate).sample }
+    follower{ create(:user) }
+  end
 end

--- a/spec/services/resource_filter_spec.rb
+++ b/spec/services/resource_filter_spec.rb
@@ -52,6 +52,62 @@ describe ResourceFilter do
         expect(collection).to_not include(@proposal3)
         expect(collection).to_not include(@proposal4)
       end
+
+      describe "interaction" do
+        it "should filter voted proposals" do
+          user = create(:user)
+          user.likes(@proposal1)
+
+          filter = ResourceFilter.new({ filter: 'interaction=voted' }, { user: user })
+          collection = filter.filter_collection(Proposal.all)
+
+          expect(collection).to include(@proposal1)
+          expect(collection).to_not include(@proposal2, @proposal3)
+        end
+
+        it "should filter commented proposals" do
+          user = create(:user)
+          create(:comment, commentable: @proposal2, user: user)
+
+          filter = ResourceFilter.new({ filter: 'interaction=commented' }, { user: user })
+          collection = filter.filter_collection(Proposal.all)
+
+          expect(collection).to include(@proposal2)
+          expect(collection).to_not include(@proposal1, @proposal3)
+        end
+
+        it "should filter followed proposals" do
+          user = create(:user)
+          create(:follow, following: @proposal2, follower: user)
+
+          filter = ResourceFilter.new({ filter: 'interaction=followed' }, { user: user })
+          collection = filter.filter_collection(Proposal.all)
+
+          expect(collection).to include(@proposal2)
+          expect(collection).to_not include(@proposal1, @proposal3)
+        end
+
+        it "should filter created proposals" do
+          user = @proposal3.author
+
+          filter = ResourceFilter.new({ filter: 'interaction=created' }, { user: user })
+          collection = filter.filter_collection(Proposal.all)
+
+          expect(collection).to include(@proposal3)
+          expect(collection).to_not include(@proposal1, @proposal2)
+        end
+
+        it "can be composed" do
+          user = @proposal3.author
+          user.likes @proposal1
+
+          filter = ResourceFilter.new({ filter: 'interaction=created,voted' }, { user: user })
+          collection = filter.filter_collection(Proposal.all)
+
+          expect(collection).to include(@proposal1, @proposal3)
+          expect(collection).to_not include(@proposal2)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What and why?

This will help a user find proposals voted, commented, created or followed by her. I believe this is a very useful feature, given we're now in a delivery phase.
## QA

When you're logged in, look for an activity filter on proposals.
## GIF TAX

![](http://i.giphy.com/GGsdLxyxyE3Sw.gif)
