### PR TITLE
Ensure proposal is loaded before answer

### DIFF
--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -33,10 +33,10 @@ class ProposalShow extends Component {
     const { fetchProposal, fetchAnswer, proposalId } = this.props;
 
     fetchProposal(proposalId).then(() => {
-      this.setState({ loading: false });
+      fetchAnswer(proposalId).then(() => {
+        this.setState({ loading: false });
+      })
     });
-
-    fetchAnswer(proposalId);
   }
 
   render() {


### PR DESCRIPTION
# What and why

Fix a race condition between loading proposal and proposal answer in production
# GIF

![](https://media.giphy.com/media/13AOZpnVPjpkAM/giphy.gif)
