### PR TITLE
Don't check user when filtering by review status

### DIFF
--- a/app/services/resource_filter.rb
+++ b/app/services/resource_filter.rb
@@ -110,24 +110,28 @@ class ResourceFilter
       collection = collection.includes(:action_plans).where(action_plans: { id: nil })
     end
 
-    if @params["review_status"]
-      collection = collection.includes(:answer).
-                  where(proposal_answers: { status: @params["review_status"]})
+    if @params['review_status']
+      collection = collection.includes(:answer)
+                             .where(proposal_answers: { 
+                               status: @params['review_status']
+                             })
     end
 
-    if @params["reviewer_status"]
-      if params["reviewer_status"].include? "reviewed"
-        collection = collection.reviewed
-      else
-        collection = collection.not_reviewed
-      end
+    if @params['reviewer_status']
+      collection = if params['reviewer_status'].include? 'reviewed'
+                     collection.reviewed
+                   else
+                     collection.not_reviewed
+                   end
     end
 
-    if @params["review_validation"]
-      if params["review_validation"].include?("validated")
-        collection = collection.includes(:answer).where(proposal_answers: { official: true })
-      elsif params["review_validation"].include?("not_validated")
-        collection = collection.includes(:answer). where(proposal_answers: { official: false })
+    if @params['review_validation']
+      if params['review_validation'].include?('validated')
+        collection = collection.includes(:answer)
+                               .where(proposal_answers: { official: true })
+      elsif params['review_validation'].include?('not_validated')
+        collection = collection.includes(:answer)
+                               .where(proposal_answers: { official: false })
       end
     end
 

--- a/app/services/resource_filter.rb
+++ b/app/services/resource_filter.rb
@@ -110,26 +110,24 @@ class ResourceFilter
       collection = collection.includes(:action_plans).where(action_plans: { id: nil })
     end
 
-    if @user && @user.ability.can?(:read, ProposalAnswer)
-      if @params["review_status"]
-        collection = collection.includes(:answer).
-                    where(proposal_answers: { status: @params["review_status"]})
-      end
+    if @params["review_status"]
+      collection = collection.includes(:answer).
+                  where(proposal_answers: { status: @params["review_status"]})
+    end
 
-      if @params["reviewer_status"]
-        if params["reviewer_status"].include? "reviewed"
-          collection = collection.reviewed
-        else
-          collection = collection.not_reviewed
-        end
+    if @params["reviewer_status"]
+      if params["reviewer_status"].include? "reviewed"
+        collection = collection.reviewed
+      else
+        collection = collection.not_reviewed
       end
+    end
 
-      if @params["review_validation"]
-        if params["review_validation"].include?("validated")
-          collection = collection.includes(:answer).where(proposal_answers: { official: true })
-        elsif params["review_validation"].include?("not_validated")
-          collection = collection.includes(:answer). where(proposal_answers: { official: false })
-        end
+    if @params["review_validation"]
+      if params["review_validation"].include?("validated")
+        collection = collection.includes(:answer).where(proposal_answers: { official: true })
+      elsif params["review_validation"].include?("not_validated")
+        collection = collection.includes(:answer). where(proposal_answers: { official: false })
       end
     end
 


### PR DESCRIPTION
# What and why

Since everyone can read `ProposalAnswers` it doesn't make any sense checking if the user is logged in when filtering proposals.
