### PR TITLE
Add missing fields to meetings xls

### DIFF
--- a/app/controllers/moderation/meetings_controller.rb
+++ b/app/controllers/moderation/meetings_controller.rb
@@ -9,8 +9,9 @@ class Moderation::MeetingsController < Moderation::BaseController
   load_and_authorize_resource
 
   def index
+    @search    = params[:search]
     @resources = @resources.send(@current_filter)
-    @resources = @resources.search(params[:search]) if params[:search].present?
+    @resources = @resources.search(@search) if @search.present?
 
     respond_to do |format|
       format.html do

--- a/app/controllers/moderation/meetings_controller.rb
+++ b/app/controllers/moderation/meetings_controller.rb
@@ -24,18 +24,13 @@ class Moderation::MeetingsController < Moderation::BaseController
           p.workbook.add_worksheet(:name => "Meetings") do |sheet|
             @resources.each do |meeting|
               row = []
-              row.push meeting.title
-              row.push meeting.author.name
               row.push meeting.held_at
-              row.push meeting.start_at.try(:strftime, "%H:%M")
-              row.push meeting.end_at.try(:strftime, "%H:%M")
+              row.push meeting.title
               row.push meeting.address
+              row.push meeting.attendee_count
+              row.push meeting.scope == 'city' ? I18n.t('action_plans.form.action_plan_scope_city') : District.find(meeting.district).try(:name)
               row.push meeting.category.try(:decorate).try(:name)
               row.push meeting.subcategory.try(:decorate).try(:name)
-              row.push District.find(meeting.district).try(:name)
-              row.push meeting.closed_at ? "CLOSED" : nil
-              row.push meeting.description
-
               sheet.add_row row
             end
           end

--- a/app/views/moderation/meetings/index.html.erb
+++ b/app/views/moderation/meetings/index.html.erb
@@ -13,7 +13,7 @@
   </div>
 </div>
 
-<%= link_to t(".download_xls"), url_for(format: 'xls'), class: 'button right tiny' %>
+<%= link_to t(".download_xls"), moderation_meetings_url(format: 'xls', filter: @current_filter, search: @search), class: 'button right tiny' %>
 
 <table class="clear">
   <tr>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -14,6 +14,9 @@
             <i class="icon-search"></i>
           </button>
         </div>
+        <% if @current_filter.present? %>
+          <input type="hidden" name="filter" value="<%= @current_filter %>" />
+        <% end %>
       </div>
     </div>
     <% end %>


### PR DESCRIPTION
# What and why

I changed the xls format for the moderation meetings report. The final format is using these fields:
- `date`
- `title`
- `address`
- `attendee count`
- `scope`
- `category`
- `subcategory`

I also fixed a few bugs related to the download link and search form
# GIF Tax

![](https://media.giphy.com/media/ToMjGpzot8uTh5nUwnu/giphy.gif)
