### PR TITLE
Remove default participatory process assumption

### DIFF
--- a/app/controllers/concerns/has_participatory_process.rb
+++ b/app/controllers/concerns/has_participatory_process.rb
@@ -6,10 +6,7 @@ module HasParticipatoryProcess
 
     def participatory_process
       begin
-        if params[:participatory_process_id].blank?
-          # TODO: load from subdomain?
-          @participatory_process = ParticipatoryProcess.first
-        else
+        if params[:participatory_process_id]
           @participatory_process_id = params[:participatory_process_id]
           @participatory_process = ParticipatoryProcess.find(params[:participatory_process_id])
         end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -12,6 +12,7 @@ class WelcomeController < ApplicationController
   end
 
   def welcome
+    @main_participatory_process = ParticipatoryProcess.first
   end
 
   def highlights

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -8,6 +8,7 @@ class WelcomeController < ApplicationController
 
   def index
     @categories = Category.order(:position).decorate
+    @main_participatory_process = ParticipatoryProcess.first
   end
 
   def welcome

--- a/app/views/participatory_processes/show.html.erb
+++ b/app/views/participatory_processes/show.html.erb
@@ -4,8 +4,8 @@
       <div class="small-12 columns">
         <h1><%= @participatory_process.title %></h1>
         <h2><%= @participatory_process.subtitle %></h2>
-        <p><%= @participatory_process.summary.html_safe %></p>
-        <p><%= @participatory_process.description.html_safe %></p>
+        <p><%== @participatory_process.summary %></p>
+        <p><%== @participatory_process.description %></p>
       </div>
     </div>
   </div>

--- a/app/views/shared/_categories.html.erb
+++ b/app/views/shared/_categories.html.erb
@@ -1,7 +1,7 @@
 <ul class="category-list">
   <% categories.each do |category| %>
     <li>
-      <%= link_to categories_path(participatory_process_id: @participatory_process, anchor: dom_id(category)), class: "#{dom_id(category)} category-item" do %>
+      <%= link_to categories_path(participatory_process_id: @main_participatory_process, anchor: dom_id(category)), class: "#{dom_id(category)} category-item" do %>
         <span class="name">
           <%= category.name %>
         </span>

--- a/app/views/verification/letter/show.html.erb
+++ b/app/views/verification/letter/show.html.erb
@@ -17,6 +17,6 @@
       %>
     </div>
 
-    <%= link_to t("verification.letter.edit.see_all"), proposals_path(participatory_process_id: @participatory_process), class: "button warning radius" %>
+    <%= link_to t("verification.letter.edit.see_all"), proposals_path(participatory_process_id: ParticipatoryProcess.first), class: "button warning radius" %>
   </div>
 </div>

--- a/app/views/welcome/_download.html.erb
+++ b/app/views/welcome/_download.html.erb
@@ -6,8 +6,8 @@
         <h4><%= t 'welcome.download.subtitle' %></h4>
       </div>
       <div class="download-buttons">
-        <%= link_to action_plans_path(participatory_process_id: @participatory_process.slug), class: 'download-pam' do %><span><%= t('welcome.download.links.pam') %></span><% end %>
-        <%= link_to page_path(id: 'download', participatory_process_id: @participatory_process), class: 'download-epub' do %><span><%= t('welcome.download.links.epub') %></span><% end %>
+        <%= link_to action_plans_path(participatory_process_id: @main_participatory_process.slug), class: 'download-pam' do %><span><%= t('welcome.download.links.pam') %></span><% end %>
+        <%= link_to page_path(id: 'download', participatory_process_id: @main_participatory_process), class: 'download-epub' do %><span><%= t('welcome.download.links.epub') %></span><% end %>
       </div>
     </div>
   </div>

--- a/app/views/welcome/_header.html.erb
+++ b/app/views/welcome/_header.html.erb
@@ -6,12 +6,12 @@
     </div>
     <div class="header-grid">
       <div class="explanation small-12 large-6 columns">
-        <%= link_to dataviz_path(id: 'summary', participatory_process_id: @participatory_process), class: "cell about" do %><span><%= t ".links.about" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
+        <%= link_to dataviz_path(id: 'summary', participatory_process_id: @main_participatory_process), class: "cell about" do %><span><%= t ".links.about" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
       </div>
       <div class="sections small-12 large-6 columns">
-        <%= link_to dataviz_path(id: 'proposals', participatory_process_id: @participatory_process), class: "cell proposals" do %><span><%= t ".links.proposals" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
-        <%= link_to dataviz_path(id: 'map', participatory_process_id: @participatory_process), class: "cell meetings" do %><span><%= t ".links.meetings" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
-        <%= link_to dataviz_path(id: 'total_interactions', participatory_process_id: @participatory_process), class: "cell network" do %><span><%= t ".links.network" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
+        <%= link_to dataviz_path(id: 'proposals', participatory_process_id: @main_participatory_process), class: "cell proposals" do %><span><%= t ".links.proposals" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
+        <%= link_to dataviz_path(id: 'map', participatory_process_id: @main_participatory_process), class: "cell meetings" do %><span><%= t ".links.meetings" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
+        <%= link_to dataviz_path(id: 'total_interactions', participatory_process_id: @main_participatory_process), class: "cell network" do %><span><%= t ".links.network" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
       </div>
     </div>
   </section>

--- a/app/views/welcome/_header_results.html.erb
+++ b/app/views/welcome/_header_results.html.erb
@@ -6,10 +6,10 @@
     </div>
     <div class="header-grid">
       <div class="explanation small-12 large-6 columns">
-        <%= link_to dataviz_path(id: 'action_plans', participatory_process_id: @participatory_process), class: "cell big explore" do %><span><%= t ".links.explore" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
+        <%= link_to dataviz_path(id: 'action_plans', participatory_process_id: @main_participatory_process), class: "cell big explore" do %><span><%= t ".links.explore" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
       </div>
       <div class="sections small-12 large-6 columns">
-        <%= link_to action_plans_path(participatory_process_id: @participatory_process.slug), class: "cell big action_plans" do %><span><%= t ".links.action_plans" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
+        <%= link_to action_plans_path(participatory_process_id: @main_participatory_process.slug), class: "cell big action_plans" do %><span><%= t ".links.action_plans" %> <%= bcn_icon "dit_assenyala" %></span><% end %>
       </div>
     </div>
   </section>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -19,7 +19,7 @@
               <li><%== t ".statistics.action_plans", count: number_with_delimiter(statistics.action_plans) %></li>
             </ul>
           </div>
-          <%= link_to action_plans_path(participatory_process_id: @participatory_process.slug), class: 'header-link' do %>
+          <%= link_to action_plans_path(participatory_process_id: @main_participatory_process.slug), class: 'header-link' do %>
             <%= t 'welcome.header-motto.link' %>
             <%= bcn_icon('dit_assenyala_vermell') %>
           <% end %>

--- a/app/views/welcome/welcome.html.erb
+++ b/app/views/welcome/welcome.html.erb
@@ -22,6 +22,6 @@
     <%= t("welcome.welcome.skip_verification") %>
   </p>
   <p class="text-center">
-    <%= link_to t("welcome.welcome.see_proposals"), proposals_path(participatory_process_id: @participatory_process) , class: "button secondary radius" %>
+    <%= link_to t("welcome.welcome.see_proposals"), proposals_path(participatory_process_id: @main_participatory_process) , class: "button secondary radius" %>
   </p>
 </div>


### PR DESCRIPTION
This removes the default participatory process assumption in order to detect pages where we're loading the first participatory process. This also levels the ground in order to start implementing the layout.
