### PR TITLE
Add feature flags to participatory processes

### DIFF
--- a/app/assets/stylesheets/barcelona/_navigation.scss
+++ b/app/assets/stylesheets/barcelona/_navigation.scss
@@ -43,7 +43,7 @@
   margin-bottom: rem-calc(15);
 }
 
-.main-menu{
+.main-menu, .menu{
   .toggle-menu{
     display: block;
     text-align: center;

--- a/app/controllers/action_plans_controller.rb
+++ b/app/controllers/action_plans_controller.rb
@@ -1,4 +1,6 @@
 class ActionPlansController < ApplicationController
+  before_filter { |c| c.check_participatory_process_flags :action_plans }
+
   include ModerateActions
 
   load_and_authorize_resource

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -10,5 +10,4 @@ class Admin::BaseController < ApplicationController
     def verify_administrator
       raise CanCan::AccessDenied unless current_user.try(:administrator?)
     end
-
 end

--- a/app/controllers/admin/participatory_processes_controller.rb
+++ b/app/controllers/admin/participatory_processes_controller.rb
@@ -64,6 +64,7 @@ class Admin::ParticipatoryProcessesController < Admin::BaseController
         :areas,
         :scope,
         :district,
+        :flags => [],
         :title => I18n.available_locales.map(&:to_s),
         :subtitle => I18n.available_locales.map(&:to_s),
         :summary => I18n.available_locales.map(&:to_s),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,4 +130,12 @@ class ApplicationController < ActionController::Base
 
       $redis.sismember("email_notifications_reminder", current_user.id.to_s)
     end
+  
+  protected
+
+    def check_participatory_process_flags(feature)
+      unless @participatory_process.send("has_#{feature}?")
+        redirect_to participatory_process_path(@participatory_process), notice: t('participatory_processes.flash.feature_disabled_notice')
+      end
+    end
 end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -1,5 +1,6 @@
 class DebatesController < ApplicationController
-  include FeatureFlags
+  before_filter { |c| c.check_participatory_process_flags :debates }
+
   include CommentableActions
   include FlagActions
 
@@ -8,8 +9,6 @@ class DebatesController < ApplicationController
   before_action :parse_tag_filter, only: :index
   before_action :set_search_order, only: :index
   before_action :authenticate_user!, except: [:index, :show]
-
-  feature_flag :debates
 
   has_orders %w{hot_score confidence_score created_at relevance}, only: :index
   has_orders %w{most_voted newest oldest}, only: :show

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -1,4 +1,6 @@
 class MeetingsController < ApplicationController
+  before_filter { |c| c.check_participatory_process_flags :meetings }
+
   load_and_authorize_resource
   respond_to :html, :json
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,4 +1,6 @@
 class ProposalsController < ApplicationController
+  before_filter { |c| c.check_participatory_process_flags :proposals }
+
   FEATURED_PROPOSALS_LIMIT = 3
   include CommentableActions
   include FlagActions

--- a/app/models/participatory_process.rb
+++ b/app/models/participatory_process.rb
@@ -1,4 +1,6 @@
 class ParticipatoryProcess < ActiveRecord::Base
+  FLAGS = %w{proposals action_plans meetings debates}
+
   extend FriendlyId
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
@@ -17,4 +19,10 @@ class ParticipatoryProcess < ActiveRecord::Base
   has_many :debates
   has_many :categories
   has_many :subcategories
+
+  FLAGS.each do |feature|
+    define_method "has_#{feature}?" do
+      flags.include?(feature)
+    end
+  end
 end

--- a/app/views/admin/participatory_processes/_form.html.erb
+++ b/app/views/admin/participatory_processes/_form.html.erb
@@ -7,6 +7,11 @@
       <%= f.text_field :name, placeholder: t("participatory_processes.form.participatory_process_name"), label: false %>
     </div>
 
+    <div div class="small-12 column">
+      <%= f.label :flags %>
+      <%= f.collection_check_boxes :flags, ParticipatoryProcess::FLAGS, :to_s, :to_s %>
+    </div>
+
     <% unless participatory_process.new_record? %>
       <div class="small-12 column">
         <%= f.label :slug, t("participatory_processes.form.participatory_process_slug") %>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="row menu-outer">
-  <nav class="main-menu collapsed small-12 columns">
+  <nav class="menu collapsed small-12 columns">
     <span class="toggle-menu">
       <%= fa_icon "bars" %> <%= t 'menu.mobile-menu' %>
     </span>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -5,19 +5,32 @@
     </span>
 
     <div class="menu-items">
-      <%= link_to t("layouts.header.proposals"), proposals_path(participatory_process_id: @participatory_process), class: ("active" if  controller_name == "proposals"), data: {'no-turbolink' => true}  %>
-      <% if can? :read, ActionPlan %>
-        <%= link_to t("layouts.header.action_plans"), action_plans_path(participatory_process_id: @participatory_process), class: ("active" if  controller_name == "action_plans"), data: {'no-turbolink' => true} %>
+      <% if @participatory_process.has_proposals? %>
+        <%= link_to t("layouts.header.proposals"), proposals_path(participatory_process_id: @participatory_process), class: ("active" if  controller_name == "proposals"), data: {'no-turbolink' => true}  %>
       <% end %>
-      <%= link_to t("layouts.header.meetings"), meetings_path(participatory_process_id: @participatory_process), class: ("active" if controller_name == 'meetings'), data: {'no-turbolink' => true} %>
-      <% if feature?(:debates) %>
+
+      <% if @participatory_process.has_action_plans? %>
+        <% if can? :read, ActionPlan %>
+          <%= link_to t("layouts.header.action_plans"), action_plans_path(participatory_process_id: @participatory_process), class: ("active" if  controller_name == "action_plans"), data: {'no-turbolink' => true} %>
+        <% end %>
+      <% end %>
+
+      <% if @participatory_process.has_meetings? %>
+        <%= link_to t("layouts.header.meetings"), meetings_path(participatory_process_id: @participatory_process), class: ("active" if controller_name == 'meetings'), data: {'no-turbolink' => true} %>
+      <% end %>
+
+      <% if @participatory_process.has_debates? %>
         <%= link_to t("layouts.header.debates"), debates_path(participatory_process_id: @participatory_process), class: ("active" if controller_name == "debates"), data: {'no-turbolink' => true} %>
       <% end %>
+
       <% if feature?(:spending_proposals) %>
         <%= link_to t("layouts.header.spending_proposals"), spending_proposals_path(participatory_process_id: @participatory_process), class: ("active" if controller_name == "spending_proposals") %>
       <% end %>
+
       <%= link_to t("categories.title"), categories_path(participatory_process_id: @participatory_process), class: ("active" if controller_name == "categories") %>
+
       <%= link_to t("layouts.header.more_information"), page_path(id: 'more_information', participatory_process_id: @participatory_process), class: ("active" if false)  %>
+      
       <%= link_to t("dataviz.title"), dataviz_index_path(participatory_process_id: @participatory_process), class: ("active" if controller_name == "dataviz")  %>
     </div>
   </nav>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -324,7 +324,7 @@ ca:
       form:
         submit_button: Actualitzar proces
     flash:
-      feature_disabled_notice: Feature disabled notice
+      feature_disabled_notice: Aquest procés no té aquesta funcionalitat activada
     form:
       participatory_process_admin_email: Correu electrònic de l'administrador
       participatory_process_admin_name: Nom de l'administrador

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -323,6 +323,8 @@ ca:
     edit:
       form:
         submit_button: Actualitzar proces
+    flash:
+      feature_disabled_notice: Feature disabled notice
     form:
       participatory_process_admin_email: Correu electrònic de l'administrador
       participatory_process_admin_name: Nom de l'administrador

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,8 @@ en:
     edit:
       form:
         submit_button: Update participatory process
+    flash:
+      feature_disabled_notice: Feature disabled notice
     form:
       participatory_process_admin_email: Admin email
       participatory_process_admin_name: Admin name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,7 +324,7 @@ en:
       form:
         submit_button: Update participatory process
     flash:
-      feature_disabled_notice: Feature disabled notice
+      feature_disabled_notice: This feature is not enabled for this process
     form:
       participatory_process_admin_email: Admin email
       participatory_process_admin_name: Admin name

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -323,6 +323,8 @@ es:
     edit:
       form:
         submit_button: Actualitzar proceso
+    flash:
+      feature_disabled_notice: Feature disabled notice
     form:
       participatory_process_admin_email: Correo electrónico del administrador
       participatory_process_admin_name: Nombre de l'administador

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -324,7 +324,7 @@ es:
       form:
         submit_button: Actualitzar proceso
     flash:
-      feature_disabled_notice: Feature disabled notice
+      feature_disabled_notice: Este proceso no tiene esta funcionalidad activa
     form:
       participatory_process_admin_email: Correo electrónico del administrador
       participatory_process_admin_name: Nombre de l'administador

--- a/db/migrate/20160926074639_flags_as_column.rb
+++ b/db/migrate/20160926074639_flags_as_column.rb
@@ -1,0 +1,5 @@
+class FlagsAsColumn < ActiveRecord::Migration
+  def change
+    add_column :participatory_processes, :flags, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160921074116) do
+ActiveRecord::Schema.define(version: 20160926074639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -380,6 +380,7 @@ ActiveRecord::Schema.define(version: 20160921074116) do
     t.text     "citizenship_scope"
     t.datetime "hidden_at"
     t.datetime "confirmed_hide_at"
+    t.string   "flags",             default: [],                  array: true
   end
 
   create_table "proposal_answers", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -464,6 +464,7 @@ FactoryGirl.define do
     summary do { :en => "Summary", :es => "Resumen", :ca => "Resum" } end
     description do { :en => "Description", :es => "Descripción", :ca => "Descripció" } end
     audience "Tota la població"
-    citizenship_scope "Només poden opinar." 
+    citizenship_scope "Només poden opinar."
+    flags ParticipatoryProcess::FLAGS.map(&:to_s)
   end
 end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -8,11 +8,6 @@ feature 'Debates' do
     Setting['feature.debates.search'] = true
   end
 
-  scenario 'Disabled with a feature flag' do
-    Setting['feature.debates'] = nil
-    expect{ visit debates_path(participatory_process_id: participatory_process) }.to raise_exception(FeatureFlags::FeatureDisabled)
-  end
-
   scenario 'Index' do
     debates = [
       create(:debate, participatory_process: participatory_process),

--- a/spec/features/participatory_process_spec.rb
+++ b/spec/features/participatory_process_spec.rb
@@ -1,0 +1,46 @@
+# coding: utf-8
+require 'rails_helper'
+
+feature 'Participatory processes' do
+  before :each do
+    @full = create(:participatory_process, name: "Complete process")
+    @half = create(:participatory_process, name: "Half process", flags: ["proposals", "debates"])
+  end
+
+  scenario "Index" do
+    visit participatory_processes_path
+    expect(page).to have_content("Complete process")
+    expect(page).to have_content("Half process")
+  end
+
+  scenario "Show process with all features" do
+    visit participatory_processes_path
+    click_link "Complete process"
+    
+    within ".menu .menu-items" do
+      expect(page).to have_content("Proposals")
+      expect(page).to have_content("Action plans")
+      expect(page).to have_content("Presencial meetings")
+      expect(page).to have_content("Debates")
+    end
+  end
+
+  scenario "Show process with half features" do
+    visit participatory_processes_path
+    click_link "Half process"
+    
+    within ".menu .menu-items" do
+      expect(page).to have_content("Proposals")
+      expect(page).to_not have_content("Action plans")
+      expect(page).to_not have_content("Presencial meetings")
+      expect(page).to have_content("Debates")
+    end
+  end
+
+  scenario "Navigate to a disabled feature" do
+    visit meetings_path(participatory_process_id: @half)
+
+    expect(page).to have_content("This feature is not enabled for this process")
+    expect(current_path).to eq(participatory_process_path(@half))
+  end
+end


### PR DESCRIPTION
# What and why

Each participatory process may have different enabled features. I added a `flags` attribute which it is serialized as an array into database.
The participatory process menu hide disabled features.
# GIF Tax

![](https://media.giphy.com/media/FSGZmbhrSmp2g/giphy.gif)
# TODOs
- [x] New tests
- [x] Add flags for proposals, action_plans, meetings and debates
- [x] Tests
- [x] Rebase
