### PR TITLE
Simpify Action Plan reports

### DIFF
--- a/app/views/revision/action_plan_reports/report/_action_plan.html.erb
+++ b/app/views/revision/action_plan_reports/report/_action_plan.html.erb
@@ -35,7 +35,7 @@
       <p>
         <strong>Organitzacions participants a les cites:</strong>
         <% if !action_plan.meeting_participants.blank? %>
-          <%= action_plan.meeting_participants %>
+          <%= action_plan.meeting_participants.length %>
         <% else %>
           Cap
         <% end %>


### PR DESCRIPTION
## What and why?

In order to save space, we're replacing the list of organizations by their _amount_.
