### PR TITLE
Fix resource url based on the step passed to the api endpoint

### DIFF
--- a/app/controllers/api/action_plans_controller.rb
+++ b/app/controllers/api/action_plans_controller.rb
@@ -33,7 +33,7 @@ class Api::ActionPlansController < Api::ApplicationController
           prev_page: action_plans.prev_page,
           total_pages: action_plans.total_pages,
           total_count: action_plans.total_count
-        }
+        }, step_id: params[:step_id]
       }
 
       format.xls do

--- a/app/controllers/api/meetings_controller.rb
+++ b/app/controllers/api/meetings_controller.rb
@@ -7,7 +7,7 @@ class Api::MeetingsController < Api::ApplicationController
       proposal = Proposal.find(params[:proposal_id])
       @meetings = proposal.meetings.includes(:tags, :proposals, :pictures)
 
-      render json: @meetings
+      render json: @meetings, step_id: params[:step_id]
     else
       meetings = Meeting.all
       meetings = meetings

--- a/app/frontend/action_plans/action_plans.actions.js
+++ b/app/frontend/action_plans/action_plans.actions.js
@@ -49,6 +49,7 @@ export function updateActionPlan(id, attributes) {
 export const fetchActionPlans = (options) => (dispatch, getState) => {
   const { participatoryProcess } = getState();
   options['participatoryProcessId'] = participatoryProcess.id;
+  options['stepId'] = participatoryProcess.step.id;
 
   const request = buildActionPlansRequest(options);
 
@@ -72,6 +73,7 @@ export function fetchActionPlan(actionPlanId) {
 export const appendActionPlansPage = (options) => (dispatch, getState) => {
   const { participatoryProcess } = getState();
   options['participatoryProcessId'] = participatoryProcess.id;
+  options['stepId'] = participatoryProcess.step.id;
 
   const request = buildActionPlansRequest(options);
 
@@ -139,6 +141,7 @@ export function buildActionPlansRequestParams(options = {}){
       order,
       page,
       participatoryProcessId,
+      stepId,
       seed;
 
   filters                = options.filters || {};
@@ -146,6 +149,7 @@ export function buildActionPlansRequestParams(options = {}){
   order                  = options.order;
   seed                   = options.seed;
   participatoryProcessId = options.participatoryProcessId;
+  stepId                 = options.stepId;
 
   // TODO: worst name ever
   filter = filters.filter;
@@ -166,7 +170,8 @@ export function buildActionPlansRequestParams(options = {}){
     page: page,
     order: order,
     random_seed: seed,
-    participatory_process_id: participatoryProcessId
+    participatory_process_id: participatoryProcessId,
+    step_id: stepId
   };
 }
 

--- a/app/frontend/meetings/meetings.actions.js
+++ b/app/frontend/meetings/meetings.actions.js
@@ -7,6 +7,7 @@ export const APPEND_MEETINGS_PAGE = 'APPEND_MEETINGS_PAGE';
 export const fetchMeetings = (options) => (dispatch, getState) => {
   const { participatoryProcess } = getState();
   options['participatoryProcessId'] = participatoryProcess.id;
+  options['stepId'] = participatoryProcess.step.id;
 
   const request = buildMeetingsRequest(options);
 
@@ -35,6 +36,7 @@ function buildMeetingsRequest(options = {}) {
       filter,
       tags,
       participatoryProcessId,
+      stepId,
       params;
 
   filters = options.filters || {};
@@ -43,6 +45,7 @@ function buildMeetingsRequest(options = {}) {
   filter                 = filters.filter;
   tags                   = filters.tags;
   participatoryProcessId = options.participatoryProcessId;
+  stepId                 = options.stepId;
 
   for (let name in filter) {
     if(filter[name].length > 0) {
@@ -58,7 +61,8 @@ function buildMeetingsRequest(options = {}) {
     search: filters.text,
     tag: tags,
     filter: filterString,
-    participatory_process_id: participatoryProcessId
+    participatory_process_id: participatoryProcessId,
+    step_id: stepId
   }
 
   replaceUrl(params);

--- a/app/helpers/steps_helper.rb
+++ b/app/helpers/steps_helper.rb
@@ -4,4 +4,11 @@ module StepsHelper
     return step_path(participatory_process_id: step.participatory_process.slug, step_id: step) unless feature
     send("#{feature}_path", participatory_process_id: step.participatory_process.slug, step_id: step.id)
   end
+
+  def active_step_for_feature(object, feature_name)
+    object.participatory_process
+      .includes(:steps)
+      .steps.where(active: true).order('position desc')
+      .to_a.find{ |s| s.flags.include? feature_name }
+  end
 end

--- a/app/serializers/concerns/participatory_process_serializer_url.rb
+++ b/app/serializers/concerns/participatory_process_serializer_url.rb
@@ -3,7 +3,7 @@ module Concerns
     def url
       scope && scope.url_for(id: object, controller: "/#{controller_name}", action: :show,
                                   participatory_process_id: object.participatory_process.slug,
-                                  step_id: step)
+                                  step_id: serialization_options[:step_id] || step)
     end
 
     def step

--- a/app/serializers/concerns/participatory_process_serializer_url.rb
+++ b/app/serializers/concerns/participatory_process_serializer_url.rb
@@ -8,6 +8,7 @@ module Concerns
 
     def step
       object.participatory_process
+        .includes(:steps)
         .steps.where(active: true).order('position desc')
         .to_a.find{ |s| s.flags.include? feature_name }
     end

--- a/app/serializers/concerns/participatory_process_serializer_url.rb
+++ b/app/serializers/concerns/participatory_process_serializer_url.rb
@@ -7,7 +7,9 @@ module Concerns
     end
 
     def step
-      object.participatory_process.steps.to_a.find{ |s| s.flags.include? feature_name }
+      object.participatory_process
+        .steps.where(active: true).order('position desc')
+        .to_a.find{ |s| s.flags.include? feature_name }
     end
 
     def feature_name

--- a/app/serializers/concerns/participatory_process_serializer_url.rb
+++ b/app/serializers/concerns/participatory_process_serializer_url.rb
@@ -8,7 +8,6 @@ module Concerns
 
     def step
       object.participatory_process
-        .includes(:steps)
         .steps.where(active: true).order('position desc')
         .to_a.find{ |s| s.flags.include? feature_name }
     end

--- a/app/views/meetings/_proposals.html.erb
+++ b/app/views/meetings/_proposals.html.erb
@@ -5,11 +5,11 @@
       <% @meeting.meeting_proposals.each do |meeting_proposal| %>
         <div class="card--list__item">
           <div class="card--list__text">
-            <%= link_to proposal_path(id: meeting_proposal.proposal) do %>
+            <%= link_to proposal_path(id: meeting_proposal.proposal, participatory_process_id: meeting_proposal.proposal.participatory_process, step_id: active_step_for_feature(meeting_proposal.proposal, "proposals")) do %>
               <%= icon "proposals", class: "card--list__icon", removeIconClass: true %>
             <% end %>
             <div>
-              <%= link_to proposal_path(id: meeting_proposal.proposal), class: 'card__link' do %>
+              <%= link_to proposal_path(id: meeting_proposal.proposal, participatory_process_id: meeting_proposal.proposal.participatory_process, step_id: active_step_for_feature(meeting_proposal.proposal, "proposals")), class: 'card__link' do %>
                 <h5 class="card--list__heading">
                   <%= meeting_proposal.proposal.title %>
                 </h5>


### PR DESCRIPTION
# What and why

This fixes the problem with resources url. For example, if I was on proposals page and click a proposal link I was redirected to that proposal on a previous step.

Now it's using the same `step_id` passed to the API.

# GIF

None