### PR TITLE
Fix broken url on action plan report

### DIFF
--- a/app/views/revision/action_plan_reports/report/_action_plan.html.erb
+++ b/app/views/revision/action_plan_reports/report/_action_plan.html.erb
@@ -5,7 +5,7 @@
   <div class="item-meta">
     <p>
       <strong>Enllaç:</strong>
-      <%= link_to action_plan_url(action_plan, participatory_process_id: action_plan.participatory_process, host: "decidim.barcelona"), action_plan_url(action_plan, host: "decidim.barcelona") %>
+      <%= link_to action_plan_url(action_plan, participatory_process_id: action_plan.participatory_process, host: "decidim.barcelona"), action_plan_url(action_plan, participatory_process_id: action_plan.participatory_process, host: "decidim.barcelona") %>
     </p>
 
     <p>


### PR DESCRIPTION
# What and why

The action plan urls for the action plan report was wrong. I forgot to include the participatory process id.
