### PR TITLE
Set locale to API controllers

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -3,9 +3,18 @@ class Api::ApplicationController < ActionController::Base
   check_authorization
   respond_to :json
 
+  before_filter :set_locale
+
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
       format.json { render json: {error: exception.message}, status: :forbidden }
     end
+  end
+
+  private
+
+  def set_locale
+    locale = params[:locale] || session[:locale] || I18n.default_locale
+    I18n.locale = locale
   end
 end


### PR DESCRIPTION
# What and why

I added the `set_locale` method for APIs controller. It fixes the problem with the `categories` and `subcategories` API responses.
# GIF Tax

![](https://media.giphy.com/media/srb6bXZHbgDsc/giphy.gif)
