### PR TITLE
Add step_id to proposal related meetings request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -788,5 +788,8 @@ DEPENDENCIES
   webmock
   whenever
 
+RUBY VERSION
+   ruby 2.2.4p230
+
 BUNDLED WITH
-   1.11.2
+   1.13.6

--- a/app/frontend/proposals/proposals.actions.js
+++ b/app/frontend/proposals/proposals.actions.js
@@ -113,13 +113,16 @@ export function updateAnswer(proposalId, answer, answerParams) {
   };
 }
 
-export function fetchRelatedMeetings(proposalId) {
-  const request = axios.get(`${API_BASE_URL}/proposals/${proposalId}/meetings.json`);
+export const fetchRelatedMeetings = (proposalId) => (dispatch, getState) => {
+  const { participatoryProcess } = getState();
+  const request = axios.get(`${API_BASE_URL}/proposals/${proposalId}/meetings.json?step_id=${participatoryProcess.step.id}`);
 
-  return {
+  dispatch({
     type: FETCH_RELATED_MEETINGS,
     payload: request
-  };
+  });
+
+  return request;
 }
 
 export function fetchReferences(proposalId) {


### PR DESCRIPTION
# What and why

Closes #783 

# ⚠️  **Important** ⚠️ 

@arnaumonty @andreslucena @josepjaume The `meetings` flag should be enabled in order to display related meetings for a proposal. 