### PR TITLE
Add status to open data proposals.csv

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -93,7 +93,8 @@ class ProposalsController < ApplicationController
             "Created at",
             "Votes",
             "Comments",
-            "URL"
+            "URL",
+            "Status"
           ]
 
           proposals.each do |proposal|
@@ -112,6 +113,7 @@ class ProposalsController < ApplicationController
             row.push proposal.cached_votes_up
             row.push proposal.comments_count
             row.push url_for(proposal)
+            row.push proposal.answer.try(:status)
             sheet.add_row row
           end
         end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -80,6 +80,7 @@ search:
   exclude:
     - app/assets/images
     - app/assets/fonts
+    - app/assets/documents
     - app/assets/*.map
 
   ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
@@ -167,6 +168,7 @@ ignore_unused:
   - 'dataviz.open_data.download-*'
   - 'proposal_results_mailer.proposal.status_*'
   - 'proposals.status.*'
+  - 'pages.download.download-district'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/spec/features/downloads_spec.rb
+++ b/spec/features/downloads_spec.rb
@@ -1,15 +1,13 @@
 require 'rails_helper'
 
 feature 'Downloads' do
+  include ActionView::Helpers
+
   scenario "Index downloads should show the correct links", :js do
 
-    visit page_path('download', locale: 'ca')
+    visit page_path('download')
 
-    expect(page).to have_css("a[href='http://www.barcelona.cat/download/pam/ca/PAD-Sants-Montjuic-CAT.pdf']")
-
-    visit page_path('download', locale: 'es')
-
-    expect(page).to have_css("a[href='http://www.barcelona.cat/download/pam/es/PAD-Sants-Montjuic-CAST.pdf']")
+    expect(page).to have_xpath "//a[contains(@href, #{asset_url('pla_municipal.pdf')})]"
   end
 end
 


### PR DESCRIPTION
# What and why

The proposals report available to download from the open data page was missing a "Status" field.
# QA

Just download the new report from https://decidim.barcelona/assets/proposals-d75b26f45dbfe8731ab394b2806778d6ad3bcd85c5f1ed1e0dad4465a32b145e.csv
