### PR TITLE
Add action plans feature tests

### DIFF
--- a/app/frontend/action_plans/action_plan_app.component.js
+++ b/app/frontend/action_plans/action_plan_app.component.js
@@ -16,11 +16,11 @@ import ActionPlanShow      from './action_plan_show.component';
 
 const middlewares = [ReduxPromise];
 
-if (process.env.NODE_ENV === 'development') {
-  const createLogger = require('redux-logger');
-  const logger = createLogger();
-  middlewares.push(logger);
-}
+//if (process.env.NODE_ENV === 'development') {
+//  const createLogger = require('redux-logger');
+//  const logger = createLogger();
+//  middlewares.push(logger);
+//}
 const createStoreWithMiddleware = applyMiddleware(...middlewares)(createStore);
 
 function createReducers(sessionState) {

--- a/app/frontend/action_plans/action_plan_reviewer.component.js
+++ b/app/frontend/action_plans/action_plan_reviewer.component.js
@@ -26,6 +26,7 @@ class ActionPlanReviewer extends Component {
           <ActionPlanProposals actionPlan={actionPlan} />
           <h2>{I18n.t('action_plans.edit.editing')}</h2>
           <ScopePicker 
+            namespace="action_plan"
             scope={scope_} 
             onScopeSelected={scope => updateActionPlan(id, { scope })}
             district={district}

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -73,7 +73,7 @@ class ActionPlanShow extends Component {
                 {I18n.t('proposals.show.back_link')}
               </a>
 
-              <DangerLink className="delete-proposal button danger tiny radius right" onClick={ () => this.props.deleteActionPlan(this.props.actionPlan.id) }>
+              <DangerLink className="delete-action-plan button danger tiny radius right" onClick={ () => this.props.deleteActionPlan(this.props.actionPlan.id) }>
                 <i className="icon-cross"></i>
                 { I18n.t("components.action_plan_show.delete") }
               </DangerLink>

--- a/app/frontend/action_plans/action_plans_app.component.js
+++ b/app/frontend/action_plans/action_plans_app.component.js
@@ -9,11 +9,11 @@ import ReduxPromise      from 'redux-promise';
 
 const middlewares = [ReduxPromise];
 
-if (process.env.NODE_ENV === 'development') {
-  const createLogger = require('redux-logger');
-  const logger = createLogger();
-  middlewares.push(logger);
-}
+//if (process.env.NODE_ENV === 'development') {
+//  const createLogger = require('redux-logger');
+//  const logger = createLogger();
+//  middlewares.push(logger);
+//}
 
 import ActionPlans       from '../action_plans/action_plans.component';
 

--- a/app/frontend/proposals/proposal_app.component.js
+++ b/app/frontend/proposals/proposal_app.component.js
@@ -16,11 +16,11 @@ import ProposalShow      from './proposal_show.component';
 
 const middlewares = [ReduxPromise];
 
-if (process.env.NODE_ENV === 'development') {
-  const createLogger = require('redux-logger');
-  const logger = createLogger();
-  middlewares.push(logger);
-}
+//if (process.env.NODE_ENV === 'development') {
+//  const createLogger = require('redux-logger');
+//  const logger = createLogger();
+//  middlewares.push(logger);
+//}
 const createStoreWithMiddleware = applyMiddleware(...middlewares)(createStore);
 
 function createReducers(sessionState) {

--- a/app/frontend/proposals/proposals_app.component.js
+++ b/app/frontend/proposals/proposals_app.component.js
@@ -9,11 +9,11 @@ import ReduxPromise      from 'redux-promise';
 
 const middlewares = [ReduxPromise];
 
-if (process.env.NODE_ENV === 'development') {
-  const createLogger = require('redux-logger');
-  const logger = createLogger();
-  middlewares.push(logger);
-}
+//if (process.env.NODE_ENV === 'development') {
+//  const createLogger = require('redux-logger');
+//  const logger = createLogger();
+//  middlewares.push(logger);
+//}
 
 import Proposals         from './proposals.component';
 

--- a/app/frontend/scope/scope_picker.component.js
+++ b/app/frontend/scope/scope_picker.component.js
@@ -4,6 +4,7 @@ import { connect }            from 'react-redux';
 
 class ScopePicker extends Component {
   render() {
+    const namespace = this.props.namespace || 'proposal';
     const { scope } = this.props;
 
     return (
@@ -13,21 +14,21 @@ class ScopePicker extends Component {
           <p className="note">{I18n.t('proposals.form.proposal_scope_note')}</p>
           <div className="small-3 column">
             <input 
-              id="proposal_scope_district"
+              id={`${namespace}_scope_district`}
               type="radio" 
               value="district" 
               onChange={() => this.selectScope('district')}
               checked={scope === 'district'}/>
-            <label htmlFor="proposal_scope_district">{I18n.t('proposals.form.proposal_scope_district')}</label>
+            <label htmlFor={`${namespace}_scope_district`}>{I18n.t('proposals.form.proposal_scope_district')}</label>
           </div>
           <div className="small-3 end column">
             <input 
-              id="proposal_scope_city"
+              id={`${namespace}_scope_city`}
               type="radio" 
               value="city" 
               onChange={() => this.selectScope('city')}
               checked={scope === 'city'}/>
-            <label htmlFor="proposal_scope_city">{I18n.t('proposals.form.proposal_scope_city')}</label>
+            <label htmlFor={`${namespace}_scope_city`}>{I18n.t('proposals.form.proposal_scope_city')}</label>
           </div>
         </div>
 
@@ -37,12 +38,16 @@ class ScopePicker extends Component {
   }
 
   renderDistrictPicker() {
+    const namespace = this.props.namespace || 'proposal';
     const { scope, district, districts } = this.props;
 
     if (scope === 'district') {
       return (
         <div className="small-12 column">
-          <select onChange={(event) => this.selectDistrict(event.target.value)} value={district && String(district.id)}>
+          <select 
+            id={`${namespace}_district`}
+            onChange={(event) => this.selectDistrict(event.target.value)} 
+            value={district && String(district.id)}>
             {
               districts.map((district) => 
                 <option key={district[1]} value={district[1]}>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -411,5 +411,14 @@ FactoryGirl.define do
   factory :action_plan do
     category
     subcategory
+
+    after :build do |action_plan|
+      action_plan.revisions << create(:action_plan_revision)
+    end
+  end
+
+  factory :action_plan_revision do
+    sequence(:title)       { |n| "Revision #{n} title" }
+    sequence(:description) { |n| "Revision #{n} description" }
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -46,6 +46,10 @@ FactoryGirl.define do
       roles ["moderator"]
     end
 
+    trait :reviewer do
+      roles ["reviewer"]
+    end
+
     trait :official do
       official_level 2
     end

--- a/spec/features/action_plans_spec.rb
+++ b/spec/features/action_plans_spec.rb
@@ -100,4 +100,15 @@ feature 'Action plans', :js do
     expect(page).to have_content('A good action plan')
     expect(page).not_to have_content('A bad action plan')
   end
+
+  scenario 'Delete an action plan' do
+    action_plan = create(:action_plan)
+
+    visit action_plans_path
+    click_link action_plan.title
+    page.find('a', text: 'remove').click
+    visit action_plans_path
+
+    expect(page).not_to have_content(action_plan.title)
+  end
 end

--- a/spec/features/action_plans_spec.rb
+++ b/spec/features/action_plans_spec.rb
@@ -76,4 +76,15 @@ feature 'Action plans', :js do
     expect(page).to have_content("My title revision")
     expect(page).to have_content("My description revision")
   end
+
+  scenario 'Filter action plans by category' do
+    target_action_plan = create(:action_plan, category: category)
+    another_action_plan = create(:action_plan)
+
+    visit action_plans_path
+    choose "filter_category_id_#{category.id}"
+
+    expect(page).to have_content(target_action_plan.title)
+    expect(page).not_to have_content(another_action_plan.title)
+  end
 end

--- a/spec/features/action_plans_spec.rb
+++ b/spec/features/action_plans_spec.rb
@@ -12,8 +12,8 @@ feature 'Action plans', :js do
 
   scenario 'Create an action plan from scratch' do
     proposal = create(:proposal, title: "A good looking proposal")
-    visit action_plans_path
 
+    visit action_plans_path
     click_link "New action plan" 
     fill_in "action_plan_title", with: "My action plan title"
     fill_in_editor "action_plan_description", with: "My action plan description"
@@ -28,5 +28,38 @@ feature 'Action plans', :js do
     expect(page).to have_content("My action plan title")
     expect(page).to have_content("My action plan description")
     expect(page).to have_content("A good looking proposal")
+    expect(page).to have_content("Ciutat Vella")
+    expect(page).to have_content(category.name["en"])
+    expect(page).to have_content(subcategory.name["en"])
+  end
+
+  scenario 'Create an action plan from an existing proposal' do
+    comment = create(:comment)
+    proposal = create(:proposal, title: "A good looking proposal")
+    related = create(:proposal, title: "A related proposal")
+    Reference.create(source: comment, referrer: proposal, referenced: related)
+
+    visit proposals_path
+    click_link "A good looking proposal"
+    click_link "Create action plan"
+    click_button "Create action plan"
+
+    expect(page).to have_content("A good looking proposal")
+    expect(page).to have_content("A related proposal")
+    expect(page).to have_content(proposal.district)
+    expect(page).to have_content(proposal.category.name["ca"])
+    expect(page).to have_content(proposal.subcategory.name["en"])
+  end
+
+  scenario 'Edit an existing action plan' do
+    action_plan = create(:action_plan, scope: 'city')
+
+    visit action_plans_path
+    click_link action_plan.title
+    choose 'action_plan_scope_district'
+    select 'Ciutat Vella', from: 'action_plan_district'
+    visit action_plans_path
+
+    expect(page).to have_content("Ciutat Vella")
   end
 end

--- a/spec/features/action_plans_spec.rb
+++ b/spec/features/action_plans_spec.rb
@@ -111,4 +111,18 @@ feature 'Action plans', :js do
 
     expect(page).not_to have_content(action_plan.title)
   end
+
+  scenario 'Approve an action plan' do 
+    approved_action_plan = create(:action_plan)
+    non_approved_action_plan = create(:action_plan)
+
+    visit action_plans_path
+    click_link approved_action_plan.title
+    page.find('a', text: 'approve').click
+    visit action_plans_path
+    choose 'filter_action_plan_approval_approved'
+
+    expect(page).to have_content(approved_action_plan.title)
+    expect(page).not_to have_content(non_approved_action_plan.title)
+  end
 end

--- a/spec/features/action_plans_spec.rb
+++ b/spec/features/action_plans_spec.rb
@@ -62,4 +62,18 @@ feature 'Action plans', :js do
 
     expect(page).to have_content("Ciutat Vella")
   end
+
+  scenario 'Create a new revision for an action plan' do
+    action_plan = create(:action_plan)
+
+    visit action_plans_path
+    click_link action_plan.title
+    click_link "New revision"
+    fill_in "action_plan_revision_title", with: "My title revision"
+    fill_in_editor "action_plan_revision_description", with: "My description revision"
+    click_button "Create revision"
+
+    expect(page).to have_content("My title revision")
+    expect(page).to have_content("My description revision")
+  end
 end

--- a/spec/features/action_plans_spec.rb
+++ b/spec/features/action_plans_spec.rb
@@ -1,0 +1,32 @@
+# coding: utf-8
+require 'rails_helper'
+
+feature 'Action plans', :js do
+  let!(:subcategory) { create(:subcategory) }
+  let(:category) { subcategory.category }
+  let(:reviewer) { create(:user, :reviewer) }
+
+  before :each do
+    login_as(reviewer)
+  end
+
+  scenario 'Create an action plan from scratch' do
+    proposal = create(:proposal, title: "A good looking proposal")
+    visit action_plans_path
+
+    click_link "New action plan" 
+    fill_in "action_plan_title", with: "My action plan title"
+    fill_in_editor "action_plan_description", with: "My action plan description"
+    choose 'action_plan_scope_district'
+    select 'Ciutat Vella', from: 'action_plan_district'
+    find('li', text: category.name["en"]).click
+    find('li', text: subcategory.name["en"]).click
+    page.find("#autocomplete-1").send_keys("good looking")
+    page.find("#autocomplete_result_#{proposal.id}").click
+    click_button "Create action plan"
+
+    expect(page).to have_content("My action plan title")
+    expect(page).to have_content("My action plan description")
+    expect(page).to have_content("A good looking proposal")
+  end
+end

--- a/spec/features/action_plans_spec.rb
+++ b/spec/features/action_plans_spec.rb
@@ -87,4 +87,17 @@ feature 'Action plans', :js do
     expect(page).to have_content(target_action_plan.title)
     expect(page).not_to have_content(another_action_plan.title)
   end
+
+  scenario 'Filter action plans by search' do
+    action_plan = create(:action_plan)
+    action_plan.revisions << create(:action_plan_revision, title: 'A good action plan')
+    action_plan = create(:action_plan)
+    action_plan.revisions << create(:action_plan_revision, title: 'A bad action plan')
+
+    visit action_plans_path
+    find('.search-filter').send_keys("good")
+
+    expect(page).to have_content('A good action plan')
+    expect(page).not_to have_content('A bad action plan')
+  end
 end


### PR DESCRIPTION
# What and why

I add a few feature tests for action plans:
- Create an action plans both from scratch or based on an existing proposal
- Edit an action plan modifying its category
- Createing a new revision from an existing action plan
- Delete an existing action plan
- Approve an existing action plan
- Different filter tests
# QA

Run the test suite for action plans features.
# GIF Tax

![](https://media.giphy.com/media/QwFnDQKQeW0ZG/giphy.gif)
