### PR TITLE
Add `enable_proposal_creation` and `enable_proposal_comments` flags

### DIFF
--- a/app/controllers/concerns/commentable_actions.rb
+++ b/app/controllers/concerns/commentable_actions.rb
@@ -25,12 +25,14 @@ module CommentableActions
   end
 
   def new
+    raise "Unauthorized" unless user_can_create?
     @resource = resource_model.new
     set_resource_instance
     load_featured_tags
   end
 
   def create
+    raise "Unauthorized" unless user_can_create?
     @resource = resource_model.new(strong_params)
     @resource.author = current_user
     @resource.participatory_process_id = @participatory_process.id if @participatory_process.present?
@@ -152,5 +154,10 @@ module CommentableActions
 
     def index_customization
       nil
+    end
+
+    def user_can_create?
+      step = Step.find(params[:step_id])
+      resource_name != "proposal" || step.feature_enabled?(:enable_proposal_creation)
     end
 end

--- a/app/frontend/comments/comment.component.js
+++ b/app/frontend/comments/comment.component.js
@@ -132,8 +132,12 @@ class Comment extends Component {
   }
 
   renderReplyAction() {
-    const { commentable } = this.props;
-    if (commentable.permissions.comment) {
+    const { commentable, participatoryProcess } = this.props;
+    const { step } = participatoryProcess;
+    const { flags } = step;
+
+    if ((commentable.type !== 'Proposal' || flags.enable_proposal_comments) &&
+      commentable.permissions.comment) {
       return (
         <span>
           <a className="comment__reply muted-link" onClick={() => this.setState({showReplyForm: !this.state.showReplyForm })}>{I18n.t("comments_helper.reply_link")}</a>
@@ -255,7 +259,10 @@ class Comment extends Component {
   }
 }
 
-export default connect(null, actions)(Comment);
+export default connect(
+  ({ participatoryProcess }) => ({ participatoryProcess }),
+  actions
+)(Comment);
 
 Comment.propTypes = {
   comment: PropTypes.object.isRequired,
@@ -265,5 +272,6 @@ Comment.propTypes = {
   hideComment: PropTypes.func.isRequired,
   hideCommentAuthor: PropTypes.func.isRequired,
   upVoteComment: PropTypes.func.isRequired,
-  downVoteComment: PropTypes.func.isRequired
+  downVoteComment: PropTypes.func.isRequired,
+  participatoryProcess: PropTypes.object.isRequired
 };

--- a/app/frontend/comments/comments.actions.js
+++ b/app/frontend/comments/comments.actions.js
@@ -43,7 +43,7 @@ export const addNewComment = ({ id, type }, { parent, newComment }) => (dispatch
       },
       step_id: stepId
     });
-
+ 
   dispatch({
     type: ADD_NEW_COMMENT,
     payload: request

--- a/app/frontend/comments/comments.actions.js
+++ b/app/frontend/comments/comments.actions.js
@@ -31,19 +31,25 @@ export function appendCommentsPage({ id, type }, { order, page }) {
   };
 }
 
-export function addNewComment({ id, type }, { parent, newComment }) {
+export const addNewComment = ({ id, type }, { parent, newComment }) => (dispatch, getState) => {
+  const { participatoryProcess } = getState();
+  const stepId = participatoryProcess.step.id;
+
   const request = 
     axios.post(baseCommentableUrl({ id, type }), {
       comment: {
         ...newComment,
         parent_id: parent && parent.id
-      }
+      },
+      step_id: stepId
     });
 
-  return {
+  dispatch({
     type: ADD_NEW_COMMENT,
     payload: request
-  };
+  });
+
+  return request;
 }
 
 export function flagComment(commentId) {

--- a/app/frontend/comments/comments.component.js
+++ b/app/frontend/comments/comments.component.js
@@ -35,13 +35,12 @@ class Comments extends Component {
     const { commentable, participatoryProcess } = this.props;
     const { step } = participatoryProcess;
     const { flags } = step;
-    const commentsDisabled = flags.proposals_readonly;
 
     return (
       <section style={{ position: 'relative', minHeight: '30em' }} className="comments">
         {
           (() => {
-            if (!commentsDisabled) {
+            if (commentable.type !== 'Proposal' || flags.enable_proposal_comments) {
               return (
                 <div className="add-coment">
                   <h5 className="section-heading">{I18n.t('components.comments.new_comment.title')}</h5>

--- a/app/frontend/debates/debate_app.component.js
+++ b/app/frontend/debates/debate_app.component.js
@@ -6,6 +6,7 @@ import {
 }                               from 'redux';
 import { Provider }             from 'react-redux';
 import ReduxPromise             from 'redux-promise';
+import ReduxThunk               from 'redux-thunk';
 
 import { debate   }             from './debates.reducers';
 import order                    from '../order/order.reducers';
@@ -14,7 +15,7 @@ import DebateShow               from './debate_show.component';
 
 import pagination               from '../pagination/pagination.reducers';
 
-const middlewares = [ReduxPromise];
+const middlewares = [ReduxPromise, ReduxThunk];
 
 // if (process.env.NODE_ENV === 'development') {
 //   const createLogger = require('redux-logger');

--- a/app/frontend/proposals/new_proposal_button.component.js
+++ b/app/frontend/proposals/new_proposal_button.component.js
@@ -6,8 +6,10 @@ import Icon                     from '../application/icon.component';
 class NewProposalButton extends Component {
   render() {
     const { session, participatoryProcess } = this.props;
+    const { step } = participatoryProcess;
+    const { flags } = step;
 
-    if (session.can_create_new_proposals) {
+    if (session.can_create_new_proposals && flags.enable_proposal_creation) {
       return (
         <a href={`/${participatoryProcess.id}/${participatoryProcess.step.id}/proposals/new`}
         className="new-proposal title-action__action button small hollow">{I18n.t("proposals.index.start_proposal")}

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -30,11 +30,7 @@ class Step < ActiveRecord::Base
   end
 
   def feature_enabled?(name)
-    if name == :proposals_readonly
-      flags.include?("proposals_readonly") || (flags.include?("proposals") && !current?)
-    else
-      flags.include?(name.to_s)
-    end
+    flags.include?(name.to_s)
   end
 
   def current?

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,5 +1,17 @@
 class Step < ActiveRecord::Base
-  FLAGS = %w{proposals proposals_readonly enable_proposal_votes enable_proposal_scope enable_proposal_unvote action_plans meetings debates dataviz categories}
+  FLAGS = %w(
+    proposals
+    enable_proposal_votes
+    enable_proposal_scope
+    enable_proposal_unvote
+    enable_proposal_creation
+    enable_proposal_comments
+    action_plans
+    meetings
+    debates
+    dataviz
+    categories
+  )
 
   belongs_to :participatory_process
   validates :participatory_process, presence: true


### PR DESCRIPTION
# What and why

- Closes #725 
- Closes #769

# :warning: WARNING :warning: 

This PR depecreates the `proposal_readonly` flag because now we have an extra granularity to define proposal features. This means by default both proposal creation and comments will be disabled.

The past steps should be revised as well because if we disable comments on a active step we must disable manually the same flag in previous steps.
