### PR TITLE
Add action plan inline update

### DIFF
--- a/app/controllers/api/action_plans/proposals_controller.rb
+++ b/app/controllers/api/action_plans/proposals_controller.rb
@@ -1,0 +1,22 @@
+class Api::ActionPlans::ProposalsController < Api::ApplicationController
+  before_action :authenticate_user!
+  load_and_authorize_resource :action_plan
+
+  def index
+    @proposals = @action_plan.proposals
+    render json: @proposals
+  end
+
+  def create
+    @proposal = Proposal.find(params[:proposal_id])
+    @action_plan.proposals << @proposal
+    @action_plan.save
+    render json: @action_plan.proposals
+  end
+
+  def destroy
+    @proposal = @action_plan.proposals.find(params[:id])
+    @action_plan.proposals.delete(@proposal)
+    render json: @action_plan.proposals
+  end
+end

--- a/app/controllers/api/action_plans_controller.rb
+++ b/app/controllers/api/action_plans_controller.rb
@@ -46,11 +46,6 @@ class Api::ActionPlansController < Api::ApplicationController
     render json: @action_plan
   end
 
-  def proposals
-    @proposals = @action_plan.proposals
-    render json: @proposals, root: 'proposals'
-  end
-
   private
 
   def strong_params

--- a/app/controllers/api/action_plans_controller.rb
+++ b/app/controllers/api/action_plans_controller.rb
@@ -56,7 +56,7 @@ class Api::ActionPlansController < Api::ApplicationController
   def strong_params
     permitted_params = []
     permitted_params += [:approved] if can?(:approve, ActionPlan)
-    permitted_params += [:scope, :district] if can?(:manage, ActionPlan)
+    permitted_params += [:scope, :district, :category_id, :subcategory_id] if can?(:manage, ActionPlan)
     params.require(:action_plan).permit(permitted_params)
   end
 

--- a/app/controllers/api/action_plans_controller.rb
+++ b/app/controllers/api/action_plans_controller.rb
@@ -56,6 +56,7 @@ class Api::ActionPlansController < Api::ApplicationController
   def strong_params
     permitted_params = []
     permitted_params += [:approved] if can?(:approve, ActionPlan)
+    permitted_params += [:scope, :district] if can?(:manage, ActionPlan)
     params.require(:action_plan).permit(permitted_params)
   end
 

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -1,10 +1,15 @@
-import { Component }                from 'react';
-import { bindActionCreators }       from 'redux';
-import { connect }                  from 'react-redux';
+import { Component }              from 'react';
+import { bindActionCreators }     from 'redux';
+import { connect }                from 'react-redux';
 
-import ProposalsTable               from '../proposals/proposals_table.component';
+import ProposalsAutocompleteInput from '../proposals/proposals_autocomplete_input.component';
+import ProposalsTable             from '../proposals/proposals_table.component';
 
-import { fetchActionPlanProposals } from './action_plans.actions';
+import { 
+  addActionPlanProposal,
+  removeActionPlanProposal,
+  fetchActionPlanProposals 
+} from './action_plans.actions';
 
 
 class ActionPlanProposals extends Component {
@@ -15,23 +20,31 @@ class ActionPlanProposals extends Component {
   }
 
   render() {
-    const { actionPlan } = this.props;
+    const { actionPlan, addActionPlanProposal, removeActionPlanProposal } = this.props;
+    const { id } = actionPlan;
     const proposals = actionPlan.proposals || [];
 
-    if (proposals.length > 0) {
-      return (
-        <div>
-          <h4>{I18n.t("components.action_plan_proposals.title")}</h4>
-          <ProposalsTable proposals={proposals} />
-        </div>
-      );
-    }
-    return null;
+    return (
+      <div>
+        <h4>{I18n.t("components.action_plan_proposals.title")}</h4>
+        <ProposalsAutocompleteInput 
+          proposalsApiUrl="/api/proposals"
+          excludeIds={proposals.map(proposal => proposal.id)}
+          onAddProposal={proposal => addActionPlanProposal(id, proposal)} />
+        <ProposalsTable 
+          proposals={proposals}
+          onRemoveProposal={proposal => removeActionPlanProposal(id, proposal)} />
+      </div>
+    );
   }
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchActionPlanProposals }, dispatch);
+  return bindActionCreators({ 
+    addActionPlanProposal,
+    removeActionPlanProposal,
+    fetchActionPlanProposals 
+  }, dispatch);
 }
 
 export default connect(null, mapDispatchToProps)(ActionPlanProposals);

--- a/app/frontend/action_plans/action_plan_reviewer.component.js
+++ b/app/frontend/action_plans/action_plan_reviewer.component.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux';
 
 import ScopePicker            from '../scope/scope_picker.component';
 import CategoryPicker         from '../categories/new_category_picker.component';
+import ActionPlanProposals    from './action_plan_proposals.component';
 
 import { fetchDistricts }     from '../districts/districts.actions';
 import { fetchCategories }    from '../categories/categories.actions';
@@ -17,17 +18,24 @@ class ActionPlanReviewer extends Component {
 
   render() {
     const { session, actionPlan, updateActionPlan } = this.props;
-    const { id, scope_, district } = actionPlan;
+    const { id, scope_, district, category, subcategory } = actionPlan;
 
     if (session.is_reviewer) {
       return (
         <div>
-          <h2>{I18n.t('proposals.edit.editing')}</h2>
+          <ActionPlanProposals actionPlan={actionPlan} />
+          <h2>{I18n.t('action_plans.edit.editing')}</h2>
           <ScopePicker 
             scope={scope_} 
             onScopeSelected={scope => updateActionPlan(id, { scope })}
             district={district}
             onDistrictSelected={districtId => updateActionPlan(id, { district: districtId })} />
+          <CategoryPicker 
+            category={category}
+            subcategory={subcategory}
+            onCategorySelected={({categoryId, subcategoryId}) => updateActionPlan(id, { category_id: categoryId, subcategory_id: subcategoryId })}
+            onSubcategorySelected={subcategoryId => updateActionPlan(id, {subcategory_id: subcategoryId})}
+          />
         </div>
       );
     }

--- a/app/frontend/action_plans/action_plan_reviewer.component.js
+++ b/app/frontend/action_plans/action_plan_reviewer.component.js
@@ -1,0 +1,51 @@
+import { Component }          from 'react';
+import { connect }            from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import ScopePicker            from '../scope/scope_picker.component';
+import CategoryPicker         from '../categories/new_category_picker.component';
+
+import { fetchDistricts }     from '../districts/districts.actions';
+import { fetchCategories }    from '../categories/categories.actions';
+import { updateActionPlan }   from './action_plans.actions';
+
+class ActionPlanReviewer extends Component {
+  componentDidMount() {
+    this.props.fetchDistricts();
+    this.props.fetchCategories();
+  }
+
+  render() {
+    const { session, actionPlan, updateActionPlan } = this.props;
+    const { id, scope_, district } = actionPlan;
+
+    if (session.is_reviewer) {
+      return (
+        <div>
+          <h2>{I18n.t('proposals.edit.editing')}</h2>
+          <ScopePicker 
+            scope={scope_} 
+            onScopeSelected={scope => updateActionPlan(id, { scope })}
+            district={district}
+            onDistrictSelected={districtId => updateActionPlan(id, { district: districtId })} />
+        </div>
+      );
+    }
+
+    return null;
+  }
+}
+
+function mapStateToProps({ session, actionPlan }) {
+  return { session, actionPlan };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ 
+    fetchDistricts,
+    fetchCategories,
+    updateActionPlan
+  }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ActionPlanReviewer);

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -52,7 +52,6 @@ class ActionPlanShow extends Component {
       const { 
         id,
         url,
-        edit_url,
         deleted,
         new_revision_url,
         title, 
@@ -78,11 +77,6 @@ class ActionPlanShow extends Component {
                 <i className="icon-cross"></i>
                 { I18n.t("components.action_plan_show.delete") }
               </DangerLink>
-
-              <a href={edit_url} className="edit-proposal button success tiny radius right">
-                <i className="icon-edit"></i>
-                { I18n.t("components.action_plan_show.edit") }
-              </a>
 
               <a href={new_revision_url} className="edit-proposal button success tiny radius right">
                 <i className="icon-edit"></i>

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -8,10 +8,12 @@ import {
   approveActionPlan
 } from './action_plans.actions';
 
-import Loading              from '../application/loading.component';
-import DangerLink           from '../application/danger_link.component';
-import FilterMeta           from '../filters/filter_meta.component';
-import ActionPlanProposals  from './action_plan_proposals.component';
+import Loading            from '../application/loading.component';
+import DangerLink         from '../application/danger_link.component';
+import FilterMeta         from '../filters/filter_meta.component';
+
+import ActionPlanReviewer from './action_plan_reviewer.component';
+
 
 class ActionPlanShow extends Component {
   constructor(props) {
@@ -111,7 +113,7 @@ class ActionPlanShow extends Component {
                 namespace="action_plans"
                 useServerLinks={ true }/>
 
-              <ActionPlanProposals actionPlan={actionPlan} />
+              <ActionPlanReviewer />
             </div>
           </div>
         </div>

--- a/app/frontend/action_plans/action_plans.actions.js
+++ b/app/frontend/action_plans/action_plans.actions.js
@@ -7,6 +7,8 @@ export const FETCH_ACTION_PLAN_PROPOSALS = 'FETCH_ACTION_PLAN_PROPOSALS';
 export const APPEND_ACTION_PLANS_PAGE    = 'APPEND_ACTION_PLANS_PAGE';
 export const DELETE_ACTION_PLAN          = 'DELETE_ACTION_PLAN';
 export const UPDATE_ACTION_PLAN          = 'UPDATE_ACTION_PLAN';
+export const ADD_ACTION_PLAN_PROPOSAL    = 'ADD_ACTION_PLAN_PROPOSAL';
+export const REMOVE_ACTION_PLAN_PROPOSAL = 'REMOVE_ACTION_PLAN_PROPOSAL';
 
 export function deleteActionPlan(id){
   const request = axios.delete(`${API_BASE_URL}/action_plans/${id}.json`);
@@ -60,6 +62,26 @@ export function fetchActionPlanProposals(actionPlanId) {
 
   return {
     type: FETCH_ACTION_PLAN_PROPOSALS,
+    payload: request
+  };
+}
+
+export function addActionPlanProposal(actionPlanId, proposal) {
+  const request = axios.post(`${API_BASE_URL}/action_plans/${actionPlanId}/proposals.json`, {
+    proposal_id: proposal.id
+  });
+
+  return {
+    type: ADD_ACTION_PLAN_PROPOSAL,
+    payload: request
+  };
+}
+
+export function removeActionPlanProposal(actionPlanId, proposal) {
+  const request = axios.delete(`${API_BASE_URL}/action_plans/${actionPlanId}/proposals/${proposal.id}.json`);
+
+  return {
+    type: REMOVE_ACTION_PLAN_PROPOSAL,
     payload: request
   };
 }

--- a/app/frontend/action_plans/action_plans.reducers.js
+++ b/app/frontend/action_plans/action_plans.reducers.js
@@ -4,7 +4,9 @@ import {
   FETCH_ACTION_PLAN_PROPOSALS,
   APPEND_ACTION_PLANS_PAGE,
   DELETE_ACTION_PLAN,
-  UPDATE_ACTION_PLAN
+  UPDATE_ACTION_PLAN,
+  ADD_ACTION_PLAN_PROPOSAL,
+  REMOVE_ACTION_PLAN_PROPOSAL
 } from './action_plans.actions';
 
 export const actionPlans = function (state = [], action) {
@@ -34,6 +36,8 @@ export const actionPlan = function (state = {}, action) {
         proposals: state.proposals
       };
     case FETCH_ACTION_PLAN_PROPOSALS:
+    case ADD_ACTION_PLAN_PROPOSAL:
+    case REMOVE_ACTION_PLAN_PROPOSAL:
       let proposals = action.payload.data.proposals;
 
       return {

--- a/app/frontend/categories/new_category_picker.component.js
+++ b/app/frontend/categories/new_category_picker.component.js
@@ -2,48 +2,47 @@ import { Component }          from 'react';
 import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
-import { updateProposal }     from '../proposals/proposals.actions';
-
 import SubcategoryPicker      from './new_subcategory_picker.component';
 
 class CategoryPicker extends Component {
   render () {
-    const { categories, proposal } = this.props;
-    const subcategories = (categories.length > 0 && proposal.category) ? categories
-      .filter(category => {
-        return proposal && category.id === proposal.category.id
+    const { categories, category, subcategory } = this.props;
+    const subcategories = (categories.length > 0 && category) ? categories
+      .filter(c => {
+        return c.id === category.id
       })[0]
       .subcategories : [];
 
-    var category = categories.map(category => this.renderRow(category));
+    var categoryList = categories.map(c => this.renderRow(c));
 
     return (
       <div>
         <div className="category-picker">
           <label>{I18n.t("components.category_picker.category.label")}</label>
-          <ul>{category}</ul>
+          <ul>{categoryList}</ul>
         </div>
         <SubcategoryPicker 
+          subcategory={subcategory}
           subcategories={subcategories} 
           onSelect={subcategory => this.selectSubcategory(subcategory)} />
       </div>
     );
   }
 
-  renderRow (category) {
-    const { proposal } = this.props;
+  renderRow (c) {
+    const { category } = this.props;
 
-    var selected = proposal.category && proposal.category.id === category.id;
-    var name = category.name;
+    var selected = category && category.id === c.id;
+    var name = c.name;
 
-    var classNames = ['category-' + category.id];
+    var classNames = ['category-' + c.id];
     if(selected){ classNames.push('selected'); }
-    var iconName = "icon category-icon-" + category.id;
+    var iconName = "icon category-icon-" + c.id;
 
     return (
       <li className={classNames.join(' ')}
-          key={category.id}
-          onClick={() => this.selectCategory(category)}>
+          key={c.id}
+          onClick={() => this.selectCategory(c)}>
         <span className="category">
           <span className={iconName}></span>
           <span className="name">{name}</span>
@@ -53,7 +52,7 @@ class CategoryPicker extends Component {
   }
 
   selectCategory(selectedCategory ){
-    const { categories, proposal } = this.props;
+    const { categories, onCategorySelected } = this.props;
 
     const subcategories = categories
       .filter(category => {
@@ -61,28 +60,22 @@ class CategoryPicker extends Component {
       })[0]
       .subcategories;
 
-    this.props.updateProposal(proposal.id, {
-      category_id: selectedCategory.id,
-      subcategory_id: subcategories[0].id
+    onCategorySelected({
+      categoryId: selectedCategory.id,
+      subcategoryId: subcategories[0].id
     });
   }
 
   selectSubcategory(subcategory){
-    const { proposal } = this.props;
+    const { onSubcategorySelected } = this.props;
 
 
-    this.props.updateProposal(proposal.id, {
-      subcategory_id: subcategory.id
-    });
+    onSubcategorySelected(subcategory.id);
   }
 }
 
-function mapStateToProps({ categories, proposal }) {
-  return { categories, proposal };
+function mapStateToProps({ categories }) {
+  return { categories };
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ updateProposal }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(CategoryPicker);
+export default connect(mapStateToProps)(CategoryPicker);

--- a/app/frontend/categories/new_subcategory_picker.component.js
+++ b/app/frontend/categories/new_subcategory_picker.component.js
@@ -2,21 +2,21 @@ import { Component }          from 'react';
 import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
-class SubcategoryPicker extends Component {
+export default class SubcategoryPicker extends Component {
   subcategories () {
-    const { subcategories, proposal } = this.props;
+    const { subcategories, subcategory } = this.props;
 
-    return subcategories.map(subcategory => {
-      var selected = proposal.subcategory && subcategory.id === proposal.subcategory.id;
+    return subcategories.map(sc => {
+      var selected = subcategory && sc.id === subcategory.id;
 
-      var classNames = ['subcategory-' + subcategory.id];
+      var classNames = ['subcategory-' + sc.id];
       if(selected){ classNames.push('selected'); }
 
       return (
         <li className={classNames.join(' ')}
-            key={subcategory.id}
-            onClick={() => this.select(subcategory)}>
-          <span className="name">{subcategory.name} <a href={`/categories#subcategory_${subcategory.id}`} target="_blank"> <i className="fa fa-info-circle"></i></a></span>
+            key={sc.id}
+            onClick={() => this.select(sc)}>
+          <span className="name">{sc.name} <a href={`/categories#subcategory_${sc.id}`} target="_blank"> <i className="fa fa-info-circle"></i></a></span>
         </li>
       );
     });
@@ -39,13 +39,3 @@ class SubcategoryPicker extends Component {
     }
   }
 }
-
-function mapStateToProps({ proposal }) {
-  return { proposal };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(SubcategoryPicker);

--- a/app/frontend/proposals/proposal_reviewer.component.js
+++ b/app/frontend/proposals/proposal_reviewer.component.js
@@ -1,14 +1,14 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { Component }                    from 'react';
+import { connect }                      from 'react-redux';
+import { bindActionCreators }           from 'redux';
 
-import ScopePicker            from './scope_picker.component';
-import CategoryPicker         from '../categories/new_category_picker.component';
-import ProposalAnswerBox      from './proposal_answer_box.component';
+import ScopePicker                      from '../scope/scope_picker.component';
+import CategoryPicker                   from '../categories/new_category_picker.component';
+import ProposalAnswerBox                from './proposal_answer_box.component';
 
-import { fetchDistricts }     from '../districts/districts.actions';
-import { fetchCategories }    from '../categories/categories.actions';
-import { updateAnswer }       from './proposals.actions';
+import { fetchDistricts }               from '../districts/districts.actions';
+import { fetchCategories }              from '../categories/categories.actions';
+import { updateAnswer, updateProposal } from './proposals.actions';
 
 class ProposalReviewer extends Component {
   componentDidMount() {
@@ -17,14 +17,18 @@ class ProposalReviewer extends Component {
   }
 
   render() {
-    const { session, proposal, updateAnswer } = this.props;
-    const { id, answer } = proposal;
+    const { session, proposal, updateAnswer, updateProposal } = this.props;
+    const { id, answer, scope_, district } = proposal;
 
     if (session.is_reviewer) {
       return (
         <div>
           <h2>{I18n.t('proposals.edit.editing')}</h2>
-          <ScopePicker />
+          <ScopePicker 
+            scope={scope_} 
+            onScopeSelected={scope => updateProposal(id, { scope })}
+            district={district}
+            onDistrictSelected={districtId => updateProposal(id, { district: districtId })} />
           <CategoryPicker />
           <ProposalAnswerBox 
             answer={answer}
@@ -46,7 +50,8 @@ function mapDispatchToProps(dispatch) {
   return bindActionCreators({ 
     fetchDistricts,
     fetchCategories, 
-    updateAnswer
+    updateAnswer,
+    updateProposal
   }, dispatch);
 }
 

--- a/app/frontend/proposals/proposal_reviewer.component.js
+++ b/app/frontend/proposals/proposal_reviewer.component.js
@@ -18,7 +18,7 @@ class ProposalReviewer extends Component {
 
   render() {
     const { session, proposal, updateAnswer, updateProposal } = this.props;
-    const { id, answer, scope_, district } = proposal;
+    const { id, answer, scope_, district, category, subcategory } = proposal;
 
     if (session.is_reviewer) {
       return (
@@ -29,7 +29,12 @@ class ProposalReviewer extends Component {
             onScopeSelected={scope => updateProposal(id, { scope })}
             district={district}
             onDistrictSelected={districtId => updateProposal(id, { district: districtId })} />
-          <CategoryPicker />
+          <CategoryPicker 
+            category={category}
+            subcategory={subcategory}
+            onCategorySelected={({categoryId, subcategoryId}) => updateProposal(id, { category_id: categoryId, subcategory_id: subcategoryId })}
+            onSubcategorySelected={subcategoryId => updateProposal(id, {subcategory_id: subcategoryId})}
+          />
           <ProposalAnswerBox 
             answer={answer}
             onButtonClick={(answerParams) => updateAnswer(proposal.id, answer, answerParams)} 

--- a/app/frontend/proposals/proposals_table.component.js
+++ b/app/frontend/proposals/proposals_table.component.js
@@ -1,5 +1,6 @@
 import { Component } from 'react';
 
+import DangerLink    from '../application/danger_link.component';
 import ProposalBadge from './proposal_badge.component';
 
 export default class ProposalsTable extends Component {
@@ -34,9 +35,9 @@ export default class ProposalsTable extends Component {
     if (this.props.onRemoveProposal) {
       return (
         <td>
-          <button onClick={(event) => this.props.onRemoveProposal(proposal) }>
+          <DangerLink onClick={(event) => this.props.onRemoveProposal(proposal) }>
             {I18n.t("components.proposals_table.remove")}
-          </button>
+          </DangerLink>
         </td>
       );
     }

--- a/app/frontend/scope/scope_picker.component.js
+++ b/app/frontend/scope/scope_picker.component.js
@@ -2,11 +2,9 @@ import { Component }          from 'react';
 import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
-import { updateProposal }     from './proposals.actions';
-
 class ScopePicker extends Component {
   render() {
-    const { proposal } = this.props;
+    const { scope } = this.props;
 
     return (
       <div>
@@ -19,7 +17,7 @@ class ScopePicker extends Component {
               type="radio" 
               value="district" 
               onChange={() => this.selectScope('district')}
-              checked={proposal.scope_ === 'district'}/>
+              checked={scope === 'district'}/>
             <label htmlFor="proposal_scope_district">{I18n.t('proposals.form.proposal_scope_district')}</label>
           </div>
           <div className="small-3 end column">
@@ -28,7 +26,7 @@ class ScopePicker extends Component {
               type="radio" 
               value="city" 
               onChange={() => this.selectScope('city')}
-              checked={proposal.scope_ === 'city'}/>
+              checked={scope === 'city'}/>
             <label htmlFor="proposal_scope_city">{I18n.t('proposals.form.proposal_scope_city')}</label>
           </div>
         </div>
@@ -39,12 +37,12 @@ class ScopePicker extends Component {
   }
 
   renderDistrictPicker() {
-    const { proposal, districts } = this.props;
+    const { scope, district, districts } = this.props;
 
-    if (proposal.scope_ === 'district') {
+    if (scope === 'district') {
       return (
         <div className="small-12 column">
-          <select onChange={(event) => this.selectDistrict(event.target.value)} value={proposal.district && String(proposal.district.id)}>
+          <select onChange={(event) => this.selectDistrict(event.target.value)} value={district && String(district.id)}>
             {
               districts.map((district) => 
                 <option key={district[1]} value={district[1]}>
@@ -60,28 +58,16 @@ class ScopePicker extends Component {
   }
 
   selectScope(scope) {
-    const { proposal } = this.props;
-
-    this.props.updateProposal(proposal.id, {
-      scope
-    });
+    this.props.onScopeSelected(scope);
   }
 
-  selectDistrict(district) {
-    const { proposal } = this.props;
-
-    this.props.updateProposal(proposal.id, {
-      district
-    });
+  selectDistrict(districtId) {
+    this.props.onDistrictSelected(districtId);
   }
 }
 
-function mapStateToProps({ proposal, districts }) {
-  return { proposal, districts };
+function mapStateToProps({ districts }) {
+  return { districts };
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ updateProposal }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ScopePicker);
+export default connect(mapStateToProps)(ScopePicker);

--- a/app/views/action_plans/edit.html.erb
+++ b/app/views/action_plans/edit.html.erb
@@ -1,5 +1,0 @@
-<div class="meeting-new row">
-  <div class="small-12 medium-9 column">
-    <%= render "form", form_url: action_plan_url %>
-  </div>
-</div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -40,6 +40,7 @@ ca:
       form:
         submit_button: Crear actuació
     edit:
+      editing: Edita actuació
       form:
         submit_button: Desar actuació
     form:

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -12,7 +12,6 @@ ca:
       approved: Aprovada
       delete: Eliminar
       deleted: Aquesta actuació ha estat eliminada
-      edit: Editar
       new_revision: Nova revisió
     action_plans:
       count: Mostrant %{count} actuacions

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -12,7 +12,6 @@ en:
       approved: adopted
       delete: remove
       deleted: This action has been removed
-      edit: Edit
       new_revision: New revision
     action_plans:
       count: Showing %{count} action plans

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -12,7 +12,6 @@ es:
       approved: Aprobada
       delete: Eliminar
       deleted: Esta actuación ha sido eliminada
-      edit: Editar
       new_revision: Nueva revisión
     action_plans:
       count: Mostrando %{count} actuaciones

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
       form:
         submit_button: Create action plan
     edit:
+      editing: Edit action plan
       form:
         submit_button: Update action plan
     form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -40,6 +40,7 @@ es:
       form:
         submit_button: Crear actuación
     edit:
+      editing: Editar actuación
       form:
         submit_button: Guardar actuación
     form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,9 +290,7 @@ Rails.application.routes.draw do
       end
     end
     resources :action_plans do
-      member do
-        get :proposals
-      end
+      resources :proposals, only: [:index, :create, :destroy], controller: 'action_plans/proposals'
     end
     resources :meetings, only: [:index]
     resources :follows, only: [:index, :create, :destroy]


### PR DESCRIPTION
# What and why

In order to make the update process a bit easier for reviewers I added the same feature as proposals in a small componen called `ActionPlanReviewer`. With this component a reviewer can update the proposals, scope, and category from an action plan.
# QA

Visit an action plan show page and try to edit some fields.
# GIF Tax

![](https://media.giphy.com/media/3pIpGbzQMNPB6/giphy.gif)
