### PR TITLE
Remove Helmet and render meta tags from server side

### DIFF
--- a/app/controllers/action_plans_controller.rb
+++ b/app/controllers/action_plans_controller.rb
@@ -9,6 +9,7 @@ class ActionPlansController < ApplicationController
 
   def show
     @action_plan_id = params[:id]
+    @action_plan = ActionPlan.find(@action_plan_id)
   end
 
   def new

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -46,6 +46,7 @@ class ProposalsController < ApplicationController
 
   def show
     @proposal_id = params[:id]
+    @proposal = Proposal.find(@proposal_id)
   end
 
   def vote

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -3,8 +3,6 @@ import { connect }              from 'react-redux';
 
 import * as actions             from './proposals.actions';
 
-import Helmet                   from "react-helmet";
-
 import Loading                  from '../application/loading.component';
 import SocialShareButtons       from '../application/social_share_buttons.component';
 import DangerLink               from '../application/danger_link.component';
@@ -78,30 +76,11 @@ class ProposalShow extends Component {
         hidden,
         can_hide,
         can_hide_author,
-        flagged,
-        social_media_image_url
+        flagged
       } = proposal;
 
       return (
         <div>
-          <Helmet
-            title={title}
-            meta={[
-              { name: "twitter:card", content: "summary" },
-              { name: "twitter:site", content: "bcn_ajuntament" },
-              { name: "twitter:title", content: title },
-              { name: "twitter:description", content: summary },
-              { name: "twitter:image", content: social_media_image_url },
-              { id: "ogtitle", property: "og:title", content: title },
-              { property: "article:publisher", content: "https://decidim.barcelona"},
-              { property: "article:author", content: "https://www.facebook.com/bcn.cat"},
-              { property: "og:type", content: "article" },
-              { id: "ogimage", property: "og:image", content: social_media_image_url },
-              { property: "og:site_name", content: "decidim.barcelona" },
-              { id: "ogdescription", property: "og:description", content: summary },
-              { property: "fb:app_id", content: "929041747208547"}
-            ]}
-          />
           <div className={(hidden || author.hidden) ? 'row faded' : 'row'} id={`proposal_${proposal.id}`}>
             <div className="small-12 medium-9 column">
               <i className="icon-angle-left left"></i>&nbsp;

--- a/app/serializers/action_plan_serializer.rb
+++ b/app/serializers/action_plan_serializer.rb
@@ -1,6 +1,7 @@
 class ActionPlanSerializer < ActiveModel::Serializer
   attributes :id, :title, :description, :created_at, :url, :scope_, :district,
-    :edit_url, :new_revision_url, :approved, :weight, :statistics
+    :edit_url, :new_revision_url, :approved, :weight, :social_media_image_url,
+    :statistics
 
   has_one :category
   has_one :subcategory
@@ -28,5 +29,9 @@ class ActionPlanSerializer < ActiveModel::Serializer
 
   def district
     District.find(object.district)
+  end
+
+  def social_media_image_url
+    scope && scope.asset_url('social-media-icon.png')
   end
 end

--- a/app/views/action_plans/show.html.erb
+++ b/app/views/action_plans/show.html.erb
@@ -1,3 +1,21 @@
+<% content_for :title do %><%= @action_plan.title %><% end %>
+
+<% content_for :social_media_meta_tags do %>
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="bcn_ajuntament" />
+  <meta name="twitter:title" content="<%= @action_plan.title %>" />
+  <meta name="twitter:description" content="<%= @action_plan.description %>" />
+  <meta name="twitter:image" content="<%= asset_url("social-media-icon.png") %>" />
+  <meta id="ogtitle" property="og:title" content="<%= @action_plan.title %>" />
+  <meta property="article:publisher" content="https://decidim.barcelona" />
+  <meta property="article:author" content="https://www.facebook.com/bcn.cat" />
+  <meta property="og:type" content="article" />
+  <meta id="ogimage" property="og:image" content="<%= asset_url("social-media-icon.png") %>" />
+  <meta property="og:site_name" content="decidim.barcelona" />
+  <meta id="ogdescription" property="og:description" content="<%= @action_plan.description %>" />
+  <meta property="fb:app_id" content="929041747208547" />
+<% end %>
+
 <section class="action-plan-show">
   <%= react_app "ActionPlan", actionPlanId: @action_plan_id %>
 </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title><%= content_for?(:title) ? yield(:title) : Setting['org_name'] %></title>
+    <title><%= content_for?(:title) ? content_for(:title) : Setting['org_name'] %></title>
     <%= stylesheet_link_tag    "application" %>
     <%= javascript_include_tag "application", 'data-turbolinks-track' => true %>
     <%= javascript_include_google_maps_api_tag %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -1,3 +1,21 @@
+<% content_for :title do %><%= @proposal.title %><% end %>
+
+<% content_for :social_media_meta_tags do %>
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="bcn_ajuntament" />
+  <meta name="twitter:title" content="<%= @proposal.title %>" />
+  <meta name="twitter:description" content="<%= @proposal.summary %>" />
+  <meta name="twitter:image" content="<%= asset_url("social-media-icon.png") %>" />
+  <meta id="ogtitle" property="og:title" content="<%= @proposal.title %>" />
+  <meta property="article:publisher" content="https://decidim.barcelona" />
+  <meta property="article:author" content="https://www.facebook.com/bcn.cat" />
+  <meta property="og:type" content="article" />
+  <meta id="ogimage" property="og:image" content="<%= asset_url("social-media-icon.png") %>" />
+  <meta property="og:site_name" content="decidim.barcelona" />
+  <meta id="ogdescription" property="og:description" content="<%= @proposal.summary %>" />
+  <meta property="fb:app_id" content="929041747208547" />
+<% end %>
+
 <section class="proposal-show">
   <%= react_app 'Proposal', proposalId: @proposal_id %>
 </section>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "react-addons-test-utils": "^0.14.6",
     "react-autocomplete": "^1.0.0-rc2",
     "react-dom": "^0.14.6",
-    "react-helmet": "^3.1.0",
     "react-quill": "^0.4.1",
     "react-redux": "^4.0.0",
     "react-share": "^1.4.1",


### PR DESCRIPTION
# What and why

~~I added some meta tags to the action plans show page. I'm using `Helmet` to modify the `<head>` section of the html document.~~

I made a mistake and I thought Facebook was parsing the meta tags generated by Javascript. I remove Helmet because it's not longer used and replaced it with meta tags render from server side.
It's using a double query as a workaround but I think we can use some third-party tools like prerender.io and use just javascript to replace the meta tags.
# GIF Tax

![](https://media.giphy.com/media/XOJ7mKGYNfipi/giphy.gif)
