### PR TITLE
Ensure a process is visible for specific user roles

### DIFF
--- a/app/controllers/concerns/api/has_participatory_process.rb
+++ b/app/controllers/concerns/api/has_participatory_process.rb
@@ -7,7 +7,11 @@ module Api::HasParticipatoryProcess
     def participatory_process
       begin
         if params[:participatory_process_id].present?
-          @participatory_process = ParticipatoryProcess.published.find(params[:participatory_process_id])
+          @participatory_process_id ||= params[:participatory_process_id]
+          @participatory_process ||= ParticipatoryProcess.find(params[:participatory_process_id])
+          raise ActionController::RoutingError.new("Not allowed") unless can?(:read, @participatory_process)
+
+          @participatory_process
         end
       rescue
         render json: {error: "Not found"}, status: 404

--- a/app/controllers/participatory_processes_controller.rb
+++ b/app/controllers/participatory_processes_controller.rb
@@ -17,7 +17,8 @@ class ParticipatoryProcessesController < ApplicationController
   end
 
   def show
-    @participatory_process = ParticipatoryProcess.find(params[:id]).decorate
+    @participatory_process = ParticipatoryProcess.find(params[:id])
     authorize! :read, @participatory_process
+    @participatory_process = @participatory_process.decorate
   end
 end

--- a/app/controllers/participatory_processes_controller.rb
+++ b/app/controllers/participatory_processes_controller.rb
@@ -18,5 +18,6 @@ class ParticipatoryProcessesController < ApplicationController
 
   def show
     @participatory_process = ParticipatoryProcess.find(params[:id]).decorate
+    authorize! :read, @participatory_process
   end
 end


### PR DESCRIPTION
# What and why

There were a few issues related to participatory process vibility:
- An unpublished process was not visible through API. If user roles can read an unpublished participatory process the API should work
- An unpublished process public page was visible for all users
# GIF

![](https://media.giphy.com/media/d5x4HPXPNqsms/giphy.gif)
