### PR TITLE
Improve API performance

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -24,3 +24,4 @@
 @import "components/new_comment_form";
 @import "components/weight_control";
 @import "components/action_plan_statistics";
+@import "components/action_plan_proposals";

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -25,3 +25,4 @@
 @import "components/weight_control";
 @import "components/action_plan_statistics";
 @import "components/action_plan_proposals";
+@import "components/action_plan_meetings";

--- a/app/assets/stylesheets/components/_action_plan_meetings.scss
+++ b/app/assets/stylesheets/components/_action_plan_meetings.scss
@@ -1,0 +1,10 @@
+.action-plan-meetings-component {
+  position: relative;
+  min-height: rem-calc(150);
+
+  .meetings-directory {
+    .meetings-list {
+      width: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_action_plan_proposals.scss
+++ b/app/assets/stylesheets/components/_action_plan_proposals.scss
@@ -1,0 +1,4 @@
+.action-plan-proposals-component {
+  position: relative;
+  min-height: rem-calc(150);
+}

--- a/app/controllers/api/action_plans/meetings_controller.rb
+++ b/app/controllers/api/action_plans/meetings_controller.rb
@@ -3,9 +3,9 @@ class Api::ActionPlans::MeetingsController < Api::ApplicationController
 
   def index
     meeting_ids = @action_plan.proposals
-    .includes(:meetings)
-    .collect(&:meeting_ids)
-    .flatten
+      .includes(:meetings)
+      .collect(&:meeting_ids)
+      .flatten
 
     @meetings = Meeting.includes(:category, :subcategory).where(id: meeting_ids)
 

--- a/app/controllers/api/action_plans/meetings_controller.rb
+++ b/app/controllers/api/action_plans/meetings_controller.rb
@@ -1,0 +1,8 @@
+class Api::ActionPlans::MeetingsController < Api::ApplicationController
+  load_and_authorize_resource :action_plan
+
+  def index
+    @meetings = @action_plan.proposals.collect(&:meetings).flatten
+    render json: @meetings
+  end
+end

--- a/app/controllers/api/action_plans/meetings_controller.rb
+++ b/app/controllers/api/action_plans/meetings_controller.rb
@@ -2,7 +2,13 @@ class Api::ActionPlans::MeetingsController < Api::ApplicationController
   load_and_authorize_resource :action_plan
 
   def index
-    @meetings = @action_plan.proposals.collect(&:meetings).flatten
+    meeting_ids = @action_plan.proposals
+    .includes(:meetings)
+    .collect(&:meeting_ids)
+    .flatten
+
+    @meetings = Meeting.includes(:category, :subcategory).where(id: meeting_ids)
+
     render json: @meetings
   end
 end

--- a/app/controllers/api/action_plans/proposals_controller.rb
+++ b/app/controllers/api/action_plans/proposals_controller.rb
@@ -4,14 +4,14 @@ class Api::ActionPlans::ProposalsController < Api::ApplicationController
 
   def index
     @action_plans_proposals = @action_plan.action_plans_proposals
-    .includes(:proposal => [
-      {:author => :organization},
-      :category,
-      :subcategory,
-      :comments,
-      :flags,
-      :votes_for
-    ])
+      .includes(:proposal => [
+        { author: :organization },
+        :category,
+        :subcategory,
+        :comments,
+        :flags,
+        :votes_for
+      ])
 
     render json: @action_plans_proposals, root: 'action_plans_proposals'
   end

--- a/app/controllers/api/action_plans/proposals_controller.rb
+++ b/app/controllers/api/action_plans/proposals_controller.rb
@@ -4,6 +4,15 @@ class Api::ActionPlans::ProposalsController < Api::ApplicationController
 
   def index
     @action_plans_proposals = @action_plan.action_plans_proposals
+    .includes(:proposal => [
+      {:author => :organization},
+      :category,
+      :subcategory,
+      :comments,
+      :flags,
+      :votes_for
+    ])
+
     render json: @action_plans_proposals, root: 'action_plans_proposals'
   end
 

--- a/app/controllers/api/action_plans_controller.rb
+++ b/app/controllers/api/action_plans_controller.rb
@@ -11,7 +11,9 @@ class Api::ActionPlansController < Api::ApplicationController
   def index
     set_seed
 
-    action_plans = ActionPlan.all
+    action_plans = ActionPlan
+    .includes(:revisions)
+    .includes(:action_plan_statistics)
 
     @action_plans = ResourceFilter.new(params, user: current_user)
       .filter_collection(action_plans.includes(:category, :subcategory))

--- a/app/controllers/api/action_plans_controller.rb
+++ b/app/controllers/api/action_plans_controller.rb
@@ -11,9 +11,7 @@ class Api::ActionPlansController < Api::ApplicationController
   def index
     set_seed
 
-    action_plans = ActionPlan
-    .includes(:revisions)
-    .includes(:action_plan_statistics)
+    action_plans = ActionPlan.includes(:revisions, :action_plan_statistics)
 
     @action_plans = ResourceFilter.new(params, user: current_user)
       .filter_collection(action_plans.includes(:category, :subcategory))

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -13,6 +13,11 @@ class Api::ProposalsController < Api::ApplicationController
 
     proposals = @current_order == "recommended" ? Recommender.new(current_user).proposals : Proposal.all
 
+    proposals = proposals
+    .includes(:comments)
+    .includes(:flags)
+    .includes(:votes_for)
+
     @proposals = ResourceFilter.new(params, user: current_user)
       .filter_collection(proposals.includes(:category, :subcategory, :author => [:organization]))
       .send("sort_by_#{@current_order}")

--- a/app/controllers/api/proposals_controller.rb
+++ b/app/controllers/api/proposals_controller.rb
@@ -13,10 +13,7 @@ class Api::ProposalsController < Api::ApplicationController
 
     proposals = @current_order == "recommended" ? Recommender.new(current_user).proposals : Proposal.all
 
-    proposals = proposals
-    .includes(:comments)
-    .includes(:flags)
-    .includes(:votes_for)
+    proposals = proposals.includes(:comments, :flags, :votes_for)
 
     @proposals = ResourceFilter.new(params, user: current_user)
       .filter_collection(proposals.includes(:category, :subcategory, :author => [:organization]))

--- a/app/controllers/api/subcategories_controller.rb
+++ b/app/controllers/api/subcategories_controller.rb
@@ -1,0 +1,11 @@
+class Api::SubcategoriesController < Api::ApplicationController
+  load_and_authorize_resource
+
+  def index
+    @subcategories = Subcategory.all
+
+    respond_to do |format|
+      format.json { render json: @subcategories }
+    end
+  end
+end

--- a/app/frontend/action_plans/action_plan_meetings.component.js
+++ b/app/frontend/action_plans/action_plan_meetings.component.js
@@ -1,0 +1,75 @@
+import { Component }            from 'react';
+import { bindActionCreators }   from 'redux';
+import { connect }              from 'react-redux';
+
+import Loading                  from '../application/loading.component';
+
+import Meeting                  from '../meetings/meeting.component';
+
+import { fetchRelatedMeetings } from './action_plans.actions';
+
+class ActionPlanMeetings extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: true
+    }
+  }
+
+  componentDidMount() {
+    const { actionPlan, fetchRelatedMeetings } = this.props;
+
+    fetchRelatedMeetings(actionPlan.id).then(() => {
+      this.setState({ loading: false });
+    });
+  }
+
+  render() {
+    return (
+      <div className="row action-plan-meetings-component">
+        <div className="small-12 medium-12 column">
+          <h2>{ I18n.t("proposals.show.meetings_title") }</h2>
+          <Loading show={this.state.loading} />
+          {this.renderMeetings()}
+        </div>
+      </div>
+    );
+  }
+
+  renderMeetings() {
+    const { actionPlan, useServerLinks } = this.props;
+    const meetings = actionPlan.meetings || [];
+
+    if (meetings.length > 0) {
+      return (
+        <div>
+          <div className="meetings-directory">
+            <div className="meetings-list">
+              <ul className="meetings-list-items">
+                { 
+                  meetings.map((meeting) => 
+                    <li key={ meeting.id }>
+                      <Meeting meeting={ meeting } useServerLinks={ useServerLinks } />
+                    </li>
+                  )
+                }
+              </ul>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return null;
+  }
+}
+
+function mapStateToProps({ actionPlan }) {
+  return { actionPlan };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ fetchRelatedMeetings }, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ActionPlanMeetings);

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -33,24 +33,37 @@ class ActionPlanProposals extends Component {
   }
 
   render() {
-    const { actionPlan, addActionPlanProposal, removeActionPlanProposal } = this.props;
+    const { editable, actionPlan, addActionPlanProposal, removeActionPlanProposal } = this.props;
     const { id } = actionPlan;
     const actionPlansProposals = actionPlan.actionPlansProposals || [];
 
     return (
       <div className="action-plan-proposals-component">
         <h2>{I18n.t("components.action_plan_proposals.title")}</h2>
-        <ProposalsAutocompleteInput 
-          proposalsApiUrl="/api/proposals"
-          excludeIds={actionPlansProposals.map(a => a.proposal.id)}
-          onAddProposal={proposal => addActionPlanProposal(id, proposal)} />
+        {this.renderSearchProposalsInput(id, actionPlansProposals)}
         <Loading show={this.state.loading} />
         <ProposalsTable 
           actionPlansProposals={ actionPlansProposals }
           onChangeLevel={ (proposal, level) => changeActionPlansProposalLevel(actionPlan, proposal, level) }
-          onRemoveProposal={proposal => removeActionPlanProposal(id, proposal)} />
+          onRemoveProposal={proposal => removeActionPlanProposal(id, proposal)} 
+          editable={editable} />
       </div>
     );
+  }
+
+  renderSearchProposalsInput(id, actionPlansProposals) {
+    const {editable} = this.props;
+
+    if (editable) {
+      return (
+        <ProposalsAutocompleteInput 
+          proposalsApiUrl="/api/proposals"
+          excludeIds={actionPlansProposals.map(a => a.proposal.id)}
+          onAddProposal={proposal => addActionPlanProposal(id, proposal)} />
+      );
+    }
+
+    return null;
   }
 }
 

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -27,7 +27,7 @@ class ActionPlanProposals extends Component {
 
     return (
       <div>
-        <h4>{I18n.t("components.action_plan_proposals.title")}</h4>
+        <h2>{I18n.t("components.action_plan_proposals.title")}</h2>
         <ProposalsAutocompleteInput 
           proposalsApiUrl="/api/proposals"
           excludeIds={actionPlansProposals.map(a => a.proposal.id)}

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -2,6 +2,8 @@ import { Component }              from 'react';
 import { bindActionCreators }     from 'redux';
 import { connect }                from 'react-redux';
 
+import Loading                    from '../application/loading.component';
+
 import ProposalsAutocompleteInput from '../proposals/proposals_autocomplete_input.component';
 import ProposalsTable             from './proposals_table.component';
 
@@ -14,10 +16,20 @@ import {
 
 
 class ActionPlanProposals extends Component {
-  componentDidMount() {
-    const { actionPlan } = this.props;
+  constructor(props) {
+    super(props);
 
-    this.props.fetchActionPlanProposals(actionPlan.id);
+    this.state = {
+      loading: true
+    }
+  }
+
+  componentDidMount() {
+    const { actionPlan, fetchActionPlanProposals } = this.props;
+
+    fetchActionPlanProposals(actionPlan.id).then(() => {
+      this.setState({ loading: false });
+    });
   }
 
   render() {
@@ -26,12 +38,13 @@ class ActionPlanProposals extends Component {
     const actionPlansProposals = actionPlan.actionPlansProposals || [];
 
     return (
-      <div>
+      <div className="action-plan-proposals-component">
         <h2>{I18n.t("components.action_plan_proposals.title")}</h2>
         <ProposalsAutocompleteInput 
           proposalsApiUrl="/api/proposals"
           excludeIds={actionPlansProposals.map(a => a.proposal.id)}
           onAddProposal={proposal => addActionPlanProposal(id, proposal)} />
+        <Loading show={this.state.loading} />
         <ProposalsTable 
           actionPlansProposals={ actionPlansProposals }
           onChangeLevel={ (proposal, level) => changeActionPlansProposalLevel(actionPlan, proposal, level) }

--- a/app/frontend/action_plans/action_plan_reviewer.component.js
+++ b/app/frontend/action_plans/action_plan_reviewer.component.js
@@ -16,10 +16,10 @@ class ActionPlanReviewer extends Component {
   }
 
   render() {
-    const { session, actionPlan, updateActionPlan } = this.props;
+    const { visible, actionPlan, updateActionPlan } = this.props;
     const { id, scope_, district, category, subcategory } = actionPlan;
 
-    if (session.is_reviewer) {
+    if (visible) {
       return (
         <div>
           <h2>{I18n.t('action_plans.edit.editing')}</h2>
@@ -43,8 +43,8 @@ class ActionPlanReviewer extends Component {
   }
 }
 
-function mapStateToProps({ session, actionPlan }) {
-  return { session, actionPlan };
+function mapStateToProps({ actionPlan }) {
+  return { actionPlan };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/app/frontend/action_plans/action_plan_reviewer.component.js
+++ b/app/frontend/action_plans/action_plan_reviewer.component.js
@@ -4,7 +4,6 @@ import { bindActionCreators } from 'redux';
 
 import ScopePicker            from '../scope/scope_picker.component';
 import CategoryPicker         from '../categories/new_category_picker.component';
-import ActionPlanProposals    from './action_plan_proposals.component';
 
 import { fetchDistricts }     from '../districts/districts.actions';
 import { fetchCategories }    from '../categories/categories.actions';
@@ -23,7 +22,6 @@ class ActionPlanReviewer extends Component {
     if (session.is_reviewer) {
       return (
         <div>
-          <ActionPlanProposals actionPlan={actionPlan} />
           <h2>{I18n.t('action_plans.edit.editing')}</h2>
           <ScopePicker 
             namespace="action_plan"

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -9,13 +9,15 @@ import {
   changeWeight
 } from './action_plans.actions';
 
-import Loading            from '../application/loading.component';
-import DangerLink         from '../application/danger_link.component';
-import FilterMeta         from '../filters/filter_meta.component';
+import Loading              from '../application/loading.component';
+import SocialShareButtons   from '../application/social_share_buttons.component';
+import DangerLink           from '../application/danger_link.component';
+import FilterMeta           from '../filters/filter_meta.component';
 
-import ActionPlanReviewer from './action_plan_reviewer.component';
-import WeightControl from './weight_control.component';
-
+import ActionPlanStatistics from './action_plan_statistics.component';
+import ActionPlanProposals  from './action_plan_proposals.component';
+import ActionPlanReviewer   from './action_plan_reviewer.component';
+import WeightControl        from './weight_control.component';
 
 class ActionPlanShow extends Component {
   constructor(props) {
@@ -63,13 +65,14 @@ class ActionPlanShow extends Component {
         category,
         subcategory,
         district,
-        weight
+        weight,
+        statistics
       } = actionPlan;
 
       return (
         <div>
           <div className="row" id={`action_plan_${actionPlan.id}`}>
-            <div className="small-12 medium-12 column">
+            <div className="small-12 medium-9 column">
               <i className="icon-angle-left left"></i>&nbsp;
 
               <a className="left back" href="/action_plans" onClick={() => window.history.back()}>
@@ -96,13 +99,9 @@ class ActionPlanShow extends Component {
 
               { this.renderNotice() }
 
-              <h2>
-                <a href={url}>{title}</a>
-              </h2>
+              <h2><a href={url}>{title}</a></h2>
 
-              <p className="proposal-info">
-                <span>{ created_at }</span>
-              </p>
+              <p className="proposal-info"><span>{ created_at }</span></p>
 
               <div 
                 className="proposal-description"
@@ -116,7 +115,38 @@ class ActionPlanShow extends Component {
                 namespace="action_plans"
                 useServerLinks={ true }/>
 
+              <h2>Estat de l'actuacio</h2>
+              <p>TODO</p>
+
+              <h2>Alegacions relacionades</h2>
+              <p>TODO</p>
+
+              <ActionPlanProposals actionPlan={actionPlan} />
+
               <ActionPlanReviewer />
+            </div>
+
+            <aside className="small-12 medium-3 column">
+              <h3>{ I18n.t("proposals.show.share") }</h3>
+              <SocialShareButtons 
+                title={ title }
+                url={ url }/>
+              <div>
+                <h3>Autoria</h3>
+                <p>Ajuntament de Barcelona, Ecologistes en Accio, Joan BCN, Josefina92</p>
+                <hr />
+                <h3>Dades</h3>
+                <ActionPlanStatistics 
+                  statistics={statistics}>
+                </ActionPlanStatistics>
+                <hr />
+                <h3>Seguiment</h3>
+              </div>
+            </aside>
+
+            <div className="small-12 medium-12 column">
+              <h2>Actuacio construida a partir de les seguents cites presencials</h2>
+              <p>TODO</p>
             </div>
           </div>
         </div>

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -25,20 +25,19 @@ class ActionPlanShow extends Component {
     super(props);
 
     this.state = {
-      loading: true
+      loading: true,
+      editable: false
     }
   }
 
   componentDidMount() {
-    const { session } = this.props;
+    const { session, fetchActionPlan } = this.props;
 
-    this.props.fetchActionPlan(this.props.actionPlanId);
-  }
+    this.setState({ editable: session.is_reviewer });
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.actionPlan.id) {
+    fetchActionPlan(this.props.actionPlanId).then(() => {
       this.setState({ loading: false });
-    }
+    });
   }
 
   render() {
@@ -58,7 +57,6 @@ class ActionPlanShow extends Component {
         id,
         url,
         deleted,
-        new_revision_url,
         title, 
         description,
         created_at,
@@ -66,7 +64,6 @@ class ActionPlanShow extends Component {
         category,
         subcategory,
         district,
-        weight,
         statistics
       } = actionPlan;
 
@@ -80,25 +77,8 @@ class ActionPlanShow extends Component {
                 {I18n.t('proposals.show.back_link')}
               </a>
 
-              <DangerLink className="delete-action-plan button danger tiny radius right" onClick={ () => this.props.deleteActionPlan(this.props.actionPlan.id) }>
-                <i className="icon-cross"></i>
-                { I18n.t("components.action_plan_show.delete") }
-              </DangerLink>
-
-              <a href={new_revision_url} className="edit-proposal button success tiny radius right">
-                <i className="icon-edit"></i>
-                { I18n.t("components.action_plan_show.new_revision") }
-              </a>
-
-              { this.renderApproveButton() }
-
-              <span className="right">
-                <WeightControl
-                  weight={ weight }
-                  onUpdateWeight={ (weight) => this.props.changeWeight(id, weight)} />
-              </span>
-
-              { this.renderNotice() }
+              {this.renderReviewerActions()}
+              {this.renderNotice()}
 
               <h2><a href={url}>{title}</a></h2>
 
@@ -116,15 +96,16 @@ class ActionPlanShow extends Component {
                 namespace="action_plans"
                 useServerLinks={ true }/>
 
+              <ActionPlanReviewer visible={this.state.editable} />
+
               <h2>Estat de l'actuacio</h2>
               <p>TODO</p>
 
               <h2>Alegacions relacionades</h2>
               <p>TODO</p>
 
-              <ActionPlanProposals actionPlan={actionPlan} />
-
-              <ActionPlanMeetings />
+              <ActionPlanProposals actionPlan={actionPlan} editable={this.state.editable} />
+              <ActionPlanMeetings useServerLinks={true} />
             </div>
 
             <aside className="small-12 medium-3 column">
@@ -144,12 +125,6 @@ class ActionPlanShow extends Component {
                 <h3>Seguiment</h3>
               </div>
             </aside>
-          </div>
-
-          <div className="row">
-            <div className="small-12 medium-12 column">
-              <ActionPlanReviewer />
-            </div>
           </div>
         </div>
       );
@@ -178,6 +153,35 @@ class ActionPlanShow extends Component {
           { I18n.t("components.action_plan_show.approve") }
         </DangerLink>
       )
+    }
+  }
+
+  renderReviewerActions() {
+    const { actionPlan, deleteActionPlan, changeWeight } = this.props;
+    const { id, weight, new_revision_url } = actionPlan;
+
+    if (this.state.editable) {
+      return (
+        <span>
+          <DangerLink className="delete-action-plan button danger tiny radius right" onClick={() => deleteActionPlan(id) }>
+            <i className="icon-cross"></i>
+            { I18n.t("components.action_plan_show.delete") }
+          </DangerLink>
+
+          <a href={new_revision_url} className="edit-proposal button success tiny radius right">
+            <i className="icon-edit"></i>
+            { I18n.t("components.action_plan_show.new_revision") }
+          </a>
+
+          { this.renderApproveButton() }
+
+          <span className="right">
+            <WeightControl
+              weight={ weight }
+              onUpdateWeight={ (weight) => changeWeight(id, weight)} />
+          </span>
+        </span>
+      );
     }
   }
 }

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -16,6 +16,7 @@ import FilterMeta           from '../filters/filter_meta.component';
 
 import ActionPlanStatistics from './action_plan_statistics.component';
 import ActionPlanProposals  from './action_plan_proposals.component';
+import ActionPlanMeetings   from './action_plan_meetings.component';
 import ActionPlanReviewer   from './action_plan_reviewer.component';
 import WeightControl        from './weight_control.component';
 
@@ -123,7 +124,7 @@ class ActionPlanShow extends Component {
 
               <ActionPlanProposals actionPlan={actionPlan} />
 
-              <ActionPlanReviewer />
+              <ActionPlanMeetings />
             </div>
 
             <aside className="small-12 medium-3 column">
@@ -143,10 +144,11 @@ class ActionPlanShow extends Component {
                 <h3>Seguiment</h3>
               </div>
             </aside>
+          </div>
 
+          <div className="row">
             <div className="small-12 medium-12 column">
-              <h2>Actuacio construida a partir de les seguents cites presencials</h2>
-              <p>TODO</p>
+              <ActionPlanReviewer />
             </div>
           </div>
         </div>

--- a/app/frontend/action_plans/action_plans.actions.js
+++ b/app/frontend/action_plans/action_plans.actions.js
@@ -9,6 +9,7 @@ export const DELETE_ACTION_PLAN          = 'DELETE_ACTION_PLAN';
 export const UPDATE_ACTION_PLAN          = 'UPDATE_ACTION_PLAN';
 export const ADD_ACTION_PLAN_PROPOSAL    = 'ADD_ACTION_PLAN_PROPOSAL';
 export const REMOVE_ACTION_PLAN_PROPOSAL = 'REMOVE_ACTION_PLAN_PROPOSAL';
+export const FETCH_RELATED_MEETINGS      = 'FETCH_RELATED_MEETINGS';
 
 export function deleteActionPlan(id){
   const request = axios.delete(`${API_BASE_URL}/action_plans/${id}.json`);
@@ -73,6 +74,15 @@ export function fetchActionPlanProposals(actionPlanId) {
 
   return {
     type: FETCH_ACTION_PLAN_PROPOSALS,
+    payload: request
+  };
+}
+
+export function fetchRelatedMeetings(actionPlanId) {
+  const request = axios.get(`${API_BASE_URL}/action_plans/${actionPlanId}/meetings.json`);
+
+  return {
+    type: FETCH_RELATED_MEETINGS,
     payload: request
   };
 }

--- a/app/frontend/action_plans/action_plans.reducers.js
+++ b/app/frontend/action_plans/action_plans.reducers.js
@@ -2,6 +2,7 @@ import {
   FETCH_ACTION_PLANS, 
   FETCH_ACTION_PLAN,
   FETCH_ACTION_PLAN_PROPOSALS,
+  FETCH_RELATED_MEETINGS,
   APPEND_ACTION_PLANS_PAGE,
   DELETE_ACTION_PLAN,
   UPDATE_ACTION_PLAN,
@@ -44,6 +45,13 @@ export const actionPlan = function (state = {}, action) {
         ...state,
         actionPlansProposals
       };
+    case FETCH_RELATED_MEETINGS:
+      let meetings = action.payload.data.meetings;
+
+      return {
+        ...state,
+        meetings
+      }
     case DELETE_ACTION_PLAN:
       return {
         ...state,

--- a/app/frontend/action_plans/proposals_table.component.js
+++ b/app/frontend/action_plans/proposals_table.component.js
@@ -39,10 +39,12 @@ export default class ActionPlanProposalsTable extends Component {
   }
 
   renderRemoveButton(proposal) {
-    if (this.props.onRemoveProposal) {
+    const {onRemoveProposal, editable} = this.props;
+
+    if (editable && onRemoveProposal) {
       return (
         <td>
-          <DangerLink onClick={(event) => this.props.onRemoveProposal(proposal) }>
+          <DangerLink onClick={(event) => onRemoveProposal(proposal) }>
             {I18n.t("components.proposals_table.remove")}
           </DangerLink>
         </td>

--- a/app/frontend/categories/categories.actions.js
+++ b/app/frontend/categories/categories.actions.js
@@ -1,13 +1,29 @@
+import { Promise }      from 'es6-promise';
 import axios            from 'axios';
 import { API_BASE_URL } from '../proposals/proposals.actions';
 
 export const FETCH_CATEGORIES = 'FETCH_CATEGORIES';
 
 export function fetchCategories () {
-  const request = axios.get(`${API_BASE_URL}/categories.json`);
+  const promise =  new Promise((resolve, reject) => {
+    axios.get(`${API_BASE_URL}/categories.json`).then(({ data }) => {
+      let { categories } = data;
+
+      axios.get(`${API_BASE_URL}/subcategories.json`).then(({ data }) => {
+        let { subcategories } = data;
+
+        categories = categories.map(category => ({
+          ...category,
+          subcategories: subcategories.filter(sc => sc.category_id === category.id)
+        }));
+
+        resolve({ categories });
+      }, reject);
+    }, reject);
+  });
 
   return {
     type: FETCH_CATEGORIES,
-    payload: request
+    payload: promise
   };
 }

--- a/app/frontend/categories/categories.reducers.js
+++ b/app/frontend/categories/categories.reducers.js
@@ -3,7 +3,7 @@ import { FETCH_CATEGORIES } from './categories.actions';
 export default function (state = [], action) {
   switch (action.type) {
     case FETCH_CATEGORIES:
-      return action.payload.data.categories
+      return action.payload.categories
   }
   return state;
 }

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -1,8 +1,6 @@
 class CategorySerializer < ActiveModel::Serializer
   attributes :id, :name
 
-  has_many :subcategories
-
   def name
     object.name[I18n.locale.to_s]
   end

--- a/app/serializers/meeting_serializer.rb
+++ b/app/serializers/meeting_serializer.rb
@@ -1,24 +1,14 @@
 class MeetingSerializer < ActiveModel::Serializer
   attributes :id, :slug, :title, :description, :address, :address_latitude, :url,
-             :address_longitude, :held_at, :start_at, :end_at, :category,
-             :subcategory, :closed, :district, :address_details, :organizations,
-             :close_report, :tags, :attendee_count, :interventions,
-             :proposal_ids, :pictures
+             :address_longitude, :held_at, :start_at, :end_at, :category_id,
+             :subcategory_id, :closed, :district, :address_details, :organizations,
+             :close_report, :attendee_count, :interventions
+
+  has_one :category
+  has_one :subcategory
 
   def held_at
     I18n.l(object.held_at)
-  end
-
-  def pictures
-    object.pictures.map{ |p| p.file.url }
-  end
-
-  def proposal_ids
-    object.proposals.map(&:id)
-  end
-
-  def tags
-    object.tags.map(&:name)
   end
 
   def district
@@ -40,20 +30,6 @@ class MeetingSerializer < ActiveModel::Serializer
 
   def end_at
     object.end_at.present? ? I18n.l(object.end_at) : nil
-  end
-
-  def category
-    {
-      id: object.category.id,
-      name: object.category.decorate.name
-    }
-  end
-
-  def subcategory
-    {
-      id: object.subcategory.id,
-      name: object.subcategory.decorate.name
-    }
   end
 
   def url

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -32,7 +32,7 @@ class ProposalSerializer < ActiveModel::Serializer
   end
 
   def voted
-    object.votes_for.detect do |v| 
+    scope && scope.current_user && object.votes_for.detect do |v| 
       v.voter_type == 'User' && v.voter_id == scope.current_user.id && v.vote_flag
     end.present?
   end
@@ -54,7 +54,9 @@ class ProposalSerializer < ActiveModel::Serializer
   end
 
   def flagged
-    scope && object.flags.detect { |flag| flag.user_id == scope.current_user.id }.present?
+    scope && scope.current_user && object.flags.detect do |flag| 
+      flag.user_id == scope.current_user.id
+    end.present?
   end
 
   def url

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -8,6 +8,7 @@ class ProposalSerializer < ActiveModel::Serializer
   
   has_one :category
   has_one :subcategory
+  has_one :author
 
   # Name collision with serialization `scope`
   def scope_

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -1,16 +1,13 @@
 class ProposalSerializer < ActiveModel::Serializer
-attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source,
-           :total_votes, :voted, :votable, :closed, :official, :from_meeting,
-           :editable, :conflictive?, :external_url, :hidden?, :can_hide, :can_hide_author,
-           :flagged, :code, :arguable?, :permissions, :total_positive_comments,
-           :total_negative_comments, :total_neutral_comments, :total_comments,
-           :total_positive_comments, :total_negative_comments, :total_neutral_comments,
-           :social_media_image_url
-
+  attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source,
+             :total_votes, :voted, :votable, :closed, :official, :from_meeting,
+             :editable, :conflictive?, :external_url, :hidden?, :can_hide, :can_hide_author,
+             :flagged, :code, :arguable?, :permissions, :total_positive_comments,
+             :total_negative_comments, :total_neutral_comments, :total_comments,
+             :social_media_image_url, :author_id
+  
   has_one :category
   has_one :subcategory
-  has_one :author
-  has_one :answer
 
   # Name collision with serialization `scope`
   def scope_
@@ -18,23 +15,25 @@ attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source
   end
 
   def total_comments
-    object.comments.count
+    object.comments.length
   end
 
   def total_positive_comments
-    object.comments.positive.count
+    object.comments.select { |c| c.alignment && c.alignment > 0 }.count
   end
 
   def total_negative_comments
-    object.comments.negative.count
+    object.comments.select { |c| c.alignment && c.alignment < 0 }.count
   end
 
   def total_neutral_comments
-    object.comments.neutral.count
+    object.comments.select { |c| c.alignment && c.alignment == 0 }.count
   end
 
   def voted
-    scope && scope.current_user && scope.current_user.voted_up_on?(object)
+    object.votes_for.detect do |v| 
+      v.voter_type == 'User' && v.voter_id == scope.current_user.id && v.vote_flag
+    end.present?
   end
 
   def votable
@@ -54,11 +53,11 @@ attributes :id, :title, :url, :summary, :created_at, :scope_, :district, :source
   end
 
   def flagged
-    scope && Flag.flagged?(scope.current_user, object)
+    scope && object.flags.detect { |flag| flag.user_id == scope.current_user.id }.present?
   end
 
   def url
-    scope && scope.proposal_url(object)
+   scope && scope.proposal_url(object)
   end
 
   def created_at

--- a/app/serializers/subcategory_serializer.rb
+++ b/app/serializers/subcategory_serializer.rb
@@ -1,5 +1,5 @@
 class SubcategorySerializer < ActiveModel::Serializer
-  attributes :id, :name
+  attributes :id, :name, :category_id
 
   def name
     object.name[I18n.locale.to_s]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,6 +284,7 @@ Rails.application.routes.draw do
     end
     resources :action_plans do
       resources :proposals, controller: 'action_plans/proposals'
+      resources :meetings, controller: 'action_plans/meetings'
     end
     resources :meetings, only: [:index]
     resources :follows, only: [:index, :create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,6 +265,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :districts, only: [:index]
     resources :categories, only: [:index]
+    resources :subcategories, only: [:index]
     resources :proposals, only: [:show, :index, :update] do
       member do
         get :references

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "redux-promise": "^0.5.3",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.14",
-    "whatwg-fetch": "^0.11.0"
+    "whatwg-fetch": "^0.11.0",
+    "html-ellipsis": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -44,7 +45,6 @@
     "cheerio": "^0.20.0",
     "enzyme": "^2.2.0",
     "jasmine-core": "^2.4.1",
-    "html-ellipsis": "^1.1.1",
     "karma": "^0.13.19",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-chai": "^0.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,8 +57,14 @@ module.exports = {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract("style-loader", "css-loader")
       },
-      { test: require.resolve("react"), loader: "expose?React" },
-      { test: require.resolve("react-dom"), loader: "expose?ReactDOM" }
+      { 
+        test: require.resolve("react"),
+        loader: "expose?React" 
+      },
+      { 
+        test: require.resolve("react-dom"),
+        loader: "expose?ReactDOM"
+      }
     ]
   }
 };


### PR DESCRIPTION
# What and why

I have detected a few problems with the current implementation of our API which caused a slow performance on some queries.

First, I simplify some serializers so they don't send redundant information. Then I fixed some N+1 queries using eager loading of some associations.

Finally I added a `subcategories` API endpoint because they are not embedded on the `categories` API response.
# GIF Tax

![](https://media.giphy.com/media/LYkySt2YmPHkQ/giphy.gif)
