### PR TITLE
Fix infinite pagination for action plans and proposals

### DIFF
--- a/app/frontend/action_plans/action_plans.actions.js
+++ b/app/frontend/action_plans/action_plans.actions.js
@@ -69,11 +69,18 @@ export function fetchActionPlan(actionPlanId) {
   };
 }
 
-export function appendActionPlansPage(options) {
-  return {
+export const appendActionPlansPage = (options) => (dispatch, getState) => {
+  const { participatoryProcessId } = getState();
+  options['participatoryProcessId'] = participatoryProcessId;
+
+  const request = buildActionPlansRequest(options);
+
+  dispatch({
     type: APPEND_ACTION_PLANS_PAGE,
-    payload: buildActionPlansRequest(options)
-  };
+    payload: request
+  });
+
+  return request;
 }
 
 export function fetchActionPlanProposals(actionPlanId) {

--- a/app/frontend/proposals/proposals.actions.js
+++ b/app/frontend/proposals/proposals.actions.js
@@ -48,11 +48,18 @@ export function updateProposal(proposalId, proposalParams) {
   };
 }
 
-export function appendProposalsPage(options) {
-  return {
+export const appendProposalsPage = (options) => (dispatch, getState) => {
+  const { participatoryProcessId } = getState();
+  options['participatoryProcessId'] = participatoryProcessId;
+
+  const request = buildProposalsRequest(options);
+
+  dispatch({
     type: APPEND_PROPOSALS_PAGE,
-    payload: buildProposalsRequest(options)
-  };
+    payload: request
+  });
+
+  return request;
 }
 
 export function voteProposal(proposalId) {


### PR DESCRIPTION
# What and why

I fixed the infinite pagination for proposals and action plans. The `participatoryProcessId` wasn't used while building the urls.
