### PR TITLE
Format insecure user content in a better way

### DIFF
--- a/app/frontend/action_plans/action_plan.component.js
+++ b/app/frontend/action_plans/action_plan.component.js
@@ -34,7 +34,7 @@ const ActionPlan = ({
           </p>
 
           <div className="proposal-description">
-            {htmlToReact(ellipsis(description.autoLink(), DESCRIPTION_MAX_CHARACTERS, true))}
+            {htmlToReact(ellipsis(description, DESCRIPTION_MAX_CHARACTERS, true))}
           </div>
 
           <div className="bottom-bar">

--- a/app/frontend/action_plans/action_plan_show.component.js
+++ b/app/frontend/action_plans/action_plan_show.component.js
@@ -78,7 +78,7 @@ class ActionPlanShow extends Component {
               <p className="proposal-info"><span>{ created_at }</span></p>
 
               <div className="proposal-description">
-                {htmlToReact(description.autoLink())}
+                {htmlToReact(description)}
               </div>
 
               <FilterMeta 

--- a/app/frontend/application/sanitize.js
+++ b/app/frontend/application/sanitize.js
@@ -1,3 +1,0 @@
-export default function sanitize(string){
-  return string.replace("<", "&lt;").replace(">", "&gt");
-}

--- a/app/frontend/application/simple_format.js
+++ b/app/frontend/application/simple_format.js
@@ -1,0 +1,6 @@
+import Autolinker from "autolinker";
+import he from "he";
+
+export default function simpleFormat(content){
+  return Autolinker.link(he.encode(content));
+}

--- a/app/frontend/application/simple_format.test.js
+++ b/app/frontend/application/simple_format.test.js
@@ -1,0 +1,13 @@
+import simpleFormat from "./simple_format";
+
+describe("simpleFormat", function () {
+  it("should escape HTML entities", function () {
+    var content = "Trying to inject <html />";
+    expect(simpleFormat(content)).to.equal("Trying to inject &#x3C;html /&#x3E;");
+  });
+
+  it("should autoLink", function () {
+    var content = "Linking https://decidim.barcelona is good linking.";
+    expect(simpleFormat(content)).to.include('href="https://decidim.barcelona"');
+  });
+});

--- a/app/frontend/entry.js
+++ b/app/frontend/entry.js
@@ -45,4 +45,3 @@ window.ActionPlanApp              = ActionPlanApp;
 window.DebateApp                  = DebateApp;
 
 require('quill/dist/quill.snow');
-require('expose?autoLink!autolink-js');

--- a/app/frontend/proposals/proposal.component.js
+++ b/app/frontend/proposals/proposal.component.js
@@ -4,8 +4,8 @@ import ProposalVoteBox from './proposal_vote_box.component';
 import ProposalBadge   from './proposal_badge.component';
 import ProposalInfo    from './proposal_info.component';
 
-import htmlToReact     from '../application/html_to_react';
-import sanitize        from '../application/sanitize';
+import htmlToReact from '../application/html_to_react';
+import simpleFormat from '../application/simple_format';
 
 const Proposal = (proposal) => (
   <div id={`proposal_${proposal.id}`} className="proposal clear">
@@ -22,7 +22,7 @@ const Proposal = (proposal) => (
             from_meeting={ proposal.from_meeting }
             author={ proposal.author }/>
           <div className="proposal-description">
-          {htmlToReact(sanitize(proposal.summary).autoLink())}
+            {htmlToReact(simpleFormat(proposal.summary))}
           </div>
           <div className="bottom-bar">
             <FilterMeta 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -21,7 +21,7 @@ import ProposalActionPlans      from './proposal_action_plans.component';
 import ProposalMeetings         from './proposal_meetings.component';
 
 import htmlToReact              from '../application/html_to_react';
-import sanitize                 from '../application/sanitize';
+import simpleFormat             from '../application/simple_format';
 
 class ProposalShow extends Component {
   constructor(props) {
@@ -133,7 +133,7 @@ class ProposalShow extends Component {
                 flagged={ flagged } />
 
               <div className="proposal-description">
-                {htmlToReact(sanitize(summary).autoLink())}
+                {htmlToReact(simpleFormat(summary))}
               </div>
 
               {this.renderExternalUrl(external_url)}
@@ -264,7 +264,7 @@ class ProposalShow extends Component {
     if (externalUrl) {
       return (
         <div className="document-link">
-          { htmlToReact(externalUrl.autoLink()) }
+          { htmlToReact(simpleFormat(externalUrl)) }
         </div>
       );
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decidim.barcelona",
   "dependencies": {
-    "autolink-js": "^1.0.1",
+    "autolinker": "^0.26.0",
     "axios": "^0.9.1",
     "babel-core": "^6.7.2",
     "babel-loader": "^6.2.4",
@@ -18,6 +18,7 @@
     "exports-loader": "^0.6.3",
     "expose-loader": "^0.7.1",
     "extract-text-webpack-plugin": "^1.0.1",
+    "he": "^1.1.0",
     "html-ellipsis": "^1.1.1",
     "html-to-react": "^1.0.0",
     "html-truncate": "^1.2.1",

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -67,7 +67,7 @@ feature 'Proposals' do
     visit proposal_path(proposal)
 
     expect(page).to have_content proposal.title
-    expect(page).to have_content "http://external_documention.es"
+    expect(page).to have_content "external_documention.es"
     expect(page).to have_content proposal.author.name
     expect(page).to have_content I18n.l(proposal.created_at.to_date)
     expect(page.html).to include "<title>#{proposal.title}</title>"
@@ -111,7 +111,7 @@ feature 'Proposals' do
     expect(page).to have_content 'Proposal created successfully.'
     expect(page).to have_content 'Help refugees'
     expect(page).to have_content 'In summary, what we want is...'
-    expect(page).to have_content 'http://rescue.org/refugees'
+    expect(page).to have_content 'rescue.org/refugees'
     expect(page).to have_content author.name
     expect(page).to have_content I18n.l(Proposal.last.created_at.to_date)
   end
@@ -222,7 +222,7 @@ feature 'Proposals' do
 
     expect(page).to have_content 'Proposal created successfully.'
     expect(page).to have_content 'Testing auto link'
-    expect(page).to have_link('http://www.example.org', href: 'http://www.example.org')
+    expect(page).to have_link('example.org', href: 'http://www.example.org')
   end
 
   context 'Tagging proposals' do


### PR DESCRIPTION
This ensures content is escaped before applying autolinking.
