### PR TITLE
[MERGE ASAP] Ignore spacemacs tmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ config/locales/*.csv
 app/assets/javascripts/bundle*
 app/assets/stylesheets/bundle*
 screenshot_*
+
+# Spacemacs tmp files
+.#*

--- a/spec/features/.#registration_form_spec.rb
+++ b/spec/features/.#registration_form_spec.rb
@@ -1,1 +1,0 @@
-josepjaume@Joseps-MBP.84037


### PR DESCRIPTION
# What and why

We need to remove spacemacs tmp files in order to pass the builds.
