### PR TITLE
Move flags from participatory process to steps. Closes #491.

### DIFF
--- a/app/models/participatory_process.rb
+++ b/app/models/participatory_process.rb
@@ -1,6 +1,4 @@
 class ParticipatoryProcess < ActiveRecord::Base
-  FLAGS = %w{proposals action_plans meetings debates}
-
   extend FriendlyId
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
@@ -21,9 +19,11 @@ class ParticipatoryProcess < ActiveRecord::Base
   has_many :subcategories
   has_many :steps
 
-  FLAGS.each do |feature|
-    define_method "has_#{feature}?" do
-      flags.include?(feature)
-    end
+  Step::FLAGS.each do |feature|
+    delegate "has_#{feature}?", to: :active_step
+  end
+
+  def active_step
+    @active_step ||= steps.where(active: true).first
   end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,4 +1,5 @@
 class Step < ActiveRecord::Base
+  FLAGS = %w{proposals action_plans meetings debates}
   belongs_to :participatory_process
 
   acts_as_paranoid column: :hidden_at
@@ -6,4 +7,10 @@ class Step < ActiveRecord::Base
 
   serialize :title, JSON
   serialize :description, JSON
+
+  FLAGS.each do |feature|
+    define_method "has_#{feature}?" do
+      flags.include?(feature)
+    end
+  end
 end

--- a/app/views/admin/participatory_processes/_form.html.erb
+++ b/app/views/admin/participatory_processes/_form.html.erb
@@ -7,11 +7,6 @@
       <%= f.text_field :name, placeholder: t("participatory_processes.form.participatory_process_name"), label: false %>
     </div>
 
-    <div div class="small-12 column">
-      <%= f.label :flags %>
-      <%= f.collection_check_boxes :flags, ParticipatoryProcess::FLAGS, :to_s, :to_s %>
-    </div>
-
     <% unless participatory_process.new_record? %>
       <div class="small-12 column">
         <%= f.label :slug, t("participatory_processes.form.participatory_process_slug") %>

--- a/app/views/admin/steps/_form.html.erb
+++ b/app/views/admin/steps/_form.html.erb
@@ -32,6 +32,11 @@
       <%= f.number_field :position, label: false %>
     </div>
 
+    <div div class="small-12 column">
+      <%= f.label :flags %>
+      <%= f.collection_check_boxes :flags, Step::FLAGS, :to_s, :to_s %>
+    </div>
+
     <div class="actions small-12 column">
       <%= f.submit(class: "button radius", value: t("#{resource_name.pluralize}.#{action_name}.form.submit_button")) %>
     </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -25,7 +25,7 @@
 
   <div class="main-menu-wrapper">
     <%= render partial: 'layouts/main_menu' %>
-    <% if @participatory_process.present? %>
+    <% if @participatory_process.present? && !controller_path.match(/^admin/) %>
       <%= render partial: 'layouts/menu' %>
     <% end %>
   </div>

--- a/db/migrate/20161005062732_add_flags_to_steps.rb
+++ b/db/migrate/20161005062732_add_flags_to_steps.rb
@@ -1,0 +1,5 @@
+class AddFlagsToSteps < ActiveRecord::Migration
+  def change
+    add_column :steps, :flags, :string, array: true, default: []
+  end
+end

--- a/db/migrate/20161005062754_remove_flags_to_participatory_processes.rb
+++ b/db/migrate/20161005062754_remove_flags_to_participatory_processes.rb
@@ -1,0 +1,5 @@
+class RemoveFlagsToParticipatoryProcesses < ActiveRecord::Migration
+  def change
+    remove_column :participatory_processes, :flags
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161004102226) do
+ActiveRecord::Schema.define(version: 20161005062754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -380,7 +380,6 @@ ActiveRecord::Schema.define(version: 20161004102226) do
     t.text     "citizenship_scope"
     t.datetime "hidden_at"
     t.datetime "confirmed_hide_at"
-    t.string   "flags",             default: [],                  array: true
   end
 
   create_table "proposal_answers", force: :cascade do |t|
@@ -489,6 +488,7 @@ ActiveRecord::Schema.define(version: 20161004102226) do
     t.boolean  "active",                   default: false
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
+    t.string   "flags",                    default: [],                 array: true
   end
 
   create_table "subcategories", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -466,7 +466,9 @@ FactoryGirl.define do
     description do { :en => "Description", :es => "Descripción", :ca => "Descripció" } end
     audience "Tota la població"
     citizenship_scope "Només poden opinar."
-    flags ParticipatoryProcess::FLAGS.map(&:to_s)
+    after(:create) do |participatory_process|
+      create(:step, active: true, participatory_process: participatory_process)
+    end
   end
 
   factory :step do
@@ -474,6 +476,7 @@ FactoryGirl.define do
     description do { en: "lorem ipsum lorem ipsum", es: "lorem ipsum lorem ipsum", ca: "lorem ipsum lorem ipsum" } end
     start_at Date.today
     end_at Date.today + 1.year
+    flags Step::FLAGS.map(&:to_s)
     participatory_process
   end
 end

--- a/spec/features/admin/step_spec.rb
+++ b/spec/features/admin/step_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 feature 'Admin steps' do
   background do
     @participatory_process = create(:participatory_process, name: "test")
+    @participatory_process.steps.delete_all
     admin = create(:administrator)
     login_as(admin)
   end

--- a/spec/features/admin/step_spec.rb
+++ b/spec/features/admin/step_spec.rb
@@ -27,6 +27,9 @@ feature 'Admin steps' do
 
     fill_in "step_position", with: 0
 
+    check "proposals"
+    check "debates"
+
     click_button "Create step"
 
     expect(page).to have_content "Step created successfully."

--- a/spec/features/participatory_process_spec.rb
+++ b/spec/features/participatory_process_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 feature 'Participatory processes' do
   before :each do
     @full = create(:participatory_process, name: "Complete process")
-    @half = create(:participatory_process, name: "Half process", flags: ["proposals", "debates"])
+    @half = create(:participatory_process, name: "Half process")
+    @half.active_step.update_attribute(:flags, ["proposals", "debates"])
   end
 
   scenario "Index" do


### PR DESCRIPTION
# What and why

As requested here #491 I have migrated the features enabled or flags to participatory process steps.
# Acceptance criteria

Features can be enabled/disabled when editing a step. A participatory process has as many features as its active step.
# GIF

![](https://media.giphy.com/media/flbElEhvXDf7W/giphy.gif)
