### PR TITLE
Add proposal vote limit

### DIFF
--- a/app/controllers/admin/steps_controller.rb
+++ b/app/controllers/admin/steps_controller.rb
@@ -74,6 +74,7 @@ class Admin::StepsController < Admin::BaseController
         :position,
         :start_at,
         :end_at,
+        :proposal_vote_limit,
         :title => I18n.available_locales.map(&:to_s),
         :summary => I18n.available_locales.map(&:to_s),
         :description => I18n.available_locales.map(&:to_s),

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -25,7 +25,7 @@ class Api::VotesController < Api::ApplicationController
   def user_can_vote?(step)
     vote_limit_reached = if step.proposal_vote_limit > 0
                            proposal_votes_count = current_user.proposal_votes(step.participatory_process.proposals).keys.count
-                           proposal_votes_count == step.proposal_vote_limit
+                           proposal_votes_count >= step.proposal_vote_limit
                          end
 
     !vote_limit_reached && !step.feature_enabled?(:proposals_readonly) && step.feature_enabled?(:enable_proposal_votes)

--- a/app/controllers/api/votes_controller.rb
+++ b/app/controllers/api/votes_controller.rb
@@ -5,8 +5,8 @@ class Api::VotesController < Api::ApplicationController
   def create
     authorize! :vote, @proposal
     step = @proposal.participatory_process.steps.where(id: params[:step_id]).first
-    raise "Unauthorized" if step.feature_enabled?(:proposals_readonly) || !step.feature_enabled?(:enable_proposal_votes)
-    @proposal.register_vote(current_user, 'yes')
+    raise "Unauthorized" unless user_can_vote?(step)
+    @proposal.register_vote(current_user, "yes")
     @vote = Vote.where(voter: current_user, votable: @proposal).first
     render json: @vote
   end
@@ -14,9 +14,24 @@ class Api::VotesController < Api::ApplicationController
   def destroy
     authorize! :unvote, @proposal
     step = @proposal.participatory_process.steps.where(id: params[:step_id]).first
-    raise "Unauthorized" if step.feature_enabled?(:proposals_readonly) || !step.feature_enabled?(:enable_proposal_votes) || !step.feature_enabled?(:enable_proposal_unvote)
+    raise "Unauthorized" unless user_can_unvote?(step)
     @vote = Vote.where(voter: current_user, votable: @proposal).first
     @vote.destroy
     render json: @vote
+  end
+
+  private
+
+  def user_can_vote?(step)
+    vote_limit_reached = if step.proposal_vote_limit > 0
+                           proposal_votes_count = current_user.proposal_votes(step.participatory_process.proposals).keys.count
+                           proposal_votes_count == step.proposal_vote_limit
+                         end
+
+    !vote_limit_reached && !step.feature_enabled?(:proposals_readonly) && step.feature_enabled?(:enable_proposal_votes)
+  end
+
+  def user_can_unvote?(step)
+    step.feature_enabled?(:enable_proposal_unvote)
   end
 end

--- a/app/frontend/proposals/proposal_app.component.js
+++ b/app/frontend/proposals/proposal_app.component.js
@@ -8,6 +8,11 @@ import { Provider }             from 'react-redux';
 import ReduxPromise             from 'redux-promise';
 import ReduxThunk               from 'redux-thunk';
 
+import { 
+  VOTE_PROPOSAL,
+  UNVOTE_PROPOSAL
+} from './proposals.actions';
+
 import { proposal }             from './proposals.reducers';
 import categories               from '../categories/categories.reducers';
 import districts                from '../districts/districts.reducers';
@@ -28,7 +33,19 @@ const middlewares = [ReduxPromise, ReduxThunk];
 const createStoreWithMiddleware = applyMiddleware(...middlewares)(createStore);
 
 function createReducers(sessionState, participatoryProcessState, decidimIconsUrlState) {
-  let session = function (state = sessionState) {
+  let session = function (state = sessionState, action) {
+    switch (action.type) {
+      case VOTE_PROPOSAL:
+        return {
+          ...state,
+          proposal_votes_count: state.proposal_votes_count + 1
+        }
+      case UNVOTE_PROPOSAL:
+        return {
+          ...state,
+          proposal_votes_count: state.proposal_votes_count - 1
+        };
+    }
     return state;
   };
 

--- a/app/frontend/proposals/proposal_show.component.js
+++ b/app/frontend/proposals/proposal_show.component.js
@@ -15,6 +15,7 @@ import ProposalInfoExtended     from './proposal_info_extended.component';
 import ProposalActionPlans      from './proposal_action_plans.component';
 import ProposalAnswerMessage    from './proposal_answer_message.component';
 import ProposalVoteButton       from './proposal_vote_button.component';
+import ProposalVoteLimit        from './proposal_vote_limit.component';
 
 import RelatedMeetings          from '../meetings/related_meetings.component';
 
@@ -83,6 +84,7 @@ class ProposalShow extends Component {
       return (
         <div className={(hidden || (author && author.hidden)) ? 'faded' : ''} id={`proposal_${proposal.id}`}>
           <div>
+            <ProposalVoteLimit />
             <div className="row column view-header">
               {this.renderEditButton(editable, url)}
               <h2 className="heading2">{title}</h2>

--- a/app/frontend/proposals/proposal_vote_button.component.js
+++ b/app/frontend/proposals/proposal_vote_button.component.js
@@ -18,18 +18,14 @@ class ProposalVoteButton extends Component {
   }
 
   renderVoteButton() {
-    const { participatoryProcess } = this.props;
+    const { participatoryProcess, session } = this.props;
     const { step } = participatoryProcess;
-    const { flags } = step;
+    const { flags, settings } = step;
+    const { proposal_vote_limit } = settings;
+    const voteLimitReached = proposal_vote_limit > 0 && session.proposal_votes_count === proposal_vote_limit;
     const votesDisabled = flags.proposals_readonly || !flags.enable_proposal_votes;
 
-    if (votesDisabled) {
-      return (
-        <button className={`card__button button ${this.props.className || 'small'}`} disabled>
-          {I18n.t("proposals.proposal.closed_support")}
-        </button>
-      )
-    } else if (this.props.voted) { 
+    if (this.props.voted) { 
       return (
         <button 
           className={`card__button button ${this.props.className || 'small'} success`}
@@ -51,6 +47,18 @@ class ProposalVoteButton extends Component {
             }
           }}>
           {I18n.t("proposals.proposal.already_supported")}
+        </button>
+      )
+    } else if (voteLimitReached) {
+      return (
+        <button className={`card__button button ${this.props.className || 'small'}`} disabled>
+          {I18n.t("proposals.proposal.not_enough_votes")}
+        </button>
+      )
+    } else if (votesDisabled) {
+      return (
+        <button className={`card__button button ${this.props.className || 'small'}`} disabled>
+          {I18n.t("proposals.proposal.closed_support")}
         </button>
       )
     } else {

--- a/app/frontend/proposals/proposal_vote_button.component.js
+++ b/app/frontend/proposals/proposal_vote_button.component.js
@@ -22,7 +22,7 @@ class ProposalVoteButton extends Component {
     const { step } = participatoryProcess;
     const { flags, settings } = step;
     const { proposal_vote_limit } = settings;
-    const voteLimitReached = proposal_vote_limit > 0 && session.proposal_votes_count === proposal_vote_limit;
+    const voteLimitReached = proposal_vote_limit > 0 && session.proposal_votes_count >= proposal_vote_limit;
     const votesDisabled = flags.proposals_readonly || !flags.enable_proposal_votes;
 
     if (this.props.voted) { 

--- a/app/frontend/proposals/proposal_vote_limit.component.js
+++ b/app/frontend/proposals/proposal_vote_limit.component.js
@@ -1,0 +1,60 @@
+import { Component, PropTypes } from 'react';
+import { connect }              from 'react-redux';
+
+class ProposalVoteLimit extends Component {
+  render() {
+    const { session, participatoryProcess } = this.props;
+    const { step } = participatoryProcess;
+    const { settings } = step;
+
+    const votesLeft = settings.proposal_vote_limit - session.proposal_votes_count;
+
+    return (
+      <div className="row column proposal-vote-limit">
+        <div className="callout secondary">
+          <div className="row">
+            <div className="columns medium-8 large-9">
+              <h3 className="heading3">
+                {
+                  I18n.t("components.proposal_vote_limit.title", { 
+                    limit: settings.proposal_vote_limit
+                  })
+                }
+              </h3>
+              <p>
+                {
+                  I18n.t("components.proposal_vote_limit.content", { 
+                    limit: settings.proposal_vote_limit
+                  })
+                }
+              </p>
+            </div>
+            <div className="columns medium-4 large-3">
+              <div className="card card--nomargin text-center">
+                <div className="card__content">
+                  <span className="definition-data__title">
+                    { I18n.t("components.proposal_vote_limit.left") }
+                  </span>
+                  <span className="extra__suport-number">{votesLeft}</span>
+                  <span className="extra__suport-text">
+                    { I18n.t("components.proposal_vote_limit.votes") }
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ProposalVoteLimit.propTypes = {
+  session: PropTypes.object.isRequired,
+  participatoryProcess: PropTypes.object.isRequired
+}
+
+export default connect(
+  ({ session, participatoryProcess }) => ({ session, participatoryProcess })
+)(ProposalVoteLimit);
+

--- a/app/frontend/proposals/proposal_vote_limit.component.js
+++ b/app/frontend/proposals/proposal_vote_limit.component.js
@@ -5,47 +5,50 @@ class ProposalVoteLimit extends Component {
   render() {
     const { session, participatoryProcess } = this.props;
     const { step } = participatoryProcess;
-    const { settings } = step;
+    const { settings: { proposal_vote_limit } } = step;
 
-    const votesLeft = settings.proposal_vote_limit - session.proposal_votes_count;
+    if (session.signed_in && proposal_vote_limit > 0) {
+      const votesLeft = proposal_vote_limit - session.proposal_votes_count;
 
-    return (
-      <div className="row column proposal-vote-limit">
-        <div className="callout secondary">
-          <div className="row">
-            <div className="columns medium-8 large-9">
-              <h3 className="heading3">
-                {
-                  I18n.t("components.proposal_vote_limit.title", { 
-                    limit: settings.proposal_vote_limit
-                  })
-                }
-              </h3>
-              <p>
-                {
-                  I18n.t("components.proposal_vote_limit.content", { 
-                    limit: settings.proposal_vote_limit
-                  })
-                }
-              </p>
-            </div>
-            <div className="columns medium-4 large-3">
-              <div className="card card--nomargin text-center">
-                <div className="card__content">
-                  <span className="definition-data__title">
-                    { I18n.t("components.proposal_vote_limit.left") }
-                  </span>
-                  <span className="extra__suport-number">{votesLeft}</span>
-                  <span className="extra__suport-text">
-                    { I18n.t("components.proposal_vote_limit.votes") }
-                  </span>
+      return (
+        <div className="row column proposal-vote-limit">
+          <div className="callout secondary">
+            <div className="row">
+              <div className="columns medium-8 large-9">
+                <h3 className="heading3">
+                  {
+                    I18n.t("components.proposal_vote_limit.title", { 
+                      limit: proposal_vote_limit
+                    })
+                  }
+                </h3>
+                <p>
+                  {
+                    I18n.t("components.proposal_vote_limit.content", { 
+                      limit: proposal_vote_limit
+                    })
+                  }
+                </p>
+              </div>
+              <div className="columns medium-4 large-3">
+                <div className="card card--nomargin text-center">
+                  <div className="card__content">
+                    <span className="definition-data__title">
+                      { I18n.t("components.proposal_vote_limit.left") }
+                    </span>
+                    <span className="extra__suport-number">{votesLeft}</span>
+                    <span className="extra__suport-text">
+                      { I18n.t("components.proposal_vote_limit.votes") }
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    );
+      );
+    }
+    return null;
   }
 }
 

--- a/app/frontend/proposals/proposals.component.js
+++ b/app/frontend/proposals/proposals.component.js
@@ -8,6 +8,7 @@ import OrderSelector            from '../order/order_selector.component';
 import ProposalsSidebar         from './proposals_sidebar.component';
 import NewProposalButton        from './new_proposal_button.component';
 import ProposalsList            from './proposals_list.component';
+import ProposalVoteLimit        from './proposal_vote_limit.component';
 
 import * as actions             from './proposals.actions';
 import { setOrder }             from '../order/order.actions';
@@ -43,6 +44,7 @@ class Proposals extends Component {
   render() {
     return (
       <div>
+        <ProposalVoteLimit />
         <div className="row column">
           <div className="title-action">
             <h2 className="title-action__title section-heading">

--- a/app/frontend/proposals/proposals.reducers.js
+++ b/app/frontend/proposals/proposals.reducers.js
@@ -38,6 +38,7 @@ export const proposals = function (state = [], action) {
         ...action.payload.data.proposals
       ];
     case VOTE_PROPOSAL:
+    case UNVOTE_PROPOSAL:
     case FETCH_ANSWER:
       return state.map(p => proposal(p, action));
   }

--- a/app/frontend/proposals/proposals_app.component.js
+++ b/app/frontend/proposals/proposals_app.component.js
@@ -21,7 +21,8 @@ import Proposals                                from './proposals.component';
 import {
   FETCH_PROPOSALS,
   APPEND_PROPOSALS_PAGE,
-  VOTE_PROPOSAL
+  VOTE_PROPOSAL,
+  UNVOTE_PROPOSAL
 }                                               from './proposals.actions';
 import { proposals }                            from './proposals.reducers';
 
@@ -71,7 +72,12 @@ function createReducers(sessionState, participatoryProcessState, decidimIconsUrl
         return {
           ...state,
           proposal_votes_count: state.proposal_votes_count + 1
-        }
+        };
+      case UNVOTE_PROPOSAL:
+        return {
+          ...state,
+          proposal_votes_count: state.proposal_votes_count - 1
+        };
     }
     return state;
   };

--- a/app/frontend/proposals/proposals_app.component.js
+++ b/app/frontend/proposals/proposals_app.component.js
@@ -20,7 +20,8 @@ import Proposals                                from './proposals.component';
 
 import {
   FETCH_PROPOSALS,
-  APPEND_PROPOSALS_PAGE
+  APPEND_PROPOSALS_PAGE,
+  VOTE_PROPOSAL
 }                                               from './proposals.actions';
 import { proposals }                            from './proposals.reducers';
 
@@ -64,7 +65,14 @@ function getInitialSeedState() {
 }
 
 function createReducers(sessionState, participatoryProcessState, decidimIconsUrlState) {
-  let session = function (state = sessionState) {
+  let session = function (state = sessionState, action) {
+    switch (action.type) {
+      case VOTE_PROPOSAL:
+        return {
+          ...state,
+          proposal_votes_count: state.proposal_votes_count + 1
+        }
+    }
     return state;
   };
 

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -9,7 +9,8 @@ module ComponentsHelper
         is_organization: current_user && current_user.organization?,
         is_reviewer: current_user && current_user.reviewer?,
         can_create_new_proposals: @participatory_process && !@participatory_process_step.feature_enabled?(:proposals_readonly),
-        can_create_action_plan: can?(:create, ActionPlan)
+        can_create_action_plan: can?(:create, ActionPlan),
+        proposal_votes_count: current_user.proposal_votes(@participatory_process.proposals).keys.count
       },
       participatory_process: {
         id: @participatory_process_id,
@@ -18,7 +19,10 @@ module ComponentsHelper
           flags: Step::FLAGS.inject({}) do |acc, feature|
             acc[feature] = @participatory_process_step.feature_enabled? feature
             acc
-          end
+          end,
+          settings: {
+            proposal_vote_limit: @participatory_process_step.proposal_vote_limit
+          }
         }
       },
       decidim_icons_url: asset_url("decidim-icons.svg")

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -10,7 +10,7 @@ module ComponentsHelper
         is_reviewer: current_user && current_user.reviewer?,
         can_create_new_proposals: @participatory_process && !@participatory_process_step.feature_enabled?(:proposals_readonly),
         can_create_action_plan: can?(:create, ActionPlan),
-        proposal_votes_count: current_user.proposal_votes(@participatory_process.proposals).keys.count
+        proposal_votes_count: current_user ? current_user.proposal_votes(@participatory_process.proposals).keys.count : 0
       },
       participatory_process: {
         id: @participatory_process_id,

--- a/app/views/admin/steps/_form.html.erb
+++ b/app/views/admin/steps/_form.html.erb
@@ -37,9 +37,15 @@
       <%= f.number_field :position, label: false %>
     </div>
 
-    <div div class="small-12 column">
+    <div class="small-12 column">
       <%= f.label :flags %>
       <%= f.collection_check_boxes :flags, Step::FLAGS, :to_s, :to_s %>
+    </div>
+
+    <div class="small-12 column">
+      <%= f.label :proposal_vote_limit %>
+      <%= f.number_field :proposal_vote_limit, label: false %>
+      <p class="note"><%= t("steps.form.proposal_vote_limit_note") %></p>
     </div>
 
     <div class="actions small-12 column">

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -439,6 +439,7 @@ ca:
       already_supported: Donant suport
       closed_support: Suports tancats
       remove_support: No donar suport
+      not_enough_votes: No et queden vots
       comments:
         one: 1 Comentari
         other: "%{count} Comentaris"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -352,7 +352,7 @@ ca:
         submit_button: Crear proces
     show:
       active_step: 'Fase actual: %{name}'
-      current_step_menu_title: "En aquesta fase:"
+      current_step_menu_title: 'En aquesta fase:'
       data:
         areas: "Àrees municipals"
         audience: A qui va dirigit?
@@ -438,12 +438,12 @@ ca:
     proposal:
       already_supported: Donant suport
       closed_support: Suports tancats
-      remove_support: No donar suport
-      not_enough_votes: No et queden vots
       comments:
         one: 1 Comentari
         other: "%{count} Comentaris"
         zero: Sense comentaris
+      not_enough_votes: No et queden vots
+      remove_support: No donar suport
       support: Donar suport
       support_title: Donar suport a aquesta proposta
       supports:
@@ -542,6 +542,7 @@ ca:
       form:
         submit_button: Update step
     form:
+      proposal_vote_limit_note: El valor 0 significa 'sense límit'
       step_description: Step description
       step_end_at: Step end at
       step_position: Step position

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -107,6 +107,11 @@ ca:
     proposal_level_selector:
       level_1: Total
       level_2: Parcial
+    proposal_vote_limit:
+      content: Durant la fase de deliberació totes les persones empadronades a la ciutat podran prioritzar les propostes, a través d’un sistema de suports. Tothom disposarà de %{limit} suports a repartir entre les diferents propostes d’actuació.
+      left: Et queden
+      title: Tens %{limit} vots per a repartir
+      votes: Vots
     proposals:
       count: Mostrant %{count} propostes
     proposals_autocomplete_input:
@@ -119,8 +124,3 @@ ca:
       search_input_placeholder: Cercar
     weight_control:
       label: Ordre
-    proposal_vote_limit:
-      title: Tens %{limit} vots per a repartir
-      content: Durant la fase de deliberació totes les persones empadronades a la ciutat podran prioritzar les propostes, a través d’un sistema de suports. Tothom disposarà de %{limit} suports a repartir entre les diferents propostes d’actuació.
-      left: Et queden
-      votes: Vots

--- a/config/locales/components.ca.yml
+++ b/config/locales/components.ca.yml
@@ -119,3 +119,8 @@ ca:
       search_input_placeholder: Cercar
     weight_control:
       label: Ordre
+    proposal_vote_limit:
+      title: Tens %{limit} vots per a repartir
+      content: Durant la fase de deliberació totes les persones empadronades a la ciutat podran prioritzar les propostes, a través d’un sistema de suports. Tothom disposarà de %{limit} suports a repartir entre les diferents propostes d’actuació.
+      left: Et queden
+      votes: Vots

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -107,6 +107,11 @@ en:
     proposal_level_selector:
       level_1: total
       level_2: partial
+    proposal_vote_limit:
+      content: Durant la fase de deliberació totes les persones empadronades a la ciutat podran prioritzar les propostes, a través d’un sistema de suports. Tothom disposarà de %{limit} suports a repartir entre les diferents propostes d’actuació.
+      left: You have
+      title: You have %{limit} votes to distribute
+      votes: Votes
     proposals:
       count: Showing %{count} proposals
     proposals_autocomplete_input:
@@ -119,8 +124,3 @@ en:
       search_input_placeholder: Search
     weight_control:
       label: Order
-    proposal_vote_limit:
-      title: You have %{limit} votes to distribute
-      content: Durant la fase de deliberació totes les persones empadronades a la ciutat podran prioritzar les propostes, a través d’un sistema de suports. Tothom disposarà de %{limit} suports a repartir entre les diferents propostes d’actuació.
-      left: You have
-      votes: Votes

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -119,3 +119,8 @@ en:
       search_input_placeholder: Search
     weight_control:
       label: Order
+    proposal_vote_limit:
+      title: You have %{limit} votes to distribute
+      content: Durant la fase de deliberació totes les persones empadronades a la ciutat podran prioritzar les propostes, a través d’un sistema de suports. Tothom disposarà de %{limit} suports a repartir entre les diferents propostes d’actuació.
+      left: You have
+      votes: Votes

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -119,3 +119,8 @@ es:
       search_input_placeholder: Buscar
     weight_control:
       label: Orden
+    proposal_vote_limit:
+      title: Tienes %{limit} votos para repartir
+      content: Durante la fase de deliberación todas las personas empadronadas en la ciudad pueden priorizar las propuestas, a través de un sistema de soportes. Todo el mundo dispone de %{limit} votos a repartir entre las diferentes propuestas de actuación.
+      left: Te quedan
+      votes: Votos

--- a/config/locales/components.es.yml
+++ b/config/locales/components.es.yml
@@ -107,6 +107,11 @@ es:
     proposal_level_selector:
       level_1: Total
       level_2: Parcial
+    proposal_vote_limit:
+      content: Durante la fase de deliberación todas las personas empadronadas en la ciudad pueden priorizar las propuestas, a través de un sistema de soportes. Todo el mundo dispone de %{limit} votos a repartir entre las diferentes propuestas de actuación.
+      left: Te quedan
+      title: Tienes %{limit} votos para repartir
+      votes: Votos
     proposals:
       count: Mostrando %{count} propuestas
     proposals_autocomplete_input:
@@ -119,8 +124,3 @@ es:
       search_input_placeholder: Buscar
     weight_control:
       label: Orden
-    proposal_vote_limit:
-      title: Tienes %{limit} votos para repartir
-      content: Durante la fase de deliberación todas las personas empadronadas en la ciudad pueden priorizar las propuestas, a través de un sistema de soportes. Todo el mundo dispone de %{limit} votos a repartir entre las diferentes propuestas de actuación.
-      left: Te quedan
-      votes: Votos

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,6 +435,7 @@ en:
     proposal:
       already_supported: Already supported
       closed_support: Closed support
+      not_enough_votes: No votes remaining
       comments:
         one: 1 comment
         other: "%{count} comments"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -435,11 +435,11 @@ en:
     proposal:
       already_supported: Already supported
       closed_support: Closed support
-      not_enough_votes: No votes remaining
       comments:
         one: 1 comment
         other: "%{count} comments"
         zero: No comments
+      not_enough_votes: No votes remaining
       remove_support: Remove support
       support: Support
       support_title: Support this proposal
@@ -539,6 +539,7 @@ en:
       form:
         submit_button: Update step
     form:
+      proposal_vote_limit_note: A 0 value means 'no limit'
       step_description: Step description
       step_end_at: Step end at
       step_position: Step position

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -438,6 +438,7 @@ es:
     proposal:
       already_supported: Dando soporte
       closed_support: Apoyos cerrados
+      not_enough_votes: No te quedan votos
       comments:
         one: 1 Comentario
         other: "%{count} Comentarios"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -438,11 +438,11 @@ es:
     proposal:
       already_supported: Dando soporte
       closed_support: Apoyos cerrados
-      not_enough_votes: No te quedan votos
       comments:
         one: 1 Comentario
         other: "%{count} Comentarios"
         zero: Sin comentarios
+      not_enough_votes: No te quedan votos
       remove_support: No dar soporte
       support: Apoyar
       support_title: Apoyar esta propuesta
@@ -542,6 +542,7 @@ es:
       form:
         submit_button: Update step
     form:
+      proposal_vote_limit_note: El valor 0 significa 'sin límite'
       step_description: Step description
       step_end_at: Step end at
       step_position: Step position

--- a/db/migrate/20161122084725_add_proposal_vote_limit_to_steps.rb
+++ b/db/migrate/20161122084725_add_proposal_vote_limit_to_steps.rb
@@ -1,0 +1,5 @@
+class AddProposalVoteLimitToSteps < ActiveRecord::Migration
+  def change
+    add_column :steps, :proposal_vote_limit, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102150720) do
+ActiveRecord::Schema.define(version: 20161122084725) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -507,6 +507,7 @@ ActiveRecord::Schema.define(version: 20161102150720) do
     t.datetime "updated_at",                               null: false
     t.string   "flags",                    default: [],                 array: true
     t.text     "summary"
+    t.integer  "proposal_vote_limit",      default: 0
   end
 
   create_table "subcategories", force: :cascade do |t|

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -629,4 +629,25 @@ feature 'Proposals' do
 
     expect(page).to have_selector("button", text: "Follow")
   end
+
+  context "Proposal vote is limited", :js do
+    before :each do
+      participatory_process.active_step.update_attribute(:proposal_vote_limit, 2)
+      3.times { create(:proposal, participatory_process: participatory_process) }
+      user = create(:user, verified_at: Time.now)
+      login_as user
+      visit proposals_path(participatory_process_id: participatory_process, step_id: participatory_process.active_step)
+    end
+
+    it "the vote limit should appear on proposals page" do
+      expect(page).to have_content("You have 2 votes to distribute")
+    end
+
+    it "user should see how many votes he has left" do
+      find('button.card__button', match: :first).click
+      within ".proposal-vote-limit .extra__suport-number" do
+        expect(page).to have_content("1")
+      end
+    end
+  end
 end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -649,5 +649,20 @@ feature 'Proposals' do
         expect(page).to have_content("1")
       end
     end
+
+    it "should disable vote buttons if limit reached" do
+      expect(page).to have_css('article.card--proposal', count: 3)
+
+      all('article.card--proposal').take(2).each do |proposal|
+        proposal.find('.card__support button').click
+        expect(proposal).to have_content("Already supported")
+      end
+
+      within ".proposal-vote-limit .extra__suport-number" do
+        expect(page).to have_content("0")
+      end
+
+      expect(page).to have_content("No votes remaining")
+    end
   end
 end


### PR DESCRIPTION
# What and why

This implements a new setting for `Step` called `proposal_vote_limit`. A zero value for this means "no limit" so it's the same behavior as before.
If a step `proposal_vote_limit` is set to a positive integer users should not be able to vote more proposals as this limit. Users can "unvote" proposals if the `enable_proposal_vote` flag is enabled (see #758)

- Depends on #758 
- Closes #753

# GIF

![](https://media.giphy.com/media/NMufrvxO8fC3C/giphy.gif)