### PR TITLE
Action plan show public page

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -24,3 +24,4 @@
 @import "components/new_comment_form";
 @import "components/weight_control";
 @import "components/action_plan_statistics";
+@import "components/action_plan_proposals";

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -23,3 +23,4 @@
 @import "components/comments";
 @import "components/new_comment_form";
 @import "components/weight_control";
+@import "components/action_plan_statistics";

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -25,3 +25,4 @@
 @import "components/weight_control";
 @import "components/action_plan_statistics";
 @import "components/action_plan_proposals";
+@import "components/action_plan_meetings";

--- a/app/assets/stylesheets/components/_action_plan_meetings.scss
+++ b/app/assets/stylesheets/components/_action_plan_meetings.scss
@@ -1,0 +1,10 @@
+.action-plan-meetings-component {
+  position: relative;
+  min-height: rem-calc(150);
+
+  .meetings-directory {
+    .meetings-list {
+      width: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_action_plan_proposals.scss
+++ b/app/assets/stylesheets/components/_action_plan_proposals.scss
@@ -1,0 +1,4 @@
+.action-plan-proposals-component {
+  position: relative;
+  min-height: rem-calc(150);
+}

--- a/app/assets/stylesheets/components/_action_plan_statistics.scss
+++ b/app/assets/stylesheets/components/_action_plan_statistics.scss
@@ -1,0 +1,22 @@
+.actionplan-statistics {
+  text-align: center;
+  background: #fff;
+
+  ul {
+    list-style: none;
+    text-align: left;
+
+    li {
+      display: block;
+
+      span.number {
+        width: 50px;
+        display: inline-block;
+        text-align: center;
+        font-size: 1.4em;
+        margin-right: 0.1em;
+        color: #999;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_action_plan_statistics.scss
+++ b/app/assets/stylesheets/components/_action_plan_statistics.scss
@@ -1,21 +1,41 @@
 .actionplan-statistics {
+  position: relative;
+  background: transparent !important;
+
+  .action-plan-statistics-inner{
+    background-color: white;
+    height: rem(300);
+    border: rem-calc(10) solid $highlight;
+    padding: rem-calc(10);
+  }
+
   text-align: center;
   background: #fff;
+
+  hr{
+    margin-left: auto;
+    margin-right: auto;
+    max-width: rem-calc(200);
+    border-color: $text-light;
+    border-style: dotted;
+  }
 
   ul {
     list-style: none;
     text-align: left;
+    margin: 0;
+    padding: 0;
 
     li {
       display: block;
 
       span.number {
-        width: 50px;
+        width: rem-calc(40);
         display: inline-block;
         text-align: center;
-        font-size: 1.4em;
         margin-right: 0.1em;
-        color: #999;
+        color: $text;
+        font-weight: bold;
       }
     }
   }

--- a/app/controllers/api/action_plans/meetings_controller.rb
+++ b/app/controllers/api/action_plans/meetings_controller.rb
@@ -1,0 +1,8 @@
+class Api::ActionPlans::MeetingsController < Api::ApplicationController
+  load_and_authorize_resource :action_plan
+
+  def index
+    @meetings = @action_plan.proposals.collect(&:meetings).flatten
+    render json: @meetings
+  end
+end

--- a/app/controllers/api/action_plans/proposals_controller.rb
+++ b/app/controllers/api/action_plans/proposals_controller.rb
@@ -11,6 +11,7 @@ class Api::ActionPlans::ProposalsController < Api::ApplicationController
     @proposal = Proposal.find(params[:proposal_id])
     @action_plan.proposals << @proposal
     @action_plan.save
+    ActionPlanStatisticsWorker.perform_async(@action_plan.id)
     render json: @action_plan.action_plans_proposals, root: 'action_plans_proposals'
   end
 
@@ -27,6 +28,7 @@ class Api::ActionPlans::ProposalsController < Api::ApplicationController
   def destroy
     @proposal = @action_plan.proposals.find(params[:id])
     @action_plan.proposals.delete(@proposal)
+    ActionPlanStatisticsWorker.perform_async(@action_plan.id)
     render json: @action_plan.action_plans_proposals, root: 'action_plans_proposals'
   end
 end

--- a/app/controllers/api/action_plans_controller.rb
+++ b/app/controllers/api/action_plans_controller.rb
@@ -6,10 +6,12 @@ class Api::ActionPlansController < Api::ApplicationController
   before_action :authenticate_user!
   load_and_authorize_resource
 
+  has_orders %w{weight random}, only: :index
+
   def index
     set_seed
 
-    action_plans = ActionPlan.sort_by_weight
+    action_plans = ActionPlan.all
 
     @action_plans = ResourceFilter.new(params, user: current_user)
       .filter_collection(action_plans.includes(:category, :subcategory))
@@ -17,7 +19,7 @@ class Api::ActionPlansController < Api::ApplicationController
     respond_to do |format|
       format.json { 
         action_plans = @action_plans
-          .send("sort_by_created_at")
+          .send("sort_by_#{@current_order}")
           .page(params[:page])
           .per(15)
 

--- a/app/controllers/api/action_plans_controller.rb
+++ b/app/controllers/api/action_plans_controller.rb
@@ -6,7 +6,7 @@ class Api::ActionPlansController < Api::ApplicationController
   before_action :authenticate_user!
   load_and_authorize_resource
 
-  has_orders %w{weight random}, only: :index
+  has_orders %w{weight random confidence_score participants}, only: :index
 
   def index
     set_seed

--- a/app/frontend/action_plans/action_plan.component.js
+++ b/app/frontend/action_plans/action_plan.component.js
@@ -44,9 +44,11 @@ export default ({
         </div>
       </div>
       <aside id={`action_plan_${id}_statistics`} className="actionplan-statistics small-12 medium-4 column">
-        <ActionPlanStatistics statistics={statistics}></ActionPlanStatistics>
-        <hr></hr>
-        <SocialShareButtons title={title} url={url} />
+        <div className="action-plan-statistics-inner">
+          <ActionPlanStatistics statistics={statistics}></ActionPlanStatistics>
+          <hr></hr>
+          <SocialShareButtons title={title} url={url} />
+        </div>
       </aside>
     </div>
   </div>

--- a/app/frontend/action_plans/action_plan.component.js
+++ b/app/frontend/action_plans/action_plan.component.js
@@ -44,7 +44,7 @@ export default ({
         </div>
       </div>
       <aside id={`action_plan_${id}_statistics`} className="small-12 medium-3 column">
-        <ActionPlanStatistics actionPlan={statistics}></ActionPlanStatistics>
+        <ActionPlanStatistics statistics={statistics}></ActionPlanStatistics>
         <hr></hr>
         <SocialShareButtons title={title} url={url} />
       </aside>

--- a/app/frontend/action_plans/action_plan.component.js
+++ b/app/frontend/action_plans/action_plan.component.js
@@ -20,7 +20,7 @@ export default ({
 }) => (
   <div id={`action_plan_${id}`} className="proposal clear">
     <div className="row">
-      <div className="small-12 medium-9 column">
+      <div className="small-12 medium-8 column">
         <div className="proposal-content">
           <span className="label-proposal">{ I18n.t('components.action_plan.label') }</span>
 
@@ -43,7 +43,7 @@ export default ({
           </div>
         </div>
       </div>
-      <aside id={`action_plan_${id}_statistics`} className="small-12 medium-3 column">
+      <aside id={`action_plan_${id}_statistics`} className="actionplan-statistics small-12 medium-4 column">
         <ActionPlanStatistics statistics={statistics}></ActionPlanStatistics>
         <hr></hr>
         <SocialShareButtons title={title} url={url} />

--- a/app/frontend/action_plans/action_plan.component.js
+++ b/app/frontend/action_plans/action_plan.component.js
@@ -1,5 +1,8 @@
-import truncate   from 'html-truncate';
-import FilterMeta from '../filters/filter_meta.component';
+import ellipsis             from 'html-ellipsis';
+
+import ActionPlanStatistics from './action_plan_statistics.component';
+import SocialShareButtons   from '../application/social_share_buttons.component';
+import FilterMeta           from '../filters/filter_meta.component';
 
 const DESCRIPTION_MAX_CHARACTERS = 300;
 
@@ -12,11 +15,12 @@ export default ({
   category,
   subcategory,
   scope_,
-  district
+  district,
+  statistics
 }) => (
   <div id={`action_plan_${id}`} className="proposal clear">
     <div className="row">
-      <div className="small-12 medium-12 column">
+      <div className="small-12 medium-9 column">
         <div className="proposal-content">
           <span className="label-proposal">{ I18n.t('components.action_plan.label') }</span>
 
@@ -28,7 +32,7 @@ export default ({
 
           <div 
             className="proposal-description"
-            dangerouslySetInnerHTML={{ __html: truncate(description.autoLink(), DESCRIPTION_MAX_CHARACTERS) }} />
+            dangerouslySetInnerHTML={{ __html: ellipsis(description.autoLink(), DESCRIPTION_MAX_CHARACTERS) }} />
 
           <div className="bottom-bar">
             <FilterMeta 
@@ -39,6 +43,11 @@ export default ({
           </div>
         </div>
       </div>
+      <aside id={`action_plan_${id}_statistics`} className="small-12 medium-3 column">
+        <ActionPlanStatistics actionPlan={statistics}></ActionPlanStatistics>
+        <hr></hr>
+        <SocialShareButtons title={title} url={url} />
+      </aside>
     </div>
   </div>
 );

--- a/app/frontend/action_plans/action_plan_meetings.component.js
+++ b/app/frontend/action_plans/action_plan_meetings.component.js
@@ -1,0 +1,75 @@
+import { Component }            from 'react';
+import { bindActionCreators }   from 'redux';
+import { connect }              from 'react-redux';
+
+import Loading                  from '../application/loading.component';
+
+import Meeting                  from '../meetings/meeting.component';
+
+import { fetchRelatedMeetings } from './action_plans.actions';
+
+class ActionPlanMeetings extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: true
+    }
+  }
+
+  componentDidMount() {
+    const { actionPlan, fetchRelatedMeetings } = this.props;
+
+    fetchRelatedMeetings(actionPlan.id).then(() => {
+      this.setState({ loading: false });
+    });
+  }
+
+  render() {
+    return (
+      <div className="row action-plan-meetings-component">
+        <div className="small-12 medium-12 column">
+          <h2>{ I18n.t("proposals.show.meetings_title") }</h2>
+          <Loading show={this.state.loading} />
+          {this.renderMeetings()}
+        </div>
+      </div>
+    );
+  }
+
+  renderMeetings() {
+    const { actionPlan, useServerLinks } = this.props;
+    const meetings = actionPlan.meetings || [];
+
+    if (meetings.length > 0) {
+      return (
+        <div>
+          <div className="meetings-directory">
+            <div className="meetings-list">
+              <ul className="meetings-list-items">
+                { 
+                  meetings.map((meeting) => 
+                    <li key={ meeting.id }>
+                      <Meeting meeting={ meeting } useServerLinks={ useServerLinks } />
+                    </li>
+                  )
+                }
+              </ul>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  }
+}
+
+function mapStateToProps({ actionPlan }) {
+  return { actionPlan };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ fetchRelatedMeetings }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ActionPlanMeetings);

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -33,24 +33,37 @@ class ActionPlanProposals extends Component {
   }
 
   render() {
-    const { actionPlan, addActionPlanProposal, removeActionPlanProposal } = this.props;
+    const { editable, actionPlan, addActionPlanProposal, removeActionPlanProposal } = this.props;
     const { id } = actionPlan;
     const actionPlansProposals = actionPlan.actionPlansProposals || [];
 
     return (
       <div className="action-plan-proposals-component">
         <h2>{I18n.t("components.action_plan_proposals.title")}</h2>
-        <ProposalsAutocompleteInput 
-          proposalsApiUrl="/api/proposals"
-          excludeIds={actionPlansProposals.map(a => a.proposal.id)}
-          onAddProposal={proposal => addActionPlanProposal(id, proposal)} />
+        {this.renderSearchProposalsInput(id, actionPlansProposals)}
         <Loading show={this.state.loading} />
         <ProposalsTable 
           actionPlansProposals={ actionPlansProposals }
           onChangeLevel={ (proposal, level) => changeActionPlansProposalLevel(actionPlan, proposal, level) }
-          onRemoveProposal={proposal => removeActionPlanProposal(id, proposal)} />
+          onRemoveProposal={proposal => removeActionPlanProposal(id, proposal)} 
+          editable={editable} />
       </div>
     );
+  }
+
+  renderSearchProposalsInput(id, actionPlansProposals) {
+    const {editable} = this.props;
+
+    if (editable) {
+      return (
+        <ProposalsAutocompleteInput 
+          proposalsApiUrl="/api/proposals"
+          excludeIds={actionPlansProposals.map(a => a.proposal.id)}
+          onAddProposal={proposal => addActionPlanProposal(id, proposal)} />
+      );
+    }
+
+    return null;
   }
 }
 

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -27,7 +27,7 @@ class ActionPlanProposals extends Component {
 
     return (
       <div>
-        <h4>{I18n.t("components.action_plan_proposals.title")}</h4>
+        <h2>{I18n.t("components.action_plan_proposals.title")}</h2>
         <ProposalsAutocompleteInput 
           proposalsApiUrl="/api/proposals"
           excludeIds={actionPlansProposals.map(a => a.proposal.id)}

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -2,6 +2,8 @@ import { Component }              from 'react';
 import { bindActionCreators }     from 'redux';
 import { connect }                from 'react-redux';
 
+import Loading                    from '../application/loading.component';
+
 import ProposalsAutocompleteInput from '../proposals/proposals_autocomplete_input.component';
 import ProposalsTable             from './proposals_table.component';
 
@@ -14,10 +16,20 @@ import {
 
 
 class ActionPlanProposals extends Component {
-  componentDidMount() {
-    const { actionPlan } = this.props;
+  constructor(props) {
+    super(props);
 
-    this.props.fetchActionPlanProposals(actionPlan.id);
+    this.state = {
+      loading: true
+    }
+  }
+
+  componentDidMount() {
+    const { actionPlan, fetchActionPlanProposals } = this.props;
+
+    fetchActionPlanProposals(actionPlan.id).then(() => {
+      this.setState({ loading: false });
+    });
   }
 
   render() {
@@ -26,12 +38,13 @@ class ActionPlanProposals extends Component {
     const actionPlansProposals = actionPlan.actionPlansProposals || [];
 
     return (
-      <div>
+      <div className="action-plan-proposals-component">
         <h2>{I18n.t("components.action_plan_proposals.title")}</h2>
         <ProposalsAutocompleteInput 
           proposalsApiUrl="/api/proposals"
           excludeIds={actionPlansProposals.map(a => a.proposal.id)}
           onAddProposal={proposal => addActionPlanProposal(id, proposal)} />
+        <Loading show={this.state.loading} />
         <ProposalsTable 
           actionPlansProposals={ actionPlansProposals }
           onChangeLevel={ (proposal, level) => changeActionPlansProposalLevel(actionPlan, proposal, level) }

--- a/app/frontend/action_plans/action_plan_reviewer.component.js
+++ b/app/frontend/action_plans/action_plan_reviewer.component.js
@@ -16,10 +16,10 @@ class ActionPlanReviewer extends Component {
   }
 
   render() {
-    const { session, actionPlan, updateActionPlan } = this.props;
+    const { visible, actionPlan, updateActionPlan } = this.props;
     const { id, scope_, district, category, subcategory } = actionPlan;
 
-    if (session.is_reviewer) {
+    if (visible) {
       return (
         <div>
           <h2>{I18n.t('action_plans.edit.editing')}</h2>
@@ -43,8 +43,8 @@ class ActionPlanReviewer extends Component {
   }
 }
 
-function mapStateToProps({ session, actionPlan }) {
-  return { session, actionPlan };
+function mapStateToProps({ actionPlan }) {
+  return { actionPlan };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/app/frontend/action_plans/action_plan_reviewer.component.js
+++ b/app/frontend/action_plans/action_plan_reviewer.component.js
@@ -4,7 +4,6 @@ import { bindActionCreators } from 'redux';
 
 import ScopePicker            from '../scope/scope_picker.component';
 import CategoryPicker         from '../categories/new_category_picker.component';
-import ActionPlanProposals    from './action_plan_proposals.component';
 
 import { fetchDistricts }     from '../districts/districts.actions';
 import { fetchCategories }    from '../categories/categories.actions';
@@ -23,7 +22,6 @@ class ActionPlanReviewer extends Component {
     if (session.is_reviewer) {
       return (
         <div>
-          <ActionPlanProposals actionPlan={actionPlan} />
           <h2>{I18n.t('action_plans.edit.editing')}</h2>
           <ScopePicker 
             namespace="action_plan"

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -9,13 +9,15 @@ import {
   changeWeight
 } from './action_plans.actions';
 
-import Loading            from '../application/loading.component';
-import DangerLink         from '../application/danger_link.component';
-import FilterMeta         from '../filters/filter_meta.component';
+import Loading              from '../application/loading.component';
+import SocialShareButtons   from '../application/social_share_buttons.component';
+import DangerLink           from '../application/danger_link.component';
+import FilterMeta           from '../filters/filter_meta.component';
 
-import ActionPlanReviewer from './action_plan_reviewer.component';
-import WeightControl from './weight_control.component';
-
+import ActionPlanStatistics from './action_plan_statistics.component';
+import ActionPlanProposals  from './action_plan_proposals.component';
+import ActionPlanReviewer   from './action_plan_reviewer.component';
+import WeightControl        from './weight_control.component';
 
 class ActionPlanShow extends Component {
   constructor(props) {
@@ -63,13 +65,14 @@ class ActionPlanShow extends Component {
         category,
         subcategory,
         district,
-        weight
+        weight,
+        statistics
       } = actionPlan;
 
       return (
         <div>
           <div className="row" id={`action_plan_${actionPlan.id}`}>
-            <div className="small-12 medium-12 column">
+            <div className="small-12 medium-9 column">
               <i className="icon-angle-left left"></i>&nbsp;
 
               <a className="left back" href="/action_plans" onClick={() => window.history.back()}>
@@ -96,13 +99,9 @@ class ActionPlanShow extends Component {
 
               { this.renderNotice() }
 
-              <h2>
-                <a href={url}>{title}</a>
-              </h2>
+              <h2><a href={url}>{title}</a></h2>
 
-              <p className="proposal-info">
-                <span>{ created_at }</span>
-              </p>
+              <p className="proposal-info"><span>{ created_at }</span></p>
 
               <div 
                 className="proposal-description"
@@ -116,7 +115,38 @@ class ActionPlanShow extends Component {
                 namespace="action_plans"
                 useServerLinks={ true }/>
 
+              <h2>Estat de l'actuacio</h2>
+              <p>TODO</p>
+
+              <h2>Alegacions relacionades</h2>
+              <p>TODO</p>
+
+              <ActionPlanProposals actionPlan={actionPlan} />
+
               <ActionPlanReviewer />
+            </div>
+
+            <aside className="small-12 medium-3 column">
+              <h3>{ I18n.t("proposals.show.share") }</h3>
+              <SocialShareButtons 
+                title={ title }
+                url={ url }/>
+              <div>
+                <h3>Autoria</h3>
+                <p>Ajuntament de Barcelona, Ecologistes en Accio, Joan BCN, Josefina92</p>
+                <hr />
+                <h3>Dades</h3>
+                <ActionPlanStatistics 
+                  statistics={statistics}>
+                </ActionPlanStatistics>
+                <hr />
+                <h3>Seguiment</h3>
+              </div>
+            </aside>
+
+            <div className="small-12 medium-12 column">
+              <h2>Actuacio construida a partir de les seguents cites presencials</h2>
+              <p>TODO</p>
             </div>
           </div>
         </div>

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -25,20 +25,19 @@ class ActionPlanShow extends Component {
     super(props);
 
     this.state = {
-      loading: true
+      loading: true,
+      editable: false
     }
   }
 
   componentDidMount() {
-    const { session } = this.props;
+    const { session, fetchActionPlan } = this.props;
 
-    this.props.fetchActionPlan(this.props.actionPlanId);
-  }
+    this.setState({ editable: session.is_reviewer });
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.actionPlan.id) {
+    fetchActionPlan(this.props.actionPlanId).then(() => {
       this.setState({ loading: false });
-    }
+    });
   }
 
   render() {
@@ -58,7 +57,6 @@ class ActionPlanShow extends Component {
         id,
         url,
         deleted,
-        new_revision_url,
         title, 
         description,
         created_at,
@@ -66,7 +64,6 @@ class ActionPlanShow extends Component {
         category,
         subcategory,
         district,
-        weight,
         statistics
       } = actionPlan;
 
@@ -80,25 +77,8 @@ class ActionPlanShow extends Component {
                 {I18n.t('proposals.show.back_link')}
               </a>
 
-              <DangerLink className="delete-action-plan button danger tiny radius right" onClick={ () => this.props.deleteActionPlan(this.props.actionPlan.id) }>
-                <i className="icon-cross"></i>
-                { I18n.t("components.action_plan_show.delete") }
-              </DangerLink>
-
-              <a href={new_revision_url} className="edit-proposal button success tiny radius right">
-                <i className="icon-edit"></i>
-                { I18n.t("components.action_plan_show.new_revision") }
-              </a>
-
-              { this.renderApproveButton() }
-
-              <span className="right">
-                <WeightControl
-                  weight={ weight }
-                  onUpdateWeight={ (weight) => this.props.changeWeight(id, weight)} />
-              </span>
-
-              { this.renderNotice() }
+              {this.renderReviewerActions()}
+              {this.renderNotice()}
 
               <h2><a href={url}>{title}</a></h2>
 
@@ -116,15 +96,16 @@ class ActionPlanShow extends Component {
                 namespace="action_plans"
                 useServerLinks={ true }/>
 
+              <ActionPlanReviewer visible={this.state.editable} />
+
               <h2>Estat de l'actuacio</h2>
               <p>TODO</p>
 
               <h2>Alegacions relacionades</h2>
               <p>TODO</p>
 
-              <ActionPlanProposals actionPlan={actionPlan} />
-
-              <ActionPlanMeetings />
+              <ActionPlanProposals actionPlan={actionPlan} editable={this.state.editable} />
+              <ActionPlanMeetings useServerLinks={true} />
             </div>
 
             <aside className="small-12 medium-3 column">
@@ -144,12 +125,6 @@ class ActionPlanShow extends Component {
                 <h3>Seguiment</h3>
               </div>
             </aside>
-          </div>
-
-          <div className="row">
-            <div className="small-12 medium-12 column">
-              <ActionPlanReviewer />
-            </div>
           </div>
         </div>
       );
@@ -178,6 +153,35 @@ class ActionPlanShow extends Component {
           { I18n.t("components.action_plan_show.approve") }
         </DangerLink>
       )
+    }
+  }
+
+  renderReviewerActions() {
+    const { actionPlan, deleteActionPlan, changeWeight } = this.props;
+    const { id, weight, new_revision_url } = actionPlan;
+
+    if (this.state.editable) {
+      return (
+        <span>
+          <DangerLink className="delete-action-plan button danger tiny radius right" onClick={() => deleteActionPlan(id) }>
+            <i className="icon-cross"></i>
+            { I18n.t("components.action_plan_show.delete") }
+          </DangerLink>
+
+          <a href={new_revision_url} className="edit-proposal button success tiny radius right">
+            <i className="icon-edit"></i>
+            { I18n.t("components.action_plan_show.new_revision") }
+          </a>
+
+          { this.renderApproveButton() }
+
+          <span className="right">
+            <WeightControl
+              weight={ weight }
+              onUpdateWeight={ (weight) => changeWeight(id, weight)} />
+          </span>
+        </span>
+      );
     }
   }
 }

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -16,6 +16,7 @@ import FilterMeta           from '../filters/filter_meta.component';
 
 import ActionPlanStatistics from './action_plan_statistics.component';
 import ActionPlanProposals  from './action_plan_proposals.component';
+import ActionPlanMeetings   from './action_plan_meetings.component';
 import ActionPlanReviewer   from './action_plan_reviewer.component';
 import WeightControl        from './weight_control.component';
 
@@ -123,7 +124,7 @@ class ActionPlanShow extends Component {
 
               <ActionPlanProposals actionPlan={actionPlan} />
 
-              <ActionPlanReviewer />
+              <ActionPlanMeetings />
             </div>
 
             <aside className="small-12 medium-3 column">
@@ -143,10 +144,11 @@ class ActionPlanShow extends Component {
                 <h3>Seguiment</h3>
               </div>
             </aside>
+          </div>
 
+          <div className="row">
             <div className="small-12 medium-12 column">
-              <h2>Actuacio construida a partir de les seguents cites presencials</h2>
-              <p>TODO</p>
+              <ActionPlanReviewer />
             </div>
           </div>
         </div>

--- a/app/frontend/action_plans/action_plan_statistics.component.js
+++ b/app/frontend/action_plans/action_plan_statistics.component.js
@@ -2,29 +2,21 @@ export default ({
   statistics
 }) => (
   <ul>
-    <li>
-      <span className="number">{statistics.related_proposals_count}</span>
-      {I18n.t('components.action_plan_statistics.related_proposals_count')}
-    </li>
-    <li>
-      <span className="number">{statistics.supports_count}</span>
-      {I18n.t('components.action_plan_statistics.supports_count')}
-    </li>
-    <li>
-      <span className="number">{statistics.comments_count}</span>
-      {I18n.t('components.action_plan_statistics.comments_count')}
-    </li>
-    <li>
-      <span className="number">{statistics.participants_count}</span>
-      {I18n.t('components.action_plan_statistics.participants_count')}
-    </li>
-    <li>
-      <span className="number">{statistics.meeting_interventions_count}</span>
-      {I18n.t('components.action_plan_statistics.meeting_interventions_count')}
-    </li>
-    <li>
-      <span className="number">{statistics.interventions_count}</span>
-      {I18n.t('components.action_plan_statistics.interventions_count')}
-    </li>
+    {renderStatistics(statistics)}
   </ul>
 );
+
+function renderStatistics (statistics) {
+  let result = [];
+
+  for (let key in statistics) {
+    result.push(
+      <li key={key}>
+        <span className="number">{statistics[key]}</span>
+        {I18n.t(`components.action_plan_statistics.${key}`)}
+      </li>
+    );
+  }
+
+  return result;
+}

--- a/app/frontend/action_plans/action_plan_statistics.component.js
+++ b/app/frontend/action_plans/action_plan_statistics.component.js
@@ -1,0 +1,16 @@
+import {Component} from 'react';
+
+export default class ActionPlanStatistics extends Component {
+  render() {
+    return (
+      <ul>
+        <li><span>30</span> Propostes relacionades</li>
+        <li><span>25</span> Suma de suports</li>
+        <li><span>15</span> Suma de comentaris</li>
+        <li><span>25</span> Suma de participants presencials</li>
+        <li><span>30</span> Intervencions en cites</li>
+        <li><span>60</span> Intervencions totals</li>
+      </ul>
+    );
+  }
+}

--- a/app/frontend/action_plans/action_plan_statistics.component.js
+++ b/app/frontend/action_plans/action_plan_statistics.component.js
@@ -1,16 +1,29 @@
-import {Component} from 'react';
-
-export default class ActionPlanStatistics extends Component {
-  render() {
-    return (
-      <ul>
-        <li><span>30</span> Propostes relacionades</li>
-        <li><span>25</span> Suma de suports</li>
-        <li><span>15</span> Suma de comentaris</li>
-        <li><span>25</span> Suma de participants presencials</li>
-        <li><span>30</span> Intervencions en cites</li>
-        <li><span>60</span> Intervencions totals</li>
-      </ul>
-    );
-  }
-}
+export default ({
+  statistics
+}) => (
+  <ul>
+    <li>
+      <span>{statistics.related_proposals_count}</span>
+      Propostes relacionades
+    </li>
+    <li>
+      <span>{statistics.supports_count}</span>
+      Suma de suports
+    </li>
+    <li>
+      <span>{statistics.comments_count}</span>
+      Suma de comentaris
+    </li>
+    <li>
+      <span>{statistics.participants_count}</span>
+      Suma de participants presencials</li>
+    <li>
+      <span>{statistics.meeting_interventions_count}</span>
+      Intervencions en cites
+    </li>
+    <li>
+      <span>{statistics.interventions_count}</span>
+      Intervencions totals
+    </li>
+  </ul>
+);

--- a/app/frontend/action_plans/action_plan_statistics.component.js
+++ b/app/frontend/action_plans/action_plan_statistics.component.js
@@ -4,26 +4,27 @@ export default ({
   <ul>
     <li>
       <span className="number">{statistics.related_proposals_count}</span>
-      Propostes relacionades
+      {I18n.t('components.action_plan_statistics.related_proposals_count')}
     </li>
     <li>
       <span className="number">{statistics.supports_count}</span>
-      Suma de suports
+      {I18n.t('components.action_plan_statistics.supports_count')}
     </li>
     <li>
       <span className="number">{statistics.comments_count}</span>
-      Suma de comentaris
+      {I18n.t('components.action_plan_statistics.comments_count')}
     </li>
     <li>
       <span className="number">{statistics.participants_count}</span>
-      Suma de participants presencials</li>
+      {I18n.t('components.action_plan_statistics.participants_count')}
+    </li>
     <li>
       <span className="number">{statistics.meeting_interventions_count}</span>
-      Intervencions en cites
+      {I18n.t('components.action_plan_statistics.meeting_interventions_count')}
     </li>
     <li>
       <span className="number">{statistics.interventions_count}</span>
-      Intervencions totals
+      {I18n.t('components.action_plan_statistics.interventions_count')}
     </li>
   </ul>
 );

--- a/app/frontend/action_plans/action_plan_statistics.component.js
+++ b/app/frontend/action_plans/action_plan_statistics.component.js
@@ -3,26 +3,26 @@ export default ({
 }) => (
   <ul>
     <li>
-      <span>{statistics.related_proposals_count}</span>
+      <span className="number">{statistics.related_proposals_count}</span>
       Propostes relacionades
     </li>
     <li>
-      <span>{statistics.supports_count}</span>
+      <span className="number">{statistics.supports_count}</span>
       Suma de suports
     </li>
     <li>
-      <span>{statistics.comments_count}</span>
+      <span className="number">{statistics.comments_count}</span>
       Suma de comentaris
     </li>
     <li>
-      <span>{statistics.participants_count}</span>
+      <span className="number">{statistics.participants_count}</span>
       Suma de participants presencials</li>
     <li>
-      <span>{statistics.meeting_interventions_count}</span>
+      <span className="number">{statistics.meeting_interventions_count}</span>
       Intervencions en cites
     </li>
     <li>
-      <span>{statistics.interventions_count}</span>
+      <span className="number">{statistics.interventions_count}</span>
       Intervencions totals
     </li>
   </ul>

--- a/app/frontend/action_plans/action_plans.actions.js
+++ b/app/frontend/action_plans/action_plans.actions.js
@@ -9,6 +9,7 @@ export const DELETE_ACTION_PLAN          = 'DELETE_ACTION_PLAN';
 export const UPDATE_ACTION_PLAN          = 'UPDATE_ACTION_PLAN';
 export const ADD_ACTION_PLAN_PROPOSAL    = 'ADD_ACTION_PLAN_PROPOSAL';
 export const REMOVE_ACTION_PLAN_PROPOSAL = 'REMOVE_ACTION_PLAN_PROPOSAL';
+export const FETCH_RELATED_MEETINGS      = 'FETCH_RELATED_MEETINGS';
 
 export function deleteActionPlan(id){
   const request = axios.delete(`${API_BASE_URL}/action_plans/${id}.json`);
@@ -73,6 +74,15 @@ export function fetchActionPlanProposals(actionPlanId) {
 
   return {
     type: FETCH_ACTION_PLAN_PROPOSALS,
+    payload: request
+  };
+}
+
+export function fetchRelatedMeetings(actionPlanId) {
+  const request = axios.get(`${API_BASE_URL}/action_plans/${actionPlanId}/meetings.json`);
+
+  return {
+    type: FETCH_RELATED_MEETINGS,
     payload: request
   };
 }

--- a/app/frontend/action_plans/action_plans.component.js
+++ b/app/frontend/action_plans/action_plans.component.js
@@ -61,7 +61,7 @@ class ActionPlans extends Component {
               </h3>
               <DownloadButton filters={this.props.filters} order={this.props.order} seed={this.props.seed}/>
               <OrderSelector 
-                orderLinks={["weight", "random"]} />
+                orderLinks={["weight", "random", "confidence_score", "participants"]} />
               <ActionPlansList actionPlans={this.props.actionPlans} />
               {this.renderInfinitePagination()}
             </div>

--- a/app/frontend/action_plans/action_plans.component.js
+++ b/app/frontend/action_plans/action_plans.component.js
@@ -5,6 +5,7 @@ import { connect }            from 'react-redux';
 import Loading                from '../application/loading.component';
 import InfinitePagination     from '../pagination/infinite_pagination.component';
 import OrderSelector          from '../order/order_selector.component';
+import ProposalsHeader        from '../proposals/proposals_header.component';
 
 import ActionPlansSidebar     from './action_plans_sidebar.component';
 import ActionPlansList        from './action_plans_list.component';
@@ -45,6 +46,8 @@ class ActionPlans extends Component {
   render() {
     return (
       <div>
+        <ProposalsHeader />
+
         <div className="wrap row">
           <div className="wrap row">
             <div className="small-12 medium-3 column">

--- a/app/frontend/action_plans/action_plans.component.js
+++ b/app/frontend/action_plans/action_plans.component.js
@@ -5,7 +5,6 @@ import { connect }            from 'react-redux';
 import Loading                from '../application/loading.component';
 import InfinitePagination     from '../pagination/infinite_pagination.component';
 import OrderSelector          from '../order/order_selector.component';
-import ProposalsHeader        from '../proposals/proposals_header.component';
 
 import ActionPlansSidebar     from './action_plans_sidebar.component';
 import ActionPlansList        from './action_plans_list.component';
@@ -46,8 +45,6 @@ class ActionPlans extends Component {
   render() {
     return (
       <div>
-        <ProposalsHeader />
-
         <div className="wrap row">
           <div className="wrap row">
             <div className="small-12 medium-3 column">

--- a/app/frontend/action_plans/action_plans.component.js
+++ b/app/frontend/action_plans/action_plans.component.js
@@ -4,6 +4,7 @@ import { connect }            from 'react-redux';
 
 import Loading                from '../application/loading.component';
 import InfinitePagination     from '../pagination/infinite_pagination.component';
+import OrderSelector          from '../order/order_selector.component';
 
 import ActionPlansSidebar     from './action_plans_sidebar.component';
 import ActionPlansList        from './action_plans_list.component';
@@ -56,6 +57,8 @@ class ActionPlans extends Component {
                 { I18n.t('components.action_plans.count', { count: this.props.count }) }
               </h3>
               <DownloadButton filters={this.props.filters} order={this.props.order} seed={this.props.seed}/>
+              <OrderSelector 
+                orderLinks={["weight", "random"]} />
               <ActionPlansList actionPlans={this.props.actionPlans} />
               {this.renderInfinitePagination()}
             </div>

--- a/app/frontend/action_plans/action_plans.reducers.js
+++ b/app/frontend/action_plans/action_plans.reducers.js
@@ -2,6 +2,7 @@ import {
   FETCH_ACTION_PLANS, 
   FETCH_ACTION_PLAN,
   FETCH_ACTION_PLAN_PROPOSALS,
+  FETCH_RELATED_MEETINGS,
   APPEND_ACTION_PLANS_PAGE,
   DELETE_ACTION_PLAN,
   UPDATE_ACTION_PLAN,
@@ -44,6 +45,13 @@ export const actionPlan = function (state = {}, action) {
         ...state,
         actionPlansProposals
       };
+    case FETCH_RELATED_MEETINGS:
+      let meetings = action.payload.data.meetings;
+
+      return {
+        ...state,
+        meetings
+      }
     case DELETE_ACTION_PLAN:
       return {
         ...state,

--- a/app/frontend/action_plans/proposals_table.component.js
+++ b/app/frontend/action_plans/proposals_table.component.js
@@ -39,10 +39,12 @@ export default class ActionPlanProposalsTable extends Component {
   }
 
   renderRemoveButton(proposal) {
-    if (this.props.onRemoveProposal) {
+    const {onRemoveProposal, editable} = this.props;
+
+    if (editable && onRemoveProposal) {
       return (
         <td>
-          <DangerLink onClick={(event) => this.props.onRemoveProposal(proposal) }>
+          <DangerLink onClick={(event) => onRemoveProposal(proposal) }>
             {I18n.t("components.proposals_table.remove")}
           </DangerLink>
         </td>

--- a/app/frontend/order/order_selector.component.js
+++ b/app/frontend/order/order_selector.component.js
@@ -1,27 +1,28 @@
+import { Component }          from 'react';
 import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { setOrder       }     from '../order/order.actions';
 
-const OrderSelector = ({ 
-  order,
-  setOrder 
-}) => (
-  <section className="submenu">
-    <a onClick={() => setOrder("random")} className={order === 'random' ? 'random active' : 'random'}>
-      { I18n.t('components.order_selector.random') }
-    </a>
-    <a onClick={() => setOrder("hot_score")} className={order === 'hot_score' ? 'hot_score active' : 'hot_score'}>
-      { I18n.t('components.order_selector.hot_score') }
-    </a>
-    <a onClick={() => setOrder("confidence_score")} className={order === 'confidence_score' ? 'confidence_score active' : 'confidence_score'}>
-      { I18n.t('components.order_selector.confidence_score') }
-    </a>
-    <a onClick={() => setOrder("created_at")} className={order === 'created_at' ? 'created_at active' : 'created_at'}>
-      { I18n.t('components.order_selector.created_at') }
-    </a>
-  </section>
-);
+class OrderSelector extends Component {
+  render() {
+    const { orderLinks, order, setOrder } = this.props;
+
+    return (
+      <section className="submenu">
+        { 
+          orderLinks.map(orderLink => {
+            return (
+              <a key={orderLink} onClick={() => setOrder(orderLink)} className={order === orderLink ? `${orderLink} active` : orderLink}>
+                { I18n.t(`components.order_selector.${orderLink}`) }
+              </a>
+            );
+          })
+        }
+      </section>
+    );
+  }
+}
 
 function mapStateToProps({ order }) {
   return {
@@ -32,5 +33,6 @@ function mapStateToProps({ order }) {
 function mapDispatchToProps(dispatch) {
   return bindActionCreators({ setOrder }, dispatch);
 }
+
 
 export default connect(mapStateToProps, mapDispatchToProps)(OrderSelector);

--- a/app/frontend/proposals/proposals.component.js
+++ b/app/frontend/proposals/proposals.component.js
@@ -59,7 +59,6 @@ class Proposals extends Component {
           </div>
 
           <div className="small-12 medium-9 column">
-            <OrderSelector />
             <div className="show-for-small-only">
               <NewProposalButton />
             </div>
@@ -67,6 +66,8 @@ class Proposals extends Component {
             <h3 className="proposals-count">
               { I18n.t('components.proposals.count', { count: this.props.count }) }
             </h3>
+            <OrderSelector
+              orderLinks={["random", "hot_score", "confidence_score", "created_at"]} />
             <ProposalsList proposals={this.props.proposals} />
             {this.renderInfinitePagination()}
           </div>

--- a/app/models/action_plan.rb
+++ b/app/models/action_plan.rb
@@ -11,8 +11,9 @@ class ActionPlan < ActiveRecord::Base
   validates :scope, inclusion: { in: %w(city district) }
   validates :district, inclusion: { in: District.all.map(&:id), allow_nil: true }
 
-  scope :sort_by_created_at, -> { reorder(:created_at) }
-  scope :sort_by_weight, -> { reorder(:weight) }
+  scope :sort_by_weight     , -> { reorder(:weight) }
+  scope :sort_by_random     , -> { reorder("RANDOM()") }
+  scope :sort_by_created_at , -> { reorder(:created_at) }
 
   delegate :title, :description, to: :current_revision, allow_nil: true
 

--- a/app/models/action_plan.rb
+++ b/app/models/action_plan.rb
@@ -1,4 +1,6 @@
 class ActionPlan < ActiveRecord::Base
+  include Statistics
+
   belongs_to :category
   belongs_to :subcategory
 

--- a/app/models/action_plan_statistics.rb
+++ b/app/models/action_plan_statistics.rb
@@ -1,0 +1,3 @@
+class ActionPlanStatistics < ActiveRecord::Base
+  belongs_to :action_plan
+end

--- a/app/models/concerns/action_plan/statistics.rb
+++ b/app/models/concerns/action_plan/statistics.rb
@@ -5,6 +5,14 @@ class ActionPlan < ActiveRecord::Base
     included do
       has_one :action_plan_statistics, class_name: ::ActionPlanStatistics
 
+      scope :sort_by_confidence_score , -> { 
+        includes(:action_plan_statistics).reorder('action_plan_statistics.supports_count desc') 
+      }
+
+      scope :sort_by_participants , -> { 
+        includes(:action_plan_statistics).reorder('action_plan_statistics.participants_count desc') 
+      }
+
       delegate :related_proposals_count, :supports_count, :comments_count, :participants_count,
         :meeting_interventions_count, :interventions_count,
         to: :action_plan_statistics, allow_nil: true

--- a/app/models/concerns/action_plan/statistics.rb
+++ b/app/models/concerns/action_plan/statistics.rb
@@ -27,45 +27,6 @@ class ActionPlan < ActiveRecord::Base
           interventions_count: interventions_count
         }
       end
-
-      def compute_statistics
-        statistics = ActionPlanStatistics.find_or_create_by(action_plan_id: self.id)
-
-        statistics.related_proposals_count     = compute_related_proposals_count
-        statistics.supports_count              = compute_supports_count
-        statistics.comments_count              = compute_comments_count
-        statistics.participants_count          = compute_participants_count
-        statistics.meeting_interventions_count = compute_meeting_interventions_count
-        statistics.interventions_count         = compute_interventions_count
-
-        statistics.save
-      end
-
-      private
-
-      def compute_related_proposals_count
-        self.proposals.count
-      end
-
-      def compute_supports_count
-        self.proposals.map(&:total_votes).sum
-      end
-
-      def compute_comments_count
-        self.proposals.map(&:comments).flatten.length
-      end
-
-      def compute_participants_count
-        self.proposals.map(&:meetings).flatten.map(&:attendee_count).compact.sum
-      end
-
-      def compute_meeting_interventions_count
-        self.proposals.map(&:meetings).flatten.map(&:interventions).compact.sum
-      end
-
-      def compute_interventions_count
-        0
-      end
     end
   end
 end

--- a/app/models/concerns/action_plan/statistics.rb
+++ b/app/models/concerns/action_plan/statistics.rb
@@ -1,0 +1,63 @@
+class ActionPlan < ActiveRecord::Base
+  module Statistics
+    extend ActiveSupport::Concern
+
+    included do
+      has_one :action_plan_statistics, class_name: ::ActionPlanStatistics
+
+      delegate :related_proposals_count, :supports_count, :comments_count, :participants_count,
+        :meeting_interventions_count, :interventions_count,
+        to: :action_plan_statistics, allow_nil: true
+
+      def statistics
+        {
+          related_proposals_count: related_proposals_count,
+          supports_count: supports_count,
+          comments_count: comments_count,
+          participants_count: participants_count,
+          meeting_interventions_count: meeting_interventions_count,
+          interventions_count: interventions_count
+        }
+      end
+
+      def compute_statistics
+        statistics = ActionPlanStatistics.find_or_create_by(action_plan_id: self.id)
+
+        statistics.related_proposals_count     = compute_related_proposals_count
+        statistics.supports_count              = compute_supports_count
+        statistics.comments_count              = compute_comments_count
+        statistics.participants_count          = compute_participants_count
+        statistics.meeting_interventions_count = compute_meeting_interventions_count
+        statistics.interventions_count         = compute_interventions_count
+
+        statistics.save
+      end
+
+      private
+
+      def compute_related_proposals_count
+        self.proposals.count
+      end
+
+      def compute_supports_count
+        self.proposals.map(&:total_votes).sum
+      end
+
+      def compute_comments_count
+        self.proposals.map(&:comments).sum
+      end
+
+      def compute_participants_count
+        self.proposals.map(&:meetings).flatten.map(&:attendee_count).compact.sum
+      end
+
+      def compute_meeting_interventions_count
+        self.proposals.map(&:meetings).flatten.map(&:interventions).compact.sum
+      end
+
+      def compute_interventions_count
+        0
+      end
+    end
+  end
+end

--- a/app/models/concerns/action_plan/statistics.rb
+++ b/app/models/concerns/action_plan/statistics.rb
@@ -44,7 +44,7 @@ class ActionPlan < ActiveRecord::Base
       end
 
       def compute_comments_count
-        self.proposals.map(&:comments).sum
+        self.proposals.map(&:comments).flatten.length
       end
 
       def compute_participants_count

--- a/app/serializers/action_plan_serializer.rb
+++ b/app/serializers/action_plan_serializer.rb
@@ -1,6 +1,6 @@
 class ActionPlanSerializer < ActiveModel::Serializer
   attributes :id, :title, :description, :created_at, :url, :scope_, :district,
-    :edit_url, :new_revision_url, :approved, :weight
+    :edit_url, :new_revision_url, :approved, :weight, :statistics
 
   has_one :category
   has_one :subcategory

--- a/app/services/action_plan_statistics_calculator.rb
+++ b/app/services/action_plan_statistics_calculator.rb
@@ -1,0 +1,77 @@
+# Compute action plan statistics and store them into database
+class ActionPlanStatisticsCalculator
+  # Static
+  #
+  # Compute the following statistics for a given action plan:
+  # - Related proposals count
+  # - Supports count
+  # - Comments count
+  # - Participations count
+  # - Meeting interventions count
+  # - Interventions count
+  #
+  # ap - An action plan to compute statistics for
+  def self.compute_statistics_for(ap)
+    statistics = ActionPlanStatistics.find_or_create_by(action_plan_id: ap.id)
+
+    statistics.related_proposals_count     = related_proposals_count(ap)
+    statistics.supports_count              = supports_count(ap)
+    statistics.comments_count              = comments_count(ap)
+    statistics.participants_count          = participants_count(ap)
+    statistics.meeting_interventions_count = meeting_interventions_count(ap)
+    statistics.interventions_count         = interventions_count(ap)
+
+    statistics.save
+    statistics
+  end
+
+  # Static
+  #
+  # Count related proposals for a given action plan
+  #
+  # ap - An action plan to compute related proposals count for
+  def self.related_proposals_count(ap)
+    ap.proposals.count
+  end
+
+  # Static
+  #
+  # Count related proposals for a given action plan
+  #
+  # ap - An action plan to compute related proposals count for
+  def self.supports_count(ap)
+    ap.proposals.map(&:total_votes).sum
+  end
+
+  # Static
+  #
+  # Sum total comments for all action plan proposals
+  #
+  # ap - An action plan to compute comments count for
+  def self.comments_count(ap)
+    ap.proposals.map(&:comments).flatten.length
+  end
+
+  # Static
+  #
+  # Sum total attendees for all meetings related to an action plan
+  #
+  # ap - An action plan to compute participants count for
+  def self.participants_count(ap)
+    ap.proposals.map(&:meetings).flatten.map(&:attendee_count).compact.sum
+  end
+
+  # Static
+  #
+  # Sum total interventions for all meetings related to an action plan
+  #
+  # ap - An action plan to compute meeting interventions count for
+  def self.meeting_interventions_count(ap)
+    ap.proposals.map(&:meetings).flatten.map(&:interventions).compact.sum
+  end
+
+  # TODO: Just a placeholder. Needs a correct implementation.
+  def self.interventions_count(ap)
+    0
+  end
+end

--- a/app/workers/action_plan_statistics_worker.rb
+++ b/app/workers/action_plan_statistics_worker.rb
@@ -1,0 +1,8 @@
+class ActionPlanStatisticsWorker
+  include Sidekiq::Worker
+
+  def perform(action_plan_id)
+    action_plan = ActionPlan.find(action_plan_id)
+    action_plan.compute_statistics
+  end
+end

--- a/app/workers/action_plan_statistics_worker.rb
+++ b/app/workers/action_plan_statistics_worker.rb
@@ -3,6 +3,6 @@ class ActionPlanStatisticsWorker
 
   def perform(action_plan_id)
     action_plan = ActionPlan.find(action_plan_id)
-    action_plan.compute_statistics
+    ActionPlanStatisticsCalculator.compute_statistics_for(action_plan)
   end
 end

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -14,12 +14,12 @@ ca:
       deleted: Aquesta actuació ha estat eliminada
       new_revision: Nova revisió
     action_plan_statistics:
-      comments_count: Suma de comentaris
+      comments_count: Comentaris
       interventions_count: Intervencions totals
       meeting_interventions_count: Intervencions en cites
-      participants_count: Suma de participacions presencials
+      participants_count: Participacions presencials
       related_proposals_count: Propostes relacionades
-      supports_count: Suma de suports
+      supports_count: Suports
     action_plans:
       count: Mostrant %{count} actuacions
       title: Actuacions relacionades

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -13,6 +13,13 @@ ca:
       delete: Eliminar
       deleted: Aquesta actuació ha estat eliminada
       new_revision: Nova revisió
+    action_plan_statistics:
+      comments_count: Suma de comentaris
+      interventions_count: Intervencions totals
+      meeting_interventions_count: Intervencions en cites
+      participants_count: Suma de participacions presencials
+      related_proposals_count: Propostes relacionades
+      supports_count: Suma de suports
     action_plans:
       count: Mostrant %{count} actuacions
       title: Actuacions relacionades
@@ -77,11 +84,11 @@ ca:
     meetings_filters:
       clean_filters: Netejar filtre
     order_selector:
-      weight: pesos
       confidence_score: amb més suport
       created_at: més noves
       hot_score: més actives avui
       random: aleatòries
+      weight: pesos
     proposal_answer_box:
       accept: Acceptar
       approve: Aprovar resposta

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -87,6 +87,7 @@ ca:
       confidence_score: amb més suport
       created_at: més noves
       hot_score: més actives avui
+      participants: més participades
       random: aleatòries
       weight: pesos
     proposal_answer_box:

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -77,6 +77,7 @@ ca:
     meetings_filters:
       clean_filters: Netejar filtre
     order_selector:
+      weight: pesos
       confidence_score: amb més suport
       created_at: més noves
       hot_score: més actives avui

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -13,6 +13,13 @@ en:
       delete: remove
       deleted: This action has been removed
       new_revision: New revision
+    action_plan_statistics:
+      comments_count: Comments
+      interventions_count: Interventions
+      meeting_interventions_count: Meeting interventions
+      participants_count: Presencial participations
+      related_proposals_count: Related proposals
+      supports_count: Supports
     action_plans:
       count: Showing %{count} action plans
       title: Related action plans
@@ -77,11 +84,11 @@ en:
     meetings_filters:
       clean_filters: Clean filter
     order_selector:
-      weight: weights
       confidence_score: highest rated
       created_at: newest
       hot_score: most active
       random: random
+      weight: weights
     proposal_answer_box:
       accept: Accept
       approve: Approve answer

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -77,6 +77,7 @@ en:
     meetings_filters:
       clean_filters: Clean filter
     order_selector:
+      weight: weights
       confidence_score: highest rated
       created_at: newest
       hot_score: most active

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -87,6 +87,7 @@ en:
       confidence_score: highest rated
       created_at: newest
       hot_score: most active
+      participants: more participation
       random: random
       weight: weights
     proposal_answer_box:

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -77,6 +77,7 @@ es:
     meetings_filters:
       clean_filters: Limpiar filtro
     order_selector:
+      weight: pesos
       confidence_score: Mejor valorados
       created_at: Nuevos
       hot_score: Más activos hoy

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -13,6 +13,13 @@ es:
       delete: Eliminar
       deleted: Esta actuación ha sido eliminada
       new_revision: Nueva revisión
+    action_plan_statistics:
+      comments_count: Suma de comentarios
+      interventions_count: Intervenciones totales
+      meeting_interventions_count: Intervenciones en citas
+      participants_count: Suma de participaciones presenciales
+      related_proposals_count: Propuestas relacionadas
+      supports_count: Suma de soportes
     action_plans:
       count: Mostrando %{count} actuaciones
       title: Actuaciones relacionadas
@@ -77,11 +84,11 @@ es:
     meetings_filters:
       clean_filters: Limpiar filtro
     order_selector:
-      weight: pesos
       confidence_score: Mejor valorados
       created_at: Nuevos
       hot_score: Más activos hoy
       random: aleatorio
+      weight: pesos
     proposal_answer_box:
       accept: Aceptar
       approve: Aprobar respuesta

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -87,6 +87,7 @@ es:
       confidence_score: Mejor valorados
       created_at: Nuevos
       hot_score: Más activos hoy
+      participants: más participadas
       random: aleatorio
       weight: pesos
     proposal_answer_box:

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -14,12 +14,12 @@ es:
       deleted: Esta actuación ha sido eliminada
       new_revision: Nueva revisión
     action_plan_statistics:
-      comments_count: Suma de comentarios
+      comments_count: Comentarios
       interventions_count: Intervenciones totales
       meeting_interventions_count: Intervenciones en citas
-      participants_count: Suma de participaciones presenciales
+      participants_count: Participaciones presenciales
       related_proposals_count: Propuestas relacionadas
-      supports_count: Suma de soportes
+      supports_count: Soportes
     action_plans:
       count: Mostrando %{count} actuaciones
       title: Actuaciones relacionadas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,6 +284,7 @@ Rails.application.routes.draw do
     end
     resources :action_plans do
       resources :proposals, controller: 'action_plans/proposals'
+      resources :meetings, controller: 'action_plans/meetings'
     end
     resources :meetings, only: [:index]
     resources :follows, only: [:index, :create, :destroy]

--- a/db/migrate/20160606123217_create_action_plan_statistics.rb
+++ b/db/migrate/20160606123217_create_action_plan_statistics.rb
@@ -1,0 +1,15 @@
+class CreateActionPlanStatistics < ActiveRecord::Migration
+  def change
+    create_table :action_plan_statistics do |t|
+      t.integer :action_plan_id
+      t.integer :related_proposals_count, default: 0
+      t.integer :supports_count, default: 0
+      t.integer :comments_count, default: 0
+      t.integer :participants_count, default: 0
+      t.integer :meeting_interventions_count, default: 0
+      t.integer :interventions_count, default: 0
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160509101511) do
+ActiveRecord::Schema.define(version: 20160606123217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,18 @@ ActiveRecord::Schema.define(version: 20160509101511) do
   end
 
   add_index "action_plan_revisions", ["tsv"], name: "index_action_plan_revisions_on_tsv", using: :gin
+
+  create_table "action_plan_statistics", force: :cascade do |t|
+    t.integer  "action_plan_id"
+    t.integer  "related_proposals_count",     default: 0
+    t.integer  "supports_count",              default: 0
+    t.integer  "comments_count",              default: 0
+    t.integer  "participants_count",          default: 0
+    t.integer  "meeting_interventions_count", default: 0
+    t.integer  "interventions_count",         default: 0
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+  end
 
   create_table "action_plans", force: :cascade do |t|
     t.integer  "category_id",                     null: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 app:
   build: .
-  command: "bundle exec rails s -b 0.0.0.0"
+  command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
   env_file: .env
   environment:
     - DATABASE_HOST=db

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cheerio": "^0.20.0",
     "enzyme": "^2.2.0",
     "jasmine-core": "^2.4.1",
+    "html-ellipsis": "^1.1.1",
     "karma": "^0.13.19",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-chai": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "redux-promise": "^0.5.3",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.14",
-    "whatwg-fetch": "^0.11.0"
+    "whatwg-fetch": "^0.11.0",
+    "html-ellipsis": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -44,7 +45,6 @@
     "cheerio": "^0.20.0",
     "enzyme": "^2.2.0",
     "jasmine-core": "^2.4.1",
-    "html-ellipsis": "^1.1.1",
     "karma": "^0.13.19",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-chai": "^0.1.0",

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -425,4 +425,14 @@ FactoryGirl.define do
     sequence(:title)       { |n| "Revision #{n} title" }
     sequence(:description) { |n| "Revision #{n} description" }
   end
+
+  factory :action_plan_statistics do
+    action_plan
+    related_proposals_count 1
+    supports_count 1
+    comments_count 1
+    participants_count 1
+    meeting_interventions_count 1
+    interventions_count 1
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,5 @@
-FactoryGirl.define do  factory :action_plan_report do
+FactoryGirl.define do 
+  factory :action_plan_report do
     file "MyString"
   end
 

--- a/spec/models/action_plan_spec.rb
+++ b/spec/models/action_plan_spec.rb
@@ -1,5 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe ActionPlan, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "statistics" do
+    before :all do
+      @meeting_1 = create(:meeting, attendee_count: 10, interventions: 2)
+      @proposal_1 = create(:proposal)
+      @proposal_1.meetings << @meeting_1
+      @proposal_1.save
+      2.times { create(:comment, commentable: @proposal_1) }
+      3.times { create(:vote, votable: @proposal_1) }
+
+      @meeting_1 = create(:meeting, attendee_count: 15, interventions: 5)
+      @proposal_2 = create(:proposal)
+      @proposal_2.meetings << @meeting_1
+      @proposal_1.save
+      4.times { create(:comment, commentable: @proposal_2) }
+      5.times { create(:vote, votable: @proposal_2) }
+
+      @action_plan = create(:action_plan)
+      @action_plan.proposals << @proposal_1
+      @action_plan.proposals << @proposal_2
+      @action_plan.save
+
+      @action_plan.compute_statistics
+      @statistics = @action_plan.statistics
+    end
+
+    it "should compute related proposals count" do
+      expect(@statistics[:related_proposals_count]).to eq(2)
+    end
+
+    it "should compute supports count" do
+      expect(@statistics[:supports_count]).to eq(8)
+    end
+
+    it "should compute comments count" do
+      expect(@statistics[:comments_count]).to eq(6)
+    end
+
+    it "should compute participants count" do
+      expect(@statistics[:participants_count]).to eq(25)
+    end
+
+    it "should compute meeting interventions count" do
+      expect(@statistics[:meeting_interventions_count]).to eq(7)
+    end
+
+    xit "should compute interventions count" do
+      expect(@statistics[:interventions_count]).to eq(0)
+    end
+  end
 end

--- a/spec/models/action_plan_spec.rb
+++ b/spec/models/action_plan_spec.rb
@@ -1,53 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe ActionPlan, type: :model do
-  context "statistics" do
-    before :all do
-      @meeting_1 = create(:meeting, attendee_count: 10, interventions: 2)
-      @proposal_1 = create(:proposal)
-      @proposal_1.meetings << @meeting_1
-      @proposal_1.save
-      2.times { create(:comment, commentable: @proposal_1) }
-      3.times { create(:vote, votable: @proposal_1) }
-
-      @meeting_1 = create(:meeting, attendee_count: 15, interventions: 5)
-      @proposal_2 = create(:proposal)
-      @proposal_2.meetings << @meeting_1
-      @proposal_1.save
-      4.times { create(:comment, commentable: @proposal_2) }
-      5.times { create(:vote, votable: @proposal_2) }
-
+  context "#statistics" do
+    it "should retorn stastics as a hash object" do
       @action_plan = create(:action_plan)
-      @action_plan.proposals << @proposal_1
-      @action_plan.proposals << @proposal_2
-      @action_plan.save
 
-      @action_plan.compute_statistics
-      @statistics = @action_plan.statistics
-    end
+      create(:action_plan_statistics, {
+        action_plan: @action_plan,
+        related_proposals_count: 1,
+        supports_count: 2,
+        comments_count: 3,
+        participants_count: 4,
+        meeting_interventions_count: 5,
+        interventions_count: 6
+      }) 
 
-    it "should compute related proposals count" do
-      expect(@statistics[:related_proposals_count]).to eq(2)
-    end
+      @action_plan.reload
 
-    it "should compute supports count" do
-      expect(@statistics[:supports_count]).to eq(8)
-    end
-
-    it "should compute comments count" do
-      expect(@statistics[:comments_count]).to eq(6)
-    end
-
-    it "should compute participants count" do
-      expect(@statistics[:participants_count]).to eq(25)
-    end
-
-    it "should compute meeting interventions count" do
-      expect(@statistics[:meeting_interventions_count]).to eq(7)
-    end
-
-    xit "should compute interventions count" do
-      expect(@statistics[:interventions_count]).to eq(0)
+      expect(@action_plan.statistics).to eq({
+        related_proposals_count: 1,
+        supports_count: 2,
+        comments_count: 3,
+        participants_count: 4,
+        meeting_interventions_count: 5,
+        interventions_count: 6
+      })
     end
   end
 end

--- a/spec/services/action_plan_statistics_calculator_spec.rb
+++ b/spec/services/action_plan_statistics_calculator_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ActionPlanStatisticsCalculator, type: :service do
+  before :all do
+    @meeting_1 = create(:meeting, attendee_count: 10, interventions: 2)
+    @proposal_1 = create(:proposal)
+    @proposal_1.meetings << @meeting_1
+    @proposal_1.save
+    2.times { create(:comment, commentable: @proposal_1) }
+    3.times { create(:vote, votable: @proposal_1) }
+
+    @meeting_1 = create(:meeting, attendee_count: 15, interventions: 5)
+    @proposal_2 = create(:proposal)
+    @proposal_2.meetings << @meeting_1
+    @proposal_1.save
+    4.times { create(:comment, commentable: @proposal_2) }
+    5.times { create(:vote, votable: @proposal_2) }
+
+    @action_plan = create(:action_plan)
+    @action_plan.proposals << @proposal_1
+    @action_plan.proposals << @proposal_2
+    @action_plan.save
+
+    @statistics = ActionPlanStatisticsCalculator.compute_statistics_for(@action_plan)
+  end
+
+  it "should compute related proposals count" do
+    expect(@statistics.related_proposals_count).to eq(2)
+  end
+
+  it "should compute supports count" do
+    expect(@statistics.supports_count).to eq(8)
+  end
+
+  it "should compute comments count" do
+    expect(@statistics.comments_count).to eq(6)
+  end
+
+  it "should compute participants count" do
+    expect(@statistics.participants_count).to eq(25)
+  end
+
+  it "should compute meeting interventions count" do
+    expect(@statistics.meeting_interventions_count).to eq(7)
+  end
+
+  xit "should compute interventions count" do
+    expect(@statistics.interventions_count).to eq(0)
+  end
+end

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,8 +57,14 @@ module.exports = {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract("style-loader", "css-loader")
       },
-      { test: require.resolve("react"), loader: "expose?React" },
-      { test: require.resolve("react-dom"), loader: "expose?ReactDOM" }
+      { 
+        test: require.resolve("react"),
+        loader: "expose?React" 
+      },
+      { 
+        test: require.resolve("react-dom"),
+        loader: "expose?ReactDOM"
+      }
     ]
   }
 };


### PR DESCRIPTION
# What and why

I added some new components to the action plan show public page:
- A sidebar with `ActionPlanStatistics` component.
- An `ActionMeetings` component. 

I also added a new api endpoint:
- `/api/action_plans/:id/meetings`: returns action plan related meetings.

I hide all reviewer links if the user doesn't have the reviewer role.
# TODOs
- [ ] Better stylesheets
- [x] Statistics sidebar
- [x] Related meetings/proposals
- [ ] Estat de l'actuacio
- [ ] Alegacions relacionades
- [ ] Autoria
- [ ] Seguiment
# GIF Tax

![](https://media.giphy.com/media/deURfFYxgQEQ8/giphy.gif)
