### PR TITLE
Hide authors on proposals from meetings

### DIFF
--- a/app/frontend/action_plans/action_plan_authors.component.js
+++ b/app/frontend/action_plans/action_plan_authors.component.js
@@ -3,12 +3,18 @@ import unique        from 'array-unique';
 
 const defaultAuthors = ["Ajuntament de Barcelona"];
 
+function proposalAuthorName(proposal){
+  if (proposal.author) {
+    return proposal.author.name;
+  }
+}
+
 function authors(actionPlan){
   let { actionPlansProposals } = actionPlan;
 
   if (actionPlansProposals) {
     let authors = actionPlansProposals.map(
-      (actionPlanProposal) => actionPlanProposal.proposal.author.name
+      (actionPlanProposal) => proposalAuthorName(actionPlanProposal.proposal)
     ).filter(name => name).map(name => name.trim());
 
     if(authors.length > 0) {

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -19,6 +19,10 @@ class ProposalSerializer < ActiveModel::Serializer
     object.comments.length
   end
 
+  def author
+    object.author unless object.from_meeting
+  end
+
   def total_positive_comments
     object.comments.select { |c| c.alignment && c.alignment > 0 }.count
   end


### PR DESCRIPTION
## What and why?

The API was returning the authors on proposals from meetings. They should be hidden (although no harm would be done).
