### PR TITLE
Discard disabled steps

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -11,7 +11,7 @@ class Step < ActiveRecord::Base
   serialize :description, JSON
 
   def self.step_for(participatory_process, flag)
-    participatory_process.steps.reverse.detect do |step|
+    participatory_process.steps.select{ |s| s.enabled? }.detect do |step|
       step.flags.map(&:to_s).include?(flag.to_s)
     end
   end


### PR DESCRIPTION
This discards disabled steps on the `step_for` method (which is used to generate links that don't have a context step).
