### PR TITLE
Ensure action plans and proposals work fine together

### DIFF
--- a/app/frontend/proposals/proposal.component.js
+++ b/app/frontend/proposals/proposal.component.js
@@ -37,7 +37,7 @@ class Proposal extends Component {
                 created_at={ proposal.created_at }
                 author={ proposal.author }/>
             </div>
-            <ProposalStatusBadge answer={proposal.answer} />
+            <ProposalStatusBadge flags={flags} answer={proposal.answer} />
             <p>
               {htmlToReact(simpleFormat(proposal.summary))}
             </p>

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -131,7 +131,7 @@ class ProposalShow extends Component {
               </div>
               <div className="columns mediumlarge-8 mediumlarge-pull-4">
                 <div className="section">
-                  <ProposalStatusBadge answer={proposal.answer} />
+                  <ProposalStatusBadge flags={flags} answer={proposal.answer} />
                   {htmlToReact(simpleFormat(summary))}
                   <br />
                   {this.renderExternalUrl(external_url)}

--- a/app/frontend/proposals/proposal_status_badge.component.js
+++ b/app/frontend/proposals/proposal_status_badge.component.js
@@ -2,9 +2,9 @@ import { Component, PropTypes } from 'react';
 
 export default class ProposalStatusBadge extends Component {
   render() {
-    const { answer } = this.props;
+    const { answer, flags } = this.props;
   
-    if (answer) {
+    if (answer && flags.action_plans) {
       const { status } = answer;
 
       if (status === 'accepted') {
@@ -22,5 +22,6 @@ export default class ProposalStatusBadge extends Component {
 }
 
 ProposalStatusBadge.propTypes = {
-  answer: PropTypes.object
+  answer: PropTypes.object,
+  flags: PropTypes.object
 };

--- a/app/frontend/proposals/proposal_vote_button.component.js
+++ b/app/frontend/proposals/proposal_vote_button.component.js
@@ -21,7 +21,7 @@ class ProposalVoteButton extends Component {
     const { participatoryProcess } = this.props;
     const { step } = participatoryProcess;
     const { flags } = step;
-    const votesDisabled = flags.proposal_readonly || !flags.enable_proposal_votes;
+    const votesDisabled = flags.proposals_readonly || !flags.enable_proposal_votes;
 
     if (votesDisabled) {
       return (

--- a/app/frontend/proposals/proposals_filters.component.js
+++ b/app/frontend/proposals/proposals_filters.component.js
@@ -37,15 +37,26 @@ class ProposalsFilters extends Component {
 
         <ReviewerFilter />
 
-        <FilterOptionGroup 
-          isExclusive={true}
-          filterGroupName="review_status"
-          filterGroupValue={this.props.filters.filter["review_status"]}
-          onChangeFilterGroup={(name, value) => this.props.setFilterGroup(name, value) }>
-          <FilterOption filterName="accepted" />
-          <FilterOption filterName="rejected" />
-        </FilterOptionGroup>
+        {
+          (() => {
+            if (flags.action_plans) {
+              return (
+                <FilterOptionGroup
+                  isExclusive={true}
+                  filterGroupName="review_status"
+                  filterGroupValue={this.props.filters.filter["review_status"]}
+                  onChangeFilterGroup={(name, value) => this.props.setFilterGroup(name, value) }>
+                  <FilterOption filterName="accepted" />
+                  <FilterOption filterName="rejected" />
+                </FilterOptionGroup>
+              );
+            }
+            return null;
+          })()
+        }
+
         <UserInteractionFilter />
+
         {
           (() => {
             if (flags.enable_proposal_scope) {
@@ -56,6 +67,7 @@ class ProposalsFilters extends Component {
             return null;
           })()
         }
+
         <CategoryFilterOptionGroup />
         <SubcategoryFilterOptionGroup />
         <FilterOptionGroup 

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -1,5 +1,5 @@
 module ComponentsHelper
-  def react_app(name, props = {}) 
+  def react_app(name, props = {})
     props.merge!({
       session: {
         signed_in: user_signed_in?,
@@ -15,8 +15,8 @@ module ComponentsHelper
         id: @participatory_process_id,
         step: {
           id: @participatory_process_step.id,
-          flags: Step::FLAGS.inject({}) do |acc, step|
-            acc[step] = @participatory_process.feature_enabled? step
+          flags: Step::FLAGS.inject({}) do |acc, feature|
+            acc[feature] = @participatory_process_step.feature_enabled? feature
             acc
           end
         }


### PR DESCRIPTION
# WARNING

**TLDR: proposals flag should be enabled if action plans are enabled**
**This PR fixes a few bugs detected when action plans is not enabled and proposals show too much information. If action plans is enabled, proposals should be enabled as well in order to show the answer filter and badge.**

# What and why

Closes #720

# GIF

![](https://media.giphy.com/media/fAv2n4Tlhshig/giphy.gif)