### PR TITLE
[refactor] Simplify react-redux connect calls

### DIFF
--- a/app/frontend/action_plans/action_plan_meetings.component.js
+++ b/app/frontend/action_plans/action_plan_meetings.component.js
@@ -1,5 +1,4 @@
 import { Component }            from 'react';
-import { bindActionCreators }   from 'redux';
 import { connect }              from 'react-redux';
 
 import Loading                  from '../application/loading.component';
@@ -64,12 +63,7 @@ class ActionPlanMeetings extends Component {
   }
 }
 
-function mapStateToProps({ actionPlan }) {
-  return { actionPlan };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchRelatedMeetings }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ActionPlanMeetings);
+export default connect(
+  ({ actionPlan }) => ({ actionPlan }),
+  { fetchRelatedMeetings }
+)(ActionPlanMeetings);

--- a/app/frontend/action_plans/action_plan_meetings.component.js
+++ b/app/frontend/action_plans/action_plan_meetings.component.js
@@ -1,11 +1,11 @@
-import { Component }            from 'react';
-import { connect }              from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import Loading                  from '../application/loading.component';
+import Loading       from '../application/loading.component';
 
-import Meeting                  from '../meetings/meeting.component';
+import Meeting       from '../meetings/meeting.component';
 
-import { fetchRelatedMeetings } from './action_plans.actions';
+import * as actions  from './action_plans.actions';
 
 class ActionPlanMeetings extends Component {
   constructor(props) {
@@ -65,5 +65,5 @@ class ActionPlanMeetings extends Component {
 
 export default connect(
   ({ actionPlan }) => ({ actionPlan }),
-  { fetchRelatedMeetings }
+  actions
 )(ActionPlanMeetings);

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -6,12 +6,7 @@ import Loading                    from '../application/loading.component';
 import ProposalsAutocompleteInput from '../proposals/proposals_autocomplete_input.component';
 import ProposalsTable             from './proposals_table.component';
 
-import { 
-  addActionPlanProposal,
-  removeActionPlanProposal,
-  changeActionPlansProposalLevel,
-  fetchActionPlanProposals 
-} from './action_plans.actions';
+import * as actions               from './action_plans.actions';
 
 
 class ActionPlanProposals extends Component {
@@ -66,12 +61,4 @@ class ActionPlanProposals extends Component {
   }
 }
 
-export default connect(
-  null,
-  {
-    addActionPlanProposal,
-    changeActionPlansProposalLevel,
-    removeActionPlanProposal,
-    fetchActionPlanProposals 
-  }
-)(ActionPlanProposals);
+export default connect(null, actions)(ActionPlanProposals);

--- a/app/frontend/action_plans/action_plan_proposals.component.js
+++ b/app/frontend/action_plans/action_plan_proposals.component.js
@@ -1,5 +1,4 @@
 import { Component }              from 'react';
-import { bindActionCreators }     from 'redux';
 import { connect }                from 'react-redux';
 
 import Loading                    from '../application/loading.component';
@@ -67,13 +66,12 @@ class ActionPlanProposals extends Component {
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ 
+export default connect(
+  null,
+  {
     addActionPlanProposal,
     changeActionPlansProposalLevel,
     removeActionPlanProposal,
     fetchActionPlanProposals 
-  }, dispatch);
-}
-
-export default connect(null, mapDispatchToProps)(ActionPlanProposals);
+  }
+)(ActionPlanProposals);

--- a/app/frontend/action_plans/action_plan_reviewer.component.js
+++ b/app/frontend/action_plans/action_plan_reviewer.component.js
@@ -1,6 +1,5 @@
 import { Component }          from 'react';
 import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import ScopePicker            from '../scope/scope_picker.component';
 import CategoryPicker         from '../categories/new_category_picker.component';
@@ -43,16 +42,11 @@ class ActionPlanReviewer extends Component {
   }
 }
 
-function mapStateToProps({ actionPlan }) {
-  return { actionPlan };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ 
+export default connect(
+  ({ actionPlan }) => ({ actionPlan }),
+  {
     fetchDistricts,
     fetchCategories,
     updateActionPlan
-  }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ActionPlanReviewer);
+  }
+)(ActionPlanReviewer);

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -1,12 +1,7 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }        from 'react';
+import { connect }          from 'react-redux';
 
-import { 
-  fetchActionPlan,
-  deleteActionPlan,
-  approveActionPlan,
-  changeWeight
-} from './action_plans.actions';
+import * as actions         from './action_plans.actions';
 
 import Loading              from '../application/loading.component';
 import SocialShareButtons   from '../application/social_share_buttons.component';
@@ -187,10 +182,5 @@ class ActionPlanShow extends Component {
 
 export default connect(
   ({ session, actionPlan }) => ({ session, actionPlan }),
-  {
-    fetchActionPlan,
-    deleteActionPlan,
-    approveActionPlan,
-    changeWeight
-  }
+  actions
 )(ActionPlanShow);

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -1,6 +1,5 @@
 import { Component }          from 'react';
 import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import { 
   fetchActionPlan,
@@ -186,18 +185,12 @@ class ActionPlanShow extends Component {
   }
 }
 
-
-function mapStateToProps({ session, actionPlan }) {
-  return { session, actionPlan };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ 
+export default connect(
+  ({ session, actionPlan }) => ({ session, actionPlan }),
+  {
     fetchActionPlan,
     deleteActionPlan,
     approveActionPlan,
     changeWeight
-  }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ActionPlanShow);
+  }
+)(ActionPlanShow);

--- a/app/frontend/action_plans/action_plans.component.js
+++ b/app/frontend/action_plans/action_plans.component.js
@@ -1,15 +1,15 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }      from 'react';
+import { connect }        from 'react-redux';
 
-import Loading                from '../application/loading.component';
-import InfinitePagination     from '../pagination/infinite_pagination.component';
-import OrderSelector          from '../order/order_selector.component';
+import Loading            from '../application/loading.component';
+import InfinitePagination from '../pagination/infinite_pagination.component';
+import OrderSelector      from '../order/order_selector.component';
 
-import ActionPlansSidebar     from './action_plans_sidebar.component';
-import ActionPlansList        from './action_plans_list.component';
-import DownloadButton         from './download_button.component';
+import ActionPlansSidebar from './action_plans_sidebar.component';
+import ActionPlansList    from './action_plans_list.component';
+import DownloadButton     from './download_button.component';
 
-import { fetchActionPlans, appendActionPlansPage } from './action_plans.actions';
+import * as actions       from './action_plans.actions';
 
 class ActionPlans extends Component {
   constructor(props) {
@@ -92,5 +92,5 @@ export default connect(
   ({ actionPlans, filters, order, pagination, seed, count }) => (
     { actionPlans, filters, order, pagination, seed, count }
   ),
-  { fetchActionPlans, appendActionPlansPage }
+  actions
 )(ActionPlans);

--- a/app/frontend/action_plans/action_plans.component.js
+++ b/app/frontend/action_plans/action_plans.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import Loading                from '../application/loading.component';
@@ -89,12 +88,9 @@ class ActionPlans extends Component {
   }
 }
 
-function mapStateToProps({ actionPlans, filters, order, pagination, seed, count }) {
-  return { actionPlans, filters, order, pagination, seed, count };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchActionPlans, appendActionPlansPage }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ActionPlans);
+export default connect(
+  ({ actionPlans, filters, order, pagination, seed, count }) => (
+    { actionPlans, filters, order, pagination, seed, count }
+  ),
+  { fetchActionPlans, appendActionPlansPage }
+)(ActionPlans);

--- a/app/frontend/action_plans/action_plans_filters.component.js
+++ b/app/frontend/action_plans/action_plans_filters.component.js
@@ -1,18 +1,18 @@
-import { Component }                    from 'react';
-import { connect }                      from 'react-redux';
+import { Component }                from 'react';
+import { connect }                  from 'react-redux';
 
-import { setFilterGroup, clearFilters } from '../filters/filters.actions';
+import * as actions                 from '../filters/filters.actions';
 
-import SearchFilter                     from '../filters/search_filter.component';
-import ScopeFilterOptionGroup           from '../filters/scope_filter_option_group.component';
-import CategoryFilterOptionGroup        from '../filters/category_filter_option_group.component';
-import SubcategoryFilterOptionGroup     from '../filters/subcategory_filter_option_group.component';
-import ActionPlanReviewFilter           from '../filters/action_plan_review_filter.component';
-import TagCloudFilter                   from '../filters/tag_cloud_filter.component';
-import UserInteractionFilter            from '../filters/user_interaction_filter.component';
+import SearchFilter                 from '../filters/search_filter.component';
+import ScopeFilterOptionGroup       from '../filters/scope_filter_option_group.component';
+import CategoryFilterOptionGroup    from '../filters/category_filter_option_group.component';
+import SubcategoryFilterOptionGroup from '../filters/subcategory_filter_option_group.component';
+import ActionPlanReviewFilter       from '../filters/action_plan_review_filter.component';
+import TagCloudFilter               from '../filters/tag_cloud_filter.component';
+import UserInteractionFilter        from '../filters/user_interaction_filter.component';
 
-import FilterOptionGroup                from '../filters/filter_option_group.component';
-import FilterOption                     from '../filters/filter_option.component';
+import FilterOptionGroup            from '../filters/filter_option_group.component';
+import FilterOption                 from '../filters/filter_option.component';
 
 class ActionPlansFilters extends Component {
   render() {
@@ -40,8 +40,5 @@ class ActionPlansFilters extends Component {
 
 export default connect(
   ({ filters }) => ({ filters }),
-  {
-    setFilterGroup,
-    clearFilters
-  }
+  actions
 )(ActionPlansFilters);

--- a/app/frontend/action_plans/action_plans_filters.component.js
+++ b/app/frontend/action_plans/action_plans_filters.component.js
@@ -1,5 +1,4 @@
 import { Component }                    from 'react';
-import { bindActionCreators }           from 'redux';
 import { connect }                      from 'react-redux';
 
 import { setFilterGroup, clearFilters } from '../filters/filters.actions';
@@ -39,14 +38,10 @@ class ActionPlansFilters extends Component {
   }
 }
 
-function mapStateToProps({ filters }) {
-  return {
-    filters
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup, clearFilters }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ActionPlansFilters);
+export default connect(
+  ({ filters }) => ({ filters }),
+  {
+    setFilterGroup,
+    clearFilters
+  }
+)(ActionPlansFilters);

--- a/app/frontend/action_plans/new_action_plan_button.component.js
+++ b/app/frontend/action_plans/new_action_plan_button.component.js
@@ -14,8 +14,6 @@ class NewActionPlanButton extends Component {
   }
 }
 
-function mapStateToProps({ session }) {
-  return { session };
-}
-
-export default connect(mapStateToProps)(NewActionPlanButton);
+export default connect(
+  ({ session }) => ({ session })
+)(NewActionPlanButton);

--- a/app/frontend/application/flag_actions.component.js
+++ b/app/frontend/application/flag_actions.component.js
@@ -1,6 +1,5 @@
 import { Component }          from 'react';
 import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 class FlagActions extends Component {
   render() {
@@ -52,8 +51,6 @@ class FlagActions extends Component {
   }
 }
 
-function mapStateToProps({ session }) {
-  return { session };
-}
-
-export default connect(mapStateToProps)(FlagActions);
+export default connect(
+  ({ session }) => ({ session })
+)(FlagActions);

--- a/app/frontend/categories/new_category_picker.component.js
+++ b/app/frontend/categories/new_category_picker.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import SubcategoryPicker      from './new_subcategory_picker.component';
@@ -74,8 +73,6 @@ class CategoryPicker extends Component {
   }
 }
 
-function mapStateToProps({ categories }) {
-  return { categories };
-}
-
-export default connect(mapStateToProps)(CategoryPicker);
+export default connect(
+  ({ categories }) => ({ categories })
+)(CategoryPicker);

--- a/app/frontend/categories/new_subcategory_picker.component.js
+++ b/app/frontend/categories/new_subcategory_picker.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 export default class SubcategoryPicker extends Component {

--- a/app/frontend/comments/comment.component.js
+++ b/app/frontend/comments/comment.component.js
@@ -10,14 +10,7 @@ import DangerLink             from '../application/danger_link.component';
 import ChildrenComments       from './children_comments.component';
 import NewCommentForm         from './new_comment_form.component';
 
-import { 
-  flagComment, 
-  unFlagComment,
-  upVoteComment,
-  downVoteComment,
-  hideComment,
-  hideCommentAuthor
-} from './comments.actions';
+import * as actions from './comments.actions';
 
 class Comment extends Component {
   constructor(props) {
@@ -247,14 +240,4 @@ class Comment extends Component {
   }
 }
 
-export default connect(
-  null,
-  {
-    flagComment, 
-    unFlagComment,
-    upVoteComment,
-    downVoteComment,
-    hideComment,
-    hideCommentAuthor
-  }
-)(Comment);
+export default connect(null, actions)(Comment);

--- a/app/frontend/comments/comment.component.js
+++ b/app/frontend/comments/comment.component.js
@@ -1,6 +1,5 @@
 import { Component }          from 'react';
 import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import classNames             from 'classnames';
 
@@ -248,15 +247,14 @@ class Comment extends Component {
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ 
+export default connect(
+  null,
+  {
     flagComment, 
     unFlagComment,
     upVoteComment,
     downVoteComment,
     hideComment,
     hideCommentAuthor
-  }, dispatch);
-}
-
-export default connect(null, mapDispatchToProps)(Comment);
+  }
+)(Comment);

--- a/app/frontend/comments/comments.component.js
+++ b/app/frontend/comments/comments.component.js
@@ -1,13 +1,13 @@
-import { Component }                         from 'react';
-import { connect }                           from 'react-redux';
+import { Component }         from 'react';
+import { connect }           from 'react-redux';
 
-import { fetchComments, appendCommentsPage } from './comments.actions';
+import * as actions          from './comments.actions';
 
-import Loading                               from '../application/loading.component';
-import InfinitePagination                    from '../pagination/infinite_pagination.component';
-import CommentsOrderSelector                 from './comments_order_selector.component';
-import Comment                               from './comment.component';
-import NewCommentForm                        from './new_comment_form.component';
+import Loading               from '../application/loading.component';
+import InfinitePagination    from '../pagination/infinite_pagination.component';
+import CommentsOrderSelector from './comments_order_selector.component';
+import Comment               from './comment.component';
+import NewCommentForm        from './new_comment_form.component';
 
 class Comments extends Component {
   constructor(props) {
@@ -187,10 +187,4 @@ function mapStateToProps(state, { commentable }) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  {
-    fetchComments,
-    appendCommentsPage
-  }
-)(Comments);
+export default connect(mapStateToProps, actions)(Comments);

--- a/app/frontend/comments/comments.component.js
+++ b/app/frontend/comments/comments.component.js
@@ -1,6 +1,5 @@
 import { Component }                         from 'react';
 import { connect }                           from 'react-redux';
-import { bindActionCreators }                from 'redux';
 
 import { fetchComments, appendCommentsPage } from './comments.actions';
 
@@ -188,8 +187,10 @@ function mapStateToProps(state, { commentable }) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchComments, appendCommentsPage }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Comments);
+export default connect(
+  mapStateToProps,
+  {
+    fetchComments,
+    appendCommentsPage
+  }
+)(Comments);

--- a/app/frontend/comments/comments_order_selector.component.js
+++ b/app/frontend/comments/comments_order_selector.component.js
@@ -1,6 +1,5 @@
 import { Component }          from 'react';
 import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import { setOrder }           from '../order/order.actions';
 
@@ -34,12 +33,7 @@ class CommentsOrderSelector extends Component {
   }
 }
 
-function mapStateToProps({ order }) {
-  return { order };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setOrder }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(CommentsOrderSelector);
+export default connect(
+  ({ order }) => ({ order }),
+  { setOrder }
+)(CommentsOrderSelector);

--- a/app/frontend/comments/comments_order_selector.component.js
+++ b/app/frontend/comments/comments_order_selector.component.js
@@ -1,7 +1,7 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import { setOrder }           from '../order/order.actions';
+import * as actions  from '../order/order.actions';
 
 class CommentsOrderSelector extends Component {
   componentDidMount() {
@@ -35,5 +35,5 @@ class CommentsOrderSelector extends Component {
 
 export default connect(
   ({ order }) => ({ order }),
-  { setOrder }
+  actions
 )(CommentsOrderSelector);

--- a/app/frontend/comments/new_comment_form.component.js
+++ b/app/frontend/comments/new_comment_form.component.js
@@ -1,6 +1,5 @@
 import { Component }          from 'react';
 import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import Loading                from '../application/loading.component';
 
@@ -186,14 +185,7 @@ class NewCommentForm extends Component {
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ addNewComment }, dispatch);
-}
-
-export default connect(null, mapDispatchToProps)(NewCommentForm);
-//<% if can? :comment_as_administrator, commentable %>
-//  <div class="right">
-//    <%= f.check_box :as_administrator, id: "comment-as-administrator-#{css_id}",label: false %>
-//    <%= label_tag "comment-as-administrator-#{css_id}", t("comments.form.comment_as_admin"), class: "checkbox" %>
-//  </div>
-//<% end %>
+export default connect(
+  null,
+  { addNewComment }
+)(NewCommentForm);

--- a/app/frontend/comments/new_comment_form.component.js
+++ b/app/frontend/comments/new_comment_form.component.js
@@ -1,9 +1,9 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import Loading                from '../application/loading.component';
+import Loading       from '../application/loading.component';
 
-import { addNewComment }      from './comments.actions';
+import * as actions  from './comments.actions';
 
 class NewCommentForm extends Component {
   constructor(props) {
@@ -185,7 +185,4 @@ class NewCommentForm extends Component {
   }
 }
 
-export default connect(
-  null,
-  { addNewComment }
-)(NewCommentForm);
+export default connect(null, actions)(NewCommentForm);

--- a/app/frontend/debates/debate_show.component.js
+++ b/app/frontend/debates/debate_show.component.js
@@ -1,6 +1,5 @@
 import { Component }          from 'react';
 import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import { 
   fetchDebate, 
@@ -47,14 +46,7 @@ class DebateShow extends Component {
   }
 }
 
-function mapStateToProps({ session, debate }) {
-  return { session, debate };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ 
-    fetchDebate 
-  }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(DebateShow);
+export default connect(
+  ({ session, debate }) => ({ session, debate }),
+  { fetchDebate }
+)(DebateShow);

--- a/app/frontend/debates/debate_show.component.js
+++ b/app/frontend/debates/debate_show.component.js
@@ -1,12 +1,10 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import { 
-  fetchDebate, 
-} from './debates.actions';
+import * as actions  from './debates.actions';
 
-import Loading              from '../application/loading.component';
-import Comments             from '../comments/comments.component';
+import Loading       from '../application/loading.component';
+import Comments      from '../comments/comments.component';
 
 class DebateShow extends Component {
   constructor(props) {
@@ -48,5 +46,5 @@ class DebateShow extends Component {
 
 export default connect(
   ({ session, debate }) => ({ session, debate }),
-  { fetchDebate }
+  actions
 )(DebateShow);

--- a/app/frontend/filters/action_plan_review_filter.component.js
+++ b/app/frontend/filters/action_plan_review_filter.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import FilterOptionGroup      from './filter_option_group.component';
@@ -36,12 +35,7 @@ class ActionPlanReviewFilter extends Component {
   }
 }
 
-function mapStateToProps({ filters, session }) {
-  return { filters, session };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ActionPlanReviewFilter);
+export default connect(
+  ({ filters, session }) => ({filters, session }),
+  { setFilterGroup }
+)(ActionPlanReviewFilter);

--- a/app/frontend/filters/action_plan_review_filter.component.js
+++ b/app/frontend/filters/action_plan_review_filter.component.js
@@ -1,10 +1,10 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }     from 'react';
+import { connect }       from 'react-redux';
 
-import FilterOptionGroup      from './filter_option_group.component';
-import FilterOption           from './filter_option.component';
+import FilterOptionGroup from './filter_option_group.component';
+import FilterOption      from './filter_option.component';
 
-import { setFilterGroup }     from './filters.actions';
+import * as actions      from './filters.actions';
 
 class ActionPlanReviewFilter extends Component {
   render() {
@@ -37,5 +37,5 @@ class ActionPlanReviewFilter extends Component {
 
 export default connect(
   ({ filters, session }) => ({filters, session }),
-  { setFilterGroup }
+  actions
 )(ActionPlanReviewFilter);

--- a/app/frontend/filters/category_filter_option_group.component.js
+++ b/app/frontend/filters/category_filter_option_group.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { fetchCategories }    from '../categories/categories.actions';
@@ -32,15 +31,10 @@ class CategoryFilterOptionGroup extends Component {
   }
 }
 
-function mapStateToProps({ filters, categories }) {
-  return {
-    filters,
-    categories
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchCategories, setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(CategoryFilterOptionGroup);
+export default connect(
+  ({ filters, categories }) => ({ filters, categories }),
+  {
+    fetchCategories,
+    setFilterGroup
+  }
+)(CategoryFilterOptionGroup);

--- a/app/frontend/filters/filter_link.component.js
+++ b/app/frontend/filters/filter_link.component.js
@@ -1,7 +1,7 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import { setFilterGroup }     from './filters.actions';
+import * as actions  from './filters.actions';
 
 class FilterLink extends Component {
   render() {
@@ -36,5 +36,5 @@ class FilterLink extends Component {
 
 export default connect(
   ({ categories, filters }) => ({ filters, categories }),
-  { setFilterGroup }
+  actions
 )(FilterLink);

--- a/app/frontend/filters/filter_link.component.js
+++ b/app/frontend/filters/filter_link.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { setFilterGroup }     from './filters.actions';
@@ -35,15 +34,7 @@ class FilterLink extends Component {
   }
 }
 
-function mapStateToProps({ categories, filters }) {
-  return {
-    filters,
-    categories
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(FilterLink);
+export default connect(
+  ({ categories, filters }) => ({ filters, categories }),
+  { setFilterGroup }
+)(FilterLink);

--- a/app/frontend/filters/filter_tabs.component.js
+++ b/app/frontend/filters/filter_tabs.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { setFilterGroup }     from '../filters/filters.actions';
@@ -26,14 +25,7 @@ const FilterTabs = ({
   </div>
 );
 
-function mapStateToProps({ filters }) {
-  return {
-    filters
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(FilterTabs);
+export default connect(
+  ({ filters }) => ({ filters }),
+  { setFilterGroup }
+)(FilterTabs);

--- a/app/frontend/filters/filter_tabs.component.js
+++ b/app/frontend/filters/filter_tabs.component.js
@@ -1,10 +1,10 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }     from 'react';
+import { connect }       from 'react-redux';
 
-import { setFilterGroup }     from '../filters/filters.actions';
+import * as actions      from '../filters/filters.actions';
 
-import FilterOptionGroup      from '../filters/filter_option_group.component';
-import FilterOption           from '../filters/filter_option.component';
+import FilterOptionGroup from '../filters/filter_option_group.component';
+import FilterOption      from '../filters/filter_option.component';
 
 const FilterTabs = ({ 
   filters,
@@ -27,5 +27,5 @@ const FilterTabs = ({
 
 export default connect(
   ({ filters }) => ({ filters }),
-  { setFilterGroup }
+  actions
 )(FilterTabs);

--- a/app/frontend/filters/reviewer_filter.component.js
+++ b/app/frontend/filters/reviewer_filter.component.js
@@ -1,10 +1,10 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }     from 'react';
+import { connect }       from 'react-redux';
 
-import FilterOptionGroup      from './filter_option_group.component';
-import FilterOption           from './filter_option.component';
+import FilterOptionGroup from './filter_option_group.component';
+import FilterOption      from './filter_option.component';
 
-import { setFilterGroup }     from './filters.actions';
+import * as actions      from './filters.actions';
 
 class ReviewerFilter extends Component {
   render() {
@@ -55,5 +55,5 @@ class ReviewerFilter extends Component {
 
 export default connect(
   ({ filters, session }) => ({ filters, session }),
-  { setFilterGroup }
+  actions
 )(ReviewerFilter);

--- a/app/frontend/filters/reviewer_filter.component.js
+++ b/app/frontend/filters/reviewer_filter.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import FilterOptionGroup      from './filter_option_group.component';
@@ -54,12 +53,7 @@ class ReviewerFilter extends Component {
   }
 }
 
-function mapStateToProps({ filters, session }) {
-  return { filters, session };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ReviewerFilter);
+export default connect(
+  ({ filters, session }) => ({ filters, session }),
+  { setFilterGroup }
+)(ReviewerFilter);

--- a/app/frontend/filters/scope_filter_option_group.component.js
+++ b/app/frontend/filters/scope_filter_option_group.component.js
@@ -41,5 +41,8 @@ class ScopeFilterOptionGroup extends Component {
 
 export default connect(
   ({ filters, districts }) => ({ filters, districts }),
-  { fetchDistricts, setFilterGroup }
+  {
+    fetchDistricts,
+    setFilterGroup
+  }
 )(ScopeFilterOptionGroup);

--- a/app/frontend/filters/scope_filter_option_group.component.js
+++ b/app/frontend/filters/scope_filter_option_group.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { fetchDistricts }     from '../districts/districts.actions';
@@ -40,15 +39,7 @@ class ScopeFilterOptionGroup extends Component {
   }
 }
 
-function mapStateToProps({ filters, districts }) {
-  return {
-    filters,
-    districts
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchDistricts, setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ScopeFilterOptionGroup);
+export default connect(
+  ({ filters, districts }) => ({ filters, districts }),
+  { fetchDistricts, setFilterGroup }
+)(ScopeFilterOptionGroup);

--- a/app/frontend/filters/search_filter.component.js
+++ b/app/frontend/filters/search_filter.component.js
@@ -1,7 +1,7 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import { setFilterText }      from './filters.actions';
+import * as actions  from './filters.actions';
 
 class SearchFilter extends Component {
   constructor(props) {
@@ -52,7 +52,4 @@ class SearchFilter extends Component {
 
 }
 
-export default connect(
-  null,
-  { setFilterText }
-)(SearchFilter);
+export default connect(null, actions)(SearchFilter);

--- a/app/frontend/filters/search_filter.component.js
+++ b/app/frontend/filters/search_filter.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { setFilterText }      from './filters.actions';
@@ -53,8 +52,7 @@ class SearchFilter extends Component {
 
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterText }, dispatch);
-}
-
-export default connect(null, mapDispatchToProps)(SearchFilter);
+export default connect(
+  null,
+  { setFilterText }
+)(SearchFilter);

--- a/app/frontend/filters/subcategory_filter_option_group.component.js
+++ b/app/frontend/filters/subcategory_filter_option_group.component.js
@@ -1,10 +1,10 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }     from 'react';
+import { connect }       from 'react-redux';
 
-import { setFilterGroup }     from './filters.actions';
+import * as actions      from './filters.actions';
 
-import FilterOptionGroup      from './filter_option_group.component';
-import FilterOption           from './filter_option.component';
+import FilterOptionGroup from './filter_option_group.component';
+import FilterOption      from './filter_option.component';
 
 class SubcategoryFilterOptionGroup extends Component {
   render() {
@@ -34,5 +34,5 @@ class SubcategoryFilterOptionGroup extends Component {
 
 export default connect(
   ({ categories, filters }) => ({ categories, filters }),
-  { setFilterGroup }
+  actions
 )(SubcategoryFilterOptionGroup);

--- a/app/frontend/filters/subcategory_filter_option_group.component.js
+++ b/app/frontend/filters/subcategory_filter_option_group.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { setFilterGroup }     from './filters.actions';
@@ -33,15 +32,7 @@ class SubcategoryFilterOptionGroup extends Component {
   }
 }
 
-function mapStateToProps({ categories, filters }) {
-  return {
-    categories,
-    filters
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(SubcategoryFilterOptionGroup);
+export default connect(
+  ({ categories, filters }) => ({ categories, filters }),
+  { setFilterGroup }
+)(SubcategoryFilterOptionGroup);

--- a/app/frontend/filters/tag_cloud_filter.component.js
+++ b/app/frontend/filters/tag_cloud_filter.component.js
@@ -1,7 +1,7 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import { toggleTag }          from './filters.actions';
+import * as actions  from './filters.actions';
 
 class TagCloudFilter extends Component {
   render() {
@@ -39,5 +39,5 @@ class TagCloudFilter extends Component {
 
 export default connect(
   ({ filters, tags }) => ({ filters, tags }),
-  { toggleTag }
+  actions
 )(TagCloudFilter);

--- a/app/frontend/filters/tag_cloud_filter.component.js
+++ b/app/frontend/filters/tag_cloud_filter.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { toggleTag }          from './filters.actions';
@@ -38,15 +37,7 @@ class TagCloudFilter extends Component {
   }
 }
 
-function mapStateToProps({ filters, tags }) {
-  return {
-    filters,
-    tags
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ toggleTag }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(TagCloudFilter);
+export default connect(
+  ({ filters, tags }) => ({ filters, tags }),
+  { toggleTag }
+)(TagCloudFilter);

--- a/app/frontend/filters/user_interaction_filter.component.js
+++ b/app/frontend/filters/user_interaction_filter.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import FilterOptionGroup      from './filter_option_group.component';
@@ -26,12 +25,7 @@ class ReviewerFilter extends Component {
   }
 }
 
-function mapStateToProps({ filters, session }) {
-  return { filters, session };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ReviewerFilter);
+export default connect(
+  ({ filters, session }) => ({ filters, session }),
+  { setFilterGroup }
+)(ReviewerFilter);

--- a/app/frontend/filters/user_interaction_filter.component.js
+++ b/app/frontend/filters/user_interaction_filter.component.js
@@ -1,10 +1,10 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }     from 'react';
+import { connect }       from 'react-redux';
 
-import FilterOptionGroup      from './filter_option_group.component';
-import FilterOption           from './filter_option.component';
+import FilterOptionGroup from './filter_option_group.component';
+import FilterOption      from './filter_option.component';
 
-import { setFilterGroup }     from './filters.actions';
+import * as actions      from './filters.actions';
 
 class ReviewerFilter extends Component {
   render() {
@@ -27,5 +27,5 @@ class ReviewerFilter extends Component {
 
 export default connect(
   ({ filters, session }) => ({ filters, session }),
-  { setFilterGroup }
+  actions
 )(ReviewerFilter);

--- a/app/frontend/follows/follow_button.component.js
+++ b/app/frontend/follows/follow_button.component.js
@@ -1,10 +1,10 @@
-import { Component }                     from 'react';
-import { connect }                       from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import SmartButton                       from '../application/smart_button.component';
-import Icon                              from '../application/icon.component';
+import SmartButton   from '../application/smart_button.component';
+import Icon          from '../application/icon.component';
 
-import { follow, unFollow, fetchFollow } from './follows.actions';
+import * as actions  from './follows.actions';
 
 export class FollowButton extends Component {
   componentDidMount() {
@@ -73,11 +73,4 @@ function mapStateToProps(state, { followingType }) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  {
-    follow,
-    unFollow,
-    fetchFollow
-  }
-)(FollowButton);
+export default connect(mapStateToProps, actions)(FollowButton);

--- a/app/frontend/follows/follow_button.component.js
+++ b/app/frontend/follows/follow_button.component.js
@@ -1,6 +1,5 @@
 import { Component }                     from 'react';
 import { connect }                       from 'react-redux';
-import { bindActionCreators }            from 'redux';
 
 import SmartButton                       from '../application/smart_button.component';
 import Icon                              from '../application/icon.component';
@@ -74,8 +73,11 @@ function mapStateToProps(state, { followingType }) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ follow, unFollow, fetchFollow }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(FollowButton);
+export default connect(
+  mapStateToProps,
+  {
+    follow,
+    unFollow,
+    fetchFollow
+  }
+)(FollowButton);

--- a/app/frontend/meetings/meetings.component.js
+++ b/app/frontend/meetings/meetings.component.js
@@ -1,5 +1,4 @@
 import { Component }                         from 'react';
-import { bindActionCreators }                from 'redux';
 import { connect }                           from 'react-redux';
 
 import Loading                               from '../application/loading.component';
@@ -76,12 +75,11 @@ class Meetings extends Component {
   }
 }
 
-function mapStateToProps({ meetings, filters, pagination }) {
-  return { meetings, filters, pagination };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchMeetings, appendMeetingsPage, setFilterGroup }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Meetings);
+export default connect(
+  ({ meetings, filters, pagination }) => ({ meetings, filters, pagination }),
+  {
+    fetchMeetings,
+    appendMeetingsPage,
+    setFilterGroup
+  }
+)(Meetings);

--- a/app/frontend/meetings/meetings_filters.component.js
+++ b/app/frontend/meetings/meetings_filters.component.js
@@ -1,16 +1,16 @@
-import { Component }                    from 'react';
-import { connect }                      from 'react-redux';
+import { Component }                from 'react';
+import { connect }                  from 'react-redux';
 
-import { setFilterGroup, clearFilters } from '../filters/filters.actions';
+import * as actions                 from '../filters/filters.actions';
 
-import SearchFilter                     from '../filters/search_filter.component';
-import ScopeFilterOptionGroup           from '../filters/scope_filter_option_group.component';
-import CategoryFilterOptionGroup        from '../filters/category_filter_option_group.component';
-import SubcategoryFilterOptionGroup     from '../filters/subcategory_filter_option_group.component';
-import TagCloudFilter                   from '../filters/tag_cloud_filter.component';
+import SearchFilter                 from '../filters/search_filter.component';
+import ScopeFilterOptionGroup       from '../filters/scope_filter_option_group.component';
+import CategoryFilterOptionGroup    from '../filters/category_filter_option_group.component';
+import SubcategoryFilterOptionGroup from '../filters/subcategory_filter_option_group.component';
+import TagCloudFilter               from '../filters/tag_cloud_filter.component';
 
-import FilterOptionGroup                from '../filters/filter_option_group.component';
-import FilterOption                     from '../filters/filter_option.component';
+import FilterOptionGroup            from '../filters/filter_option_group.component';
+import FilterOption                 from '../filters/filter_option.component';
 
 class MeetingsFilters extends Component {
   render() {
@@ -48,8 +48,5 @@ class MeetingsFilters extends Component {
 
 export default connect(
   ({ filters }) => ({ filters }),
-  {
-    setFilterGroup,
-    clearFilters
-  }
+  actions
 )(MeetingsFilters);

--- a/app/frontend/meetings/meetings_filters.component.js
+++ b/app/frontend/meetings/meetings_filters.component.js
@@ -1,5 +1,4 @@
 import { Component }                    from 'react';
-import { bindActionCreators }           from 'redux';
 import { connect }                      from 'react-redux';
 
 import { setFilterGroup, clearFilters } from '../filters/filters.actions';
@@ -47,14 +46,10 @@ class MeetingsFilters extends Component {
   }
 }
 
-function mapStateToProps({ filters }) {
-  return {
-    filters
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup, clearFilters }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(MeetingsFilters);
+export default connect(
+  ({ filters }) => ({ filters }),
+  {
+    setFilterGroup,
+    clearFilters
+  }
+)(MeetingsFilters);

--- a/app/frontend/order/order_selector.component.js
+++ b/app/frontend/order/order_selector.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import { setOrder       }     from '../order/order.actions';
@@ -24,15 +23,7 @@ class OrderSelector extends Component {
   }
 }
 
-function mapStateToProps({ order }) {
-  return {
-    order
-  }
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setOrder }, dispatch);
-}
-
-
-export default connect(mapStateToProps, mapDispatchToProps)(OrderSelector);
+export default connect(
+  ({ order }) => ({ order }),
+  { setOrder }
+)(OrderSelector);

--- a/app/frontend/order/order_selector.component.js
+++ b/app/frontend/order/order_selector.component.js
@@ -1,7 +1,7 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import { setOrder       }     from '../order/order.actions';
+import * as actions  from '../order/order.actions';
 
 class OrderSelector extends Component {
   render() {
@@ -25,5 +25,5 @@ class OrderSelector extends Component {
 
 export default connect(
   ({ order }) => ({ order }),
-  { setOrder }
+  actions
 )(OrderSelector);

--- a/app/frontend/proposals/new_proposal_button.component.js
+++ b/app/frontend/proposals/new_proposal_button.component.js
@@ -14,8 +14,6 @@ class NewProposalButton extends Component {
   }
 }
 
-function mapStateToProps({ session }) {
-  return { session };
-}
-
-export default connect(mapStateToProps)(NewProposalButton);
+export default connect(
+  ({ session }) => ({ session })
+)(NewProposalButton);

--- a/app/frontend/proposals/proposal_action_plans.component.js
+++ b/app/frontend/proposals/proposal_action_plans.component.js
@@ -1,5 +1,4 @@
 import { Component }            from 'react';
-import { bindActionCreators }   from 'redux';
 import { connect }              from 'react-redux';
 
 import { fetchActionPlans }      from './proposals.actions';
@@ -35,12 +34,7 @@ class ProposalActionPlans extends Component {
   }
 }
 
-function mapStateToProps({ proposal }) {
-  return { proposal };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchActionPlans }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProposalActionPlans);
+export default connect(
+  ({ proposal }) => ({ proposal }),
+  { fetchActionPlans }
+)(ProposalActionPlans);

--- a/app/frontend/proposals/proposal_action_plans.component.js
+++ b/app/frontend/proposals/proposal_action_plans.component.js
@@ -1,7 +1,7 @@
-import { Component }            from 'react';
-import { connect }              from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import { fetchActionPlans }      from './proposals.actions';
+import * as actions  from './proposals.actions';
 
 class ProposalActionPlans extends Component {
   componentDidMount() {
@@ -36,5 +36,5 @@ class ProposalActionPlans extends Component {
 
 export default connect(
   ({ proposal }) => ({ proposal }),
-  { fetchActionPlans }
+  actions
 )(ProposalActionPlans);

--- a/app/frontend/proposals/proposal_info_extended.component.js
+++ b/app/frontend/proposals/proposal_info_extended.component.js
@@ -1,12 +1,12 @@
-import { Component }                    from 'react';
-import { connect }                      from 'react-redux';
+import { Component }  from 'react';
+import { connect }    from 'react-redux';
 
-import FlagActions                      from '../application/flag_actions.component';
-import UserAvatar                       from '../application/user_avatar.component';
+import FlagActions    from '../application/flag_actions.component';
+import UserAvatar     from '../application/user_avatar.component';
 
-import ProposalAuthor                   from './proposal_author.component';
+import ProposalAuthor from './proposal_author.component';
 
-import { flagProposal, unFlagProposal } from './proposals.actions';
+import * as actions   from './proposals.actions';
 
 class ProposalInfoExtended extends Component {
   render() {
@@ -51,8 +51,5 @@ class ProposalInfoExtended extends Component {
 
 export default connect(
   ({ session }) => ({ session }),
-  {
-    flagProposal,
-    unFlagProposal
-  }
+  actions
 )(ProposalInfoExtended);

--- a/app/frontend/proposals/proposal_info_extended.component.js
+++ b/app/frontend/proposals/proposal_info_extended.component.js
@@ -1,6 +1,5 @@
 import { Component }                    from 'react';
 import { connect }                      from 'react-redux';
-import { bindActionCreators }           from 'redux';
 
 import FlagActions                      from '../application/flag_actions.component';
 import UserAvatar                       from '../application/user_avatar.component';
@@ -50,12 +49,10 @@ class ProposalInfoExtended extends Component {
   }
 }
 
-function mapStateToProps({ session }) {
-  return { session };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ flagProposal, unFlagProposal }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProposalInfoExtended);
+export default connect(
+  ({ session }) => ({ session }),
+  {
+    flagProposal,
+    unFlagProposal
+  }
+)(ProposalInfoExtended);

--- a/app/frontend/proposals/proposal_meetings.component.js
+++ b/app/frontend/proposals/proposal_meetings.component.js
@@ -1,5 +1,4 @@
 import { Component }            from 'react';
-import { bindActionCreators }   from 'redux';
 import { connect }              from 'react-redux';
 
 import Meeting                  from '../meetings/meeting.component';
@@ -51,12 +50,7 @@ class ProposalMeetings extends Component {
   }
 }
 
-function mapStateToProps({ proposal }) {
-  return { proposal };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchRelatedMeetings }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProposalMeetings);
+export default connect(
+  ({ proposal }) => ({ proposal }),
+  { fetchRelatedMeetings }
+)(ProposalMeetings);

--- a/app/frontend/proposals/proposal_meetings.component.js
+++ b/app/frontend/proposals/proposal_meetings.component.js
@@ -1,9 +1,9 @@
-import { Component }            from 'react';
-import { connect }              from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import Meeting                  from '../meetings/meeting.component';
+import Meeting       from '../meetings/meeting.component';
 
-import { fetchRelatedMeetings } from './proposals.actions';
+import * as actions  from './proposals.actions';
 
 class ProposalMeetings extends Component {
   componentDidMount() {
@@ -52,5 +52,5 @@ class ProposalMeetings extends Component {
 
 export default connect(
   ({ proposal }) => ({ proposal }),
-  { fetchRelatedMeetings }
+  actions
 )(ProposalMeetings);

--- a/app/frontend/proposals/proposal_references.component.js
+++ b/app/frontend/proposals/proposal_references.component.js
@@ -1,5 +1,4 @@
 import { Component }            from 'react';
-import { bindActionCreators }   from 'redux';
 import { connect }              from 'react-redux';
 
 import { fetchReferences }      from './proposals.actions';
@@ -33,12 +32,7 @@ class ProposalReferences extends Component {
   }
 }
 
-function mapStateToProps({ proposal }) {
-  return { proposal };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchReferences }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProposalReferences);
+export default connect(
+  ({ proposal }) => ({ proposal }),
+  { fetchReferences }
+)(ProposalReferences);

--- a/app/frontend/proposals/proposal_references.component.js
+++ b/app/frontend/proposals/proposal_references.component.js
@@ -1,7 +1,7 @@
-import { Component }            from 'react';
-import { connect }              from 'react-redux';
+import { Component } from 'react';
+import { connect }   from 'react-redux';
 
-import { fetchReferences }      from './proposals.actions';
+import * as actions  from './proposals.actions';
 
 class ProposalReferences extends Component {
   componentDidMount() {
@@ -34,5 +34,5 @@ class ProposalReferences extends Component {
 
 export default connect(
   ({ proposal }) => ({ proposal }),
-  { fetchReferences }
+  actions
 )(ProposalReferences);

--- a/app/frontend/proposals/proposal_reviewer.component.js
+++ b/app/frontend/proposals/proposal_reviewer.component.js
@@ -1,6 +1,5 @@
 import { Component }                    from 'react';
 import { connect }                      from 'react-redux';
-import { bindActionCreators }           from 'redux';
 
 import ScopePicker                      from '../scope/scope_picker.component';
 import CategoryPicker                   from '../categories/new_category_picker.component';
@@ -47,17 +46,12 @@ class ProposalReviewer extends Component {
   }
 }
 
-function mapStateToProps({ session, proposal }) {
-  return { session, proposal };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ 
+export default connect(
+  ({ session, proposal }) => ({ session, proposal }),
+  {
     fetchDistricts,
     fetchCategories, 
     updateAnswer,
     updateProposal
-  }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProposalReviewer);
+  }
+)(ProposalReviewer);

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -1,11 +1,7 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }        from 'react';
+import { connect }          from 'react-redux';
 
-import { 
-  fetchProposal, 
-  hideProposal,
-  hideProposalAuthor
-} from './proposals.actions';
+import * as actions         from './proposals.actions';
 
 import Helmet               from "react-helmet";
 
@@ -279,9 +275,5 @@ class ProposalShow extends Component {
 
 export default connect(
   ({ session, proposal }) => ({ session, proposal }),
-  {
-    fetchProposal, 
-    hideProposal,
-    hideProposalAuthor
-  }
+  actions
 )(ProposalShow);

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -1,6 +1,5 @@
 import { Component }          from 'react';
 import { connect }            from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 import { 
   fetchProposal, 
@@ -278,16 +277,11 @@ class ProposalShow extends Component {
   }
 }
 
-function mapStateToProps({ session, proposal }) {
-  return { session, proposal };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ 
+export default connect(
+  ({ session, proposal }) => ({ session, proposal }),
+  {
     fetchProposal, 
     hideProposal,
     hideProposalAuthor
-  }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProposalShow);
+  }
+)(ProposalShow);

--- a/app/frontend/proposals/proposal_vote_box.component.js
+++ b/app/frontend/proposals/proposal_vote_box.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import SmartButton            from '../application/smart_button.component';
@@ -110,12 +109,7 @@ class ProposalVoteBox extends Component {
   }
 }
 
-function mapStateToProps({ session }) {
-  return { session };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ voteProposal }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProposalVoteBox);
+export default connect(
+  ({ session }) => ({ session }),
+  { voteProposal }
+)(ProposalVoteBox);

--- a/app/frontend/proposals/proposal_vote_box.component.js
+++ b/app/frontend/proposals/proposal_vote_box.component.js
@@ -1,10 +1,10 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }      from 'react';
+import { connect }        from 'react-redux';
 
-import SmartButton            from '../application/smart_button.component';
-import SocialShareButtons     from '../application/social_share_buttons.component';
+import SmartButton        from '../application/smart_button.component';
+import SocialShareButtons from '../application/social_share_buttons.component';
 
-import { voteProposal }       from './proposals.actions';
+import * as actions       from './proposals.actions';
 
 class ProposalVoteBox extends Component {
   constructor(props) {
@@ -111,5 +111,5 @@ class ProposalVoteBox extends Component {
 
 export default connect(
   ({ session }) => ({ session }),
-  { voteProposal }
+  actions
 )(ProposalVoteBox);

--- a/app/frontend/proposals/proposals.component.js
+++ b/app/frontend/proposals/proposals.component.js
@@ -1,17 +1,17 @@
-import { Component }          from 'react';
-import { connect }            from 'react-redux';
+import { Component }      from 'react';
+import { connect }        from 'react-redux';
 
-import Loading                from '../application/loading.component';
-import InfinitePagination     from '../pagination/infinite_pagination.component';
-import FilterTabs             from '../filters/filter_tabs.component';
-import OrderSelector          from '../order/order_selector.component';
+import Loading            from '../application/loading.component';
+import InfinitePagination from '../pagination/infinite_pagination.component';
+import FilterTabs         from '../filters/filter_tabs.component';
+import OrderSelector      from '../order/order_selector.component';
 
-import ProposalsHeader        from './proposals_header.component';
-import ProposalsSidebar       from './proposals_sidebar.component';
-import NewProposalButton      from './new_proposal_button.component';
-import ProposalsList          from './proposals_list.component';
+import ProposalsHeader    from './proposals_header.component';
+import ProposalsSidebar   from './proposals_sidebar.component';
+import NewProposalButton  from './new_proposal_button.component';
+import ProposalsList      from './proposals_list.component';
 
-import { fetchProposals, appendProposalsPage } from './proposals.actions';
+import * as actions       from './proposals.actions';
 
 class Proposals extends Component {
   constructor(props) {
@@ -99,8 +99,5 @@ export default connect(
   ({ proposals, filters, order, pagination, seed, count }) => ({
     proposals, filters, order, pagination, seed, count
   }),
-  {
-    fetchProposals,
-    appendProposalsPage
-  }
+  actions
 )(Proposals);

--- a/app/frontend/proposals/proposals.component.js
+++ b/app/frontend/proposals/proposals.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 import Loading                from '../application/loading.component';
@@ -96,12 +95,12 @@ class Proposals extends Component {
   }
 }
 
-function mapStateToProps({ proposals, filters, order, pagination, seed, count }) {
-  return { proposals, filters, order, pagination, seed, count };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ fetchProposals, appendProposalsPage }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Proposals);
+export default connect(
+  ({ proposals, filters, order, pagination, seed, count }) => ({
+    proposals, filters, order, pagination, seed, count
+  }),
+  {
+    fetchProposals,
+    appendProposalsPage
+  }
+)(Proposals);

--- a/app/frontend/proposals/proposals_filters.component.js
+++ b/app/frontend/proposals/proposals_filters.component.js
@@ -1,5 +1,4 @@
 import { Component }                    from 'react';
-import { bindActionCreators }           from 'redux';
 import { connect }                      from 'react-redux';
 
 import { setFilterGroup, clearFilters } from '../filters/filters.actions';
@@ -46,26 +45,10 @@ class ProposalsFilters extends Component {
   }
 }
 
-function mapStateToProps({ filters }) {
-  return {
-    filters
-  };
-}
-
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ setFilterGroup, clearFilters }, dispatch);
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ProposalsFilters);
-
-//renderTagCloudFilter() {
-//  //if (this.props.tagsEnabled) {
-//  //  return (
-//  //    <TagCloudFilter 
-//  //      currentTags={this.state.tags} 
-//  //      tagCloud={this.props.tagCloud} 
-//  //      onSetFilterTags={(tags) => this.onSetFilterTags(tags)} />
-//  //  )
-//  //}
-//  return null;
-//}
+export default connect(
+  ({ filters }) => ({ filters }),
+  {
+    setFilterGroup,
+    clearFilters
+  }
+)(ProposalsFilters);

--- a/app/frontend/proposals/proposals_filters.component.js
+++ b/app/frontend/proposals/proposals_filters.component.js
@@ -1,18 +1,18 @@
-import { Component }                    from 'react';
-import { connect }                      from 'react-redux';
+import { Component }                from 'react';
+import { connect }                  from 'react-redux';
 
-import { setFilterGroup, clearFilters } from '../filters/filters.actions';
+import * as actions                 from '../filters/filters.actions';
 
-import SearchFilter                     from '../filters/search_filter.component';
-import ScopeFilterOptionGroup           from '../filters/scope_filter_option_group.component';
-import CategoryFilterOptionGroup        from '../filters/category_filter_option_group.component';
-import SubcategoryFilterOptionGroup     from '../filters/subcategory_filter_option_group.component';
-import TagCloudFilter                   from '../filters/tag_cloud_filter.component';
-import ReviewerFilter                   from '../filters/reviewer_filter.component';
-import UserInteractionFilter            from '../filters/user_interaction_filter.component';
+import SearchFilter                 from '../filters/search_filter.component';
+import ScopeFilterOptionGroup       from '../filters/scope_filter_option_group.component';
+import CategoryFilterOptionGroup    from '../filters/category_filter_option_group.component';
+import SubcategoryFilterOptionGroup from '../filters/subcategory_filter_option_group.component';
+import TagCloudFilter               from '../filters/tag_cloud_filter.component';
+import ReviewerFilter               from '../filters/reviewer_filter.component';
+import UserInteractionFilter        from '../filters/user_interaction_filter.component';
 
-import FilterOptionGroup                from '../filters/filter_option_group.component';
-import FilterOption                     from '../filters/filter_option.component';
+import FilterOptionGroup            from '../filters/filter_option_group.component';
+import FilterOption                 from '../filters/filter_option.component';
 
 class ProposalsFilters extends Component {
   render() {
@@ -47,8 +47,5 @@ class ProposalsFilters extends Component {
 
 export default connect(
   ({ filters }) => ({ filters }),
-  {
-    setFilterGroup,
-    clearFilters
-  }
+  actions
 )(ProposalsFilters);

--- a/app/frontend/scope/scope_picker.component.js
+++ b/app/frontend/scope/scope_picker.component.js
@@ -1,5 +1,4 @@
 import { Component }          from 'react';
-import { bindActionCreators } from 'redux';
 import { connect }            from 'react-redux';
 
 class ScopePicker extends Component {
@@ -71,8 +70,6 @@ class ScopePicker extends Component {
   }
 }
 
-function mapStateToProps({ districts }) {
-  return { districts };
-}
-
-export default connect(mapStateToProps)(ScopePicker);
+export default connect(
+  ({ districts }) => ({ districts })
+)(ScopePicker);


### PR DESCRIPTION
# What and why

After watching a few screencasts of advanced redux I simplified our react-redux `connect` calls to use a simple form for `mapStateToProps` and `mapDispatchToProps`
# GIF Tax

![](https://media.giphy.com/media/mEtfDhbWwc4GA/giphy.gif)
