### PR TITLE
Add action plan description

### DIFF
--- a/app/frontend/action_plans/action_plans.component.js
+++ b/app/frontend/action_plans/action_plans.component.js
@@ -8,6 +8,7 @@ import OrderSelector            from '../order/order_selector.component';
 import ActionPlansSidebar       from './action_plans_sidebar.component';
 import ActionPlansList          from './action_plans_list.component';
 import DownloadButton           from './download_button.component';
+import ActionPlansHeader        from './action_plans_header.component';
 
 import * as actions             from './action_plans.actions';
 import { setOrder }             from '../order/order.actions';
@@ -43,6 +44,8 @@ class ActionPlans extends Component {
   render() {
     return (
       <div>
+        <ActionPlansHeader />
+
         <div className="wrap row">
           <div className="wrap row">
             <div className="small-12 medium-3 column">

--- a/app/frontend/action_plans/action_plans_header.component.js
+++ b/app/frontend/action_plans/action_plans_header.component.js
@@ -1,0 +1,17 @@
+const ActionPlansHeader = ()  => (
+  <div className="page-title">
+    <div className="wrap row proposals-header">
+      <div className="small-12 columns">
+        <h2>{ I18n.t('action_plans.index.title') }</h2>
+      </div>
+    </div>
+    <div className="wrap row proposals-header">
+      <div className="small-12 medium-12 large-12 columns">
+        <h3>{ I18n.t('action_plans.index.description') }</h3>
+      </div>
+    </div>
+  </div>
+);
+
+export default ActionPlansHeader;
+

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -51,7 +51,9 @@ ca:
       description: Descripció
       title: Títol
     index:
+      description: Aquí pots navegar per les actuacions que l'Ajuntament ha elaborat pel Pla d'Actuació Municipal 2016-2019 basant-se en les propostes elaborades pel mateix Ajuntament, la ciutadania, organitzacions i entitats socials, així com aquelles que provenen de cites presencials. Des de les actuacions podràs consultar les propostes en què estan basades, així com els suports rebuts, els comentaris realitzats a cadascuna d'elles, i les cites presencials associades.
       new: Nova actuació
+      title: Actuacions
     new:
       form:
         submit_button: Crear actuació

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,9 @@ en:
       description: Description
       title: Title
     index:
+      description: Here you can browse the actions developed by the City Council Municipal Action Plan 2016-2019 on the basis of proposals made by the same council, citizens, organizations and social organizations, as well as those from dating face. Since actions can view the proposals which are based, as well as the support received, comments made to each of them and face associated appointments.
       new: New action plan
+      title: actions
     new:
       form:
         submit_button: Create action plan

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -51,7 +51,9 @@ es:
       description: Descripción
       title: Título
     index:
+      description: Aquí  puedes navegar por las actuaciones que el Ayuntamiento ha elaborado para el Plan de actuación municipal 2016-2019 basándose en las propuestas elaboradas por el propio Ayuntamiento, la ciudadanía, organizaciones y entidades sociales, así como esas que provienen de las citas presenciales. Desde las actuaciones podrás consultar las propuestas en las que están basadas, así como los  apoyos recibidos, los  comentarios realizados a cada una, y las citas presenciales asociadas con ellas.
       new: Nueva actuación
+      title: Actuaciones
     new:
       form:
         submit_button: Crear actuación


### PR DESCRIPTION
## What and why?

This adds a header with a title and description to the `Action Plans` page.
