### PR TITLE
Fix categories and more_information pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ config/locales/*.csv
 
 app/assets/javascripts/bundle*
 app/assets/stylesheets/bundle*
+
+# Ignore emacs temp files
+.#*

--- a/app/controllers/concerns/has_participatory_process.rb
+++ b/app/controllers/concerns/has_participatory_process.rb
@@ -11,7 +11,7 @@ module HasParticipatoryProcess
           @participatory_process = ParticipatoryProcess.first
         else
           @participatory_process_id = params[:participatory_process_id]
-          @participatory_process = ParticipatoryProcess.published.find(params[:participatory_process_id]).decorate
+          @participatory_process = ParticipatoryProcess.published.find(params[:participatory_process_id])
         end
       rescue
         raise ActionController::RoutingError.new('Not Found')

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-FactoryGirl.define do  factory :participatory_process_attachment do
+FactoryGirl.define do
   factory :newsletter do
     title do { I18n.default_locale => "Newsletter subject" } end
     body do {I18n.default_locale => "Newsletter body" } end

--- a/spec/features/admin/.#participatory_process_spec.rb
+++ b/spec/features/admin/.#participatory_process_spec.rb
@@ -1,1 +1,0 @@
-josepjaume@Joseps-MacBook-Pro.local.46176


### PR DESCRIPTION
# What and why

Fix #590 
# Acceptance criteria

These pages works:
`/pam/categories`
`/pam/more_information`
# GIF

![](https://media.giphy.com/media/l2JhwIWzwUJO1I2OI/source.gif)
