### PR TITLE
Add published flag to participatory processes

### DIFF
--- a/app/controllers/admin/participatory_processes_controller.rb
+++ b/app/controllers/admin/participatory_processes_controller.rb
@@ -1,48 +1,56 @@
 class Admin::ParticipatoryProcessesController < Admin::BaseController
+  has_filters %w{published unpublished}, only: :index
+
   authorize_resource
 
   def index
-    @participatory_processes = ParticipatoryProcess.with_hidden.page(params[:page])
+    @participatory_processes = ParticipatoryProcess.send(@current_filter).with_hidden.page(params[:page])
   end
 
   def new
-    @new_participatory_process = ParticipatoryProcess.new
+    @participatory_process = ParticipatoryProcess.new
   end
 
   def create
-    @new_participatory_process = ParticipatoryProcess.new(strong_params)
+    @participatory_process = ParticipatoryProcess.new(strong_params)
 
-    if @new_participatory_process.save
-      redirect_to admin_participatory_processes_url, notice: t('flash.actions.create.notice', resource_name: "Participatory process")
+    if @participatory_process.save
+      redirect_to admin_participatory_processes_url(published: false), notice: t('flash.actions.create.notice', resource_name: "Participatory process")
     else
       render :new
     end
   end
 
   def edit
-    @edit_participatory_process = ParticipatoryProcess.find(params[:id])
+    @participatory_process = ParticipatoryProcess.find(params[:id])
   end
 
   def update
-    @edit_participatory_process = ParticipatoryProcess.find(params[:id])
-    @edit_participatory_process.assign_attributes(strong_params)
-    if @edit_participatory_process.save
-      redirect_to admin_participatory_processes_url, notice: t('flash.actions.update.notice', resource_name: "Participatory process")
+    @participatory_process = ParticipatoryProcess.find(params[:id])
+    @participatory_process.assign_attributes(strong_params)
+    if @participatory_process.save
+      redirect_to admin_participatory_processes_url(published: @participatory_process.published), notice: t('flash.actions.update.notice', resource_name: "Participatory process")
     else
       render :edit
     end
   end
 
   def destroy
-    @destroy_participatory_process = ParticipatoryProcess.find(params[:id])
-    @destroy_participatory_process.destroy
-    redirect_to admin_participatory_processes_url, notice: t('flash.actions.destroy.notice', resource_name: "Participatory process")
+    @participatory_process = ParticipatoryProcess.find(params[:id])
+    @participatory_process.destroy
+    redirect_to admin_participatory_processes_url(published: @participatory_process.published), notice: t('flash.actions.destroy.notice', resource_name: "Participatory process")
   end
 
   def restore
-    @restore_participatory_process = ParticipatoryProcess.with_hidden.find(params[:id])
-    @restore_participatory_process.restore
-    redirect_to admin_participatory_processes_url, notice: t('flash.actions.update.notice', resource_name: "Participatory process")
+    @participatory_process = ParticipatoryProcess.with_hidden.find(params[:id])
+    @participatory_process.restore
+    redirect_to admin_participatory_processes_url(published: @participatory_process.published), notice: t('flash.actions.update.notice', resource_name: "Participatory process")
+  end
+
+  def publish
+    @participatory_process = ParticipatoryProcess.find(params[:id])
+    @participatory_process.update_attribute(:published, true)
+    redirect_to admin_participatory_processes_url(published: true), notice: t('flash.actions.update.notice', resource_name: "Participatory process")
   end
 
   private

--- a/app/controllers/concerns/api/has_participatory_process.rb
+++ b/app/controllers/concerns/api/has_participatory_process.rb
@@ -7,7 +7,7 @@ module Api::HasParticipatoryProcess
     def participatory_process
       begin
         if params[:participatory_process_id].present?
-          @participatory_process = ParticipatoryProcess.find(params[:participatory_process_id])
+          @participatory_process = ParticipatoryProcess.published.find(params[:participatory_process_id])
         end
       rescue
         render json: {error: "Not found"}, status: 404

--- a/app/controllers/concerns/has_participatory_process.rb
+++ b/app/controllers/concerns/has_participatory_process.rb
@@ -8,7 +8,7 @@ module HasParticipatoryProcess
       begin
         if params[:participatory_process_id]
           @participatory_process_id = params[:participatory_process_id]
-          @participatory_process = ParticipatoryProcess.find(params[:participatory_process_id]).decorate
+          @participatory_process = ParticipatoryProcess.published.find(params[:participatory_process_id]).decorate
         end
       rescue
         raise ActionController::RoutingError.new('Not Found')

--- a/app/controllers/participatory_processes_controller.rb
+++ b/app/controllers/participatory_processes_controller.rb
@@ -5,10 +5,10 @@ class ParticipatoryProcessesController < ApplicationController
   layout -> { params[:action] == 'show' ? "participatory_process" : "application" }
 
   def index
-    @participatory_processes = ParticipatoryProcess.all
+    @participatory_processes = ParticipatoryProcess.published.all
   end
 
   def show
-    @participatory_process = ParticipatoryProcess.find(params[:id]).decorate
+    @participatory_process = ParticipatoryProcess.published.find(params[:id]).decorate
   end
 end

--- a/app/models/participatory_process.rb
+++ b/app/models/participatory_process.rb
@@ -4,6 +4,7 @@ class ParticipatoryProcess < ActiveRecord::Base
   include ActsAsParanoidAliases
 
   scope :published, -> { where(published: true) }
+  scope :unpublished, -> { where(published: false) }
 
   validates :name, presence: true
   friendly_id :name, use: [:slugged, :finders]

--- a/app/models/participatory_process.rb
+++ b/app/models/participatory_process.rb
@@ -3,6 +3,8 @@ class ParticipatoryProcess < ActiveRecord::Base
   acts_as_paranoid column: :hidden_at
   include ActsAsParanoidAliases
 
+  scope :published, -> { where(published: true) }
+
   validates :name, presence: true
   friendly_id :name, use: [:slugged, :finders]
 

--- a/app/views/admin/participatory_processes/edit.html.erb
+++ b/app/views/admin/participatory_processes/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="participatory-process-edit row">
   <div class="small-12 medium-9 column">
-    <%= render "form", participatory_process: @edit_participatory_process, resource_name: 'participatory_process', form_url: admin_participatory_process_path(@edit_participatory_process) %>
+    <%= render "form", participatory_process: @participatory_process, resource_name: 'participatory_process', form_url: admin_participatory_process_path(@participatory_process) %>
   </div>
 </div>

--- a/app/views/admin/participatory_processes/index.html.erb
+++ b/app/views/admin/participatory_processes/index.html.erb
@@ -10,6 +10,8 @@
         <%= link_to t('admin.participatory_processes.index.steps'), admin_participatory_process_steps_path(process), class: "button tiny radius" %>
         <% unless process.published? %>
           <%= link_to t('admin.participatory_processes.index.publish'), publish_admin_participatory_process_path(process), method: :put, class: "button tiny radius", data: { confirm: t('admin.actions.confirm') } %>
+        <% else %>
+          <%= link_to t('admin.participatory_processes.index.unpublish'), unpublish_admin_participatory_process_path(process), method: :put, class: "button tiny radius", data: { confirm: t('admin.actions.confirm') } %>
         <% end %>
         <% if process.hidden? %>
           <%= link_to t('admin.participatory_processes.index.restore'), restore_admin_participatory_process_path(process), method: :put, class: "button tiny radius" %>

--- a/app/views/admin/participatory_processes/index.html.erb
+++ b/app/views/admin/participatory_processes/index.html.erb
@@ -1,4 +1,5 @@
 <h2><%= t("admin.participatory_processes.index.title") %></h2>
+<%= render 'shared/filter_subnav', i18n_namespace: "admin.participatory_processes.index" %>
 <h3><%= page_entries_info @participatory_processes %></h3>
 <ul id="participatory_processes" class="admin-list">
   <% @participatory_processes.each do |process| %>
@@ -7,6 +8,9 @@
       <span><%= " (/" + process.slug + ")" %></span>
       <div class="right">
         <%= link_to t('admin.participatory_processes.index.steps'), admin_participatory_process_steps_path(process), class: "button tiny radius" %>
+        <% unless process.published? %>
+          <%= link_to t('admin.participatory_processes.index.publish'), publish_admin_participatory_process_path(process), method: :put, class: "button tiny radius", data: { confirm: t('admin.actions.confirm') } %>
+        <% end %>
         <% if process.hidden? %>
           <%= link_to t('admin.participatory_processes.index.restore'), restore_admin_participatory_process_path(process), method: :put, class: "button tiny radius" %>
         <% else %>

--- a/app/views/admin/participatory_processes/new.html.erb
+++ b/app/views/admin/participatory_processes/new.html.erb
@@ -1,5 +1,5 @@
 <div class="participatory-process-edit row">
   <div class="small-12 medium-9 column">
-    <%= render "form", participatory_process: @new_participatory_process, resource_name: 'participatory_process', form_url: admin_participatory_processes_path %>
+    <%= render "form", participatory_process: @participatory_process, resource_name: 'participatory_process', form_url: admin_participatory_processes_path %>
   </div>
 </div>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -57,6 +57,11 @@ ca:
     new:
       form:
         submit_button: Crear actuació
+  admin:
+    participatory_processes:
+      index:
+        publish: Publish
+        unpublish: Unpublish
   application:
     close: Tancar
   categories:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,11 @@ en:
     new:
       form:
         submit_button: Create action plan
+  admin:
+    participatory_processes:
+      index:
+        publish: Publish
+        unpublish: Unpublish
   application:
     close: Close
   categories:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -57,6 +57,11 @@ es:
     new:
       form:
         submit_button: Crear actuación
+  admin:
+    participatory_processes:
+      index:
+        publish: Publish
+        unpublish: Unpublish
   application:
     close: Cerrar
   categories:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,7 @@ Rails.application.routes.draw do
       member do
         put :restore
         put :publish
+        put :unpublish
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,7 @@ Rails.application.routes.draw do
       end
       member do
         put :restore
+        put :publish
       end
     end
   end

--- a/db/migrate/20161010073413_add_published_to_participatory_processes.rb
+++ b/db/migrate/20161010073413_add_published_to_participatory_processes.rb
@@ -1,0 +1,5 @@
+class AddPublishedToParticipatoryProcesses < ActiveRecord::Migration
+  def change
+    add_column :participatory_processes, :published, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161005062754) do
+ActiveRecord::Schema.define(version: 20161010073413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -382,6 +382,7 @@ ActiveRecord::Schema.define(version: 20161005062754) do
     t.datetime "confirmed_hide_at"
     t.string   "full_image"
     t.string   "banner_image"
+    t.boolean  "published",         default: false
   end
 
   create_table "proposal_answers", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -453,6 +453,7 @@ FactoryGirl.define do
     description do { :en => "Description", :es => "Descripción", :ca => "Descripció" } end
     audience "Tota la població"
     citizenship_scope "Només poden opinar."
+    published true
     after(:create) do |participatory_process|
       create(:step, active: true, participatory_process: participatory_process)
     end

--- a/spec/features/admin/participatory_process_spec.rb
+++ b/spec/features/admin/participatory_process_spec.rb
@@ -96,4 +96,17 @@ feature 'Admin participatory processes' do
     expect(page).to have_content("test")
     expect(page).to_not have_css("a", text: "Publish")
   end
+  
+  scenario "Unpublish a participatory process", :js do
+    ParticipatoryProcess.delete_all
+    create(:participatory_process, name: "test", published: true)
+
+    visit admin_participatory_processes_path
+
+    click_link "Unpublish"
+
+    expect(page).to have_css(".sub-nav .active span", text: "Unpublished")
+    expect(page).to have_content("test")
+    expect(page).to have_css("a", text: "Publish")
+  end
 end

--- a/spec/features/admin/participatory_process_spec.rb
+++ b/spec/features/admin/participatory_process_spec.rb
@@ -83,4 +83,17 @@ feature 'Admin participatory processes' do
 
     expect(page).to_not have_content "Restore"
   end
+
+  scenario "Publish a participatory process", :js do
+    create(:participatory_process, name: "test", published: false)
+
+    visit admin_participatory_processes_path
+
+    click_link "Unpublished"
+    click_link "Publish"
+
+    expect(page).to have_css(".sub-nav .active span", text: "Published")
+    expect(page).to have_content("test")
+    expect(page).to_not have_css("a", text: "Publish")
+  end
 end

--- a/spec/features/participatory_process_spec.rb
+++ b/spec/features/participatory_process_spec.rb
@@ -5,6 +5,7 @@ feature 'Participatory processes' do
   before :each do
     @full = create(:participatory_process, name: "Complete process")
     @half = create(:participatory_process, name: "Half process")
+    @unpublished = create(:participatory_process, name: "Unpublished", published: false)
     @half.active_step.update_attribute(:flags, ["proposals", "debates"])
   end
 
@@ -12,6 +13,7 @@ feature 'Participatory processes' do
     visit participatory_processes_path
     expect(page).to have_content("Complete process")
     expect(page).to have_content("Half process")
+    expect(page).to_not have_content("Unpublished")
   end
 
   scenario "Show process with all features" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,7 @@ RSpec.configure do |config|
   config.before(:each, type: :feature) do
     Bullet.start_request
 
-    ParticipatoryProcess.create(name: "pam")
+    create(:participatory_process, name: "pam")
 
     Setting['feature.debates'] = true
     Setting['feature.spending_proposals'] = true


### PR DESCRIPTION
# What and why

Explained at #496 
# Acceptance criteria

An admin can publish and unpublish participatory processes. Only published participatory processes are public to standard users.
# GIF Tax

![](https://media.giphy.com/media/26hisTycIYYjQ4zjq/giphy.gif)
